### PR TITLE
Save snopshot.json before saving timestamp.json

### DIFF
--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -79,6 +79,11 @@ func (r *V1Repository) Mirror() Mirror {
 	return r.mirror
 }
 
+// Local returns the local cached manifests
+func (r *V1Repository) Local() v1manifest.LocalManifests {
+	return r.local
+}
+
 // UpdateComponents updates the components described by specs.
 func (r *V1Repository) UpdateComponents(specs []ComponentSpec) error {
 	err := r.ensureManifests()
@@ -569,6 +574,23 @@ func (r *V1Repository) DownloadTiup(targetDir string) error {
 		Force:     false,
 	}
 	return r.UpdateComponents([]ComponentSpec{spec})
+}
+
+// UpdateComponentManifests updates all components's manifest to the latest version
+func (r *V1Repository) UpdateComponentManifests() error {
+	index, err := r.FetchIndexManifest()
+	if err != nil {
+		return err
+	}
+
+	for name := range index.Components {
+		_, err = r.updateComponentManifest(name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // FetchComponentManifest fetch the component manifest.

--- a/pkg/repository/v1_repository_test.go
+++ b/pkg/repository/v1_repository_test.go
@@ -80,7 +80,7 @@ func TestCheckTimestamp(t *testing.T) {
 	expiredTimestamp := timestampManifest()
 	expiredTimestamp.Expires = "2000-05-12T04:51:08Z"
 	mirror.Resources[v1manifest.ManifestURLTimestamp] = serialize(t, expiredTimestamp)
-	changed, _, err = repo.fetchTimestamp()
+	_, _, err = repo.fetchTimestamp()
 	assert.NotNil(t, err)
 
 	// Test that an invalid manifest from the mirror causes an error

--- a/pkg/repository/v1_repository_test.go
+++ b/pkg/repository/v1_repository_test.go
@@ -53,16 +53,22 @@ func TestCheckTimestamp(t *testing.T) {
 	repoTimestamp := timestampManifest()
 	// Test that no local timestamp => return changed = true
 	mirror.Resources[v1manifest.ManifestURLTimestamp] = serialize(t, repoTimestamp, privk)
-	changed, hash, err := repo.checkTimestamp()
+	changed, manifest, err := repo.checkTimestamp()
 	assert.Nil(t, err)
+	assert.NotNil(t, manifest)
+	tmp := manifest.Signed.(*v1manifest.Timestamp).SnapshotHash()
+	hash := &tmp
 	assert.NotNil(t, hash)
 	assert.Equal(t, changed, true)
 	assert.Equal(t, uint(1001), hash.Length)
 	assert.Equal(t, "123456", hash.Hashes[v1manifest.SHA256])
 	assert.Contains(t, local.Saved, v1manifest.ManifestFilenameTimestamp)
 
-	changed, hash, err = repo.checkTimestamp()
+	changed, manifest, err = repo.checkTimestamp()
 	assert.Nil(t, err)
+	assert.NotNil(t, manifest)
+	tmp = manifest.Signed.(*v1manifest.Timestamp).SnapshotHash()
+	hash = &tmp
 	assert.NotNil(t, hash)
 	assert.Equal(t, changed, false)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Persistent the snapshot first and prevent the snapshot.json/timestamp.json inconsistently

1. timestamp.json will fetch every time
2. saved timestamp.json and crash before saving snapshot.json will cause snapshot.json doesn't be updated anymore

This PR saves snopshot.json before saving timestamp.json.

In addition, this PR optimizes the `tiup list` and reduce the duplicated fetch timestamp.json and snapshot.json.
