### PR TITLE
Fix dashboard address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ bin/
 /tests/tiup_home/
 /tests/tiup_mirrors/*.sha1
 /tests/tiup_mirrors/
+/logs

--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -218,8 +218,13 @@ func displayClusterTopology(clusterName string, opt *operator.Options) error {
 func formatInstanceStatus(status string) string {
 	lowercaseStatus := strings.ToLower(status)
 
-	startsWith := func(prefix string) bool {
-		return strings.HasPrefix(lowercaseStatus, prefix)
+	startsWith := func(prefixs ...string) bool {
+		for _, prefix := range prefixs {
+			if strings.HasPrefix(lowercaseStatus, prefix) {
+				return true
+			}
+		}
+		return false
 	}
 
 	switch {
@@ -227,15 +232,11 @@ func formatInstanceStatus(status string) string {
 		return color.HiGreenString(status)
 	case startsWith("healthy"): // healthy, healthy|ui
 		return color.GreenString(status)
-	case startsWith("unhealthy"),
-		startsWith("down"),
-		startsWith("err"): // unhealthy/down/err, unhealthy/down/err|ui
+	case startsWith("unhealthy", "down", "err"): // unhealthy/down/err, unhealthy/down/err|ui
 		return color.RedString(status)
 	case startsWith("up"):
 		return color.GreenString(status)
-	case startsWith("offline"),
-		startsWith("tombstone"),
-		startsWith("disconnected"):
+	case startsWith("offline", "tombstone", "disconnected"):
 		return color.YellowString(status)
 	default:
 		return status

--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -218,22 +218,25 @@ func displayClusterTopology(clusterName string, opt *operator.Options) error {
 func formatInstanceStatus(status string) string {
 	lowercaseStatus := strings.ToLower(status)
 
-	switch {
-	case strings.HasPrefix(lowercaseStatus, "healthy|l"): // healthy|l , healthy|l|ui
-		return color.HiGreenString(status)
-	case strings.HasPrefix(lowercaseStatus, "healthy"): // healthy , healthy|ui
-		return color.GreenString(status)
-	case strings.HasPrefix(lowercaseStatus, "unhealthy"): // unhealthy , unhealthy|ui
-		return color.RedString(status)
+	startsWith := func(prefix string) bool {
+		return strings.HasPrefix(lowercaseStatus, prefix)
 	}
 
-	switch lowercaseStatus {
-	case "up":
+	switch {
+	case startsWith("healthy|l"): // healthy|l, healthy|l|ui
+		return color.HiGreenString(status)
+	case startsWith("healthy"): // healthy, healthy|ui
 		return color.GreenString(status)
-	case "offline", "tombstone", "disconnected":
-		return color.YellowString(status)
-	case "down", "err":
+	case startsWith("unhealthy"),
+		startsWith("down"),
+		startsWith("err"): // unhealthy/down/err, unhealthy/down/err|ui
 		return color.RedString(status)
+	case startsWith("up"):
+		return color.GreenString(status)
+	case startsWith("offline"),
+		startsWith("tombstone"),
+		startsWith("disconnected"):
+		return color.YellowString(status)
 	default:
 		return status
 	}

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -275,8 +274,7 @@ func (pc *PDClient) GetDashboardAddress() (string, error) {
 		return "", errors.AddStack(err)
 	}
 
-	r := strings.NewReplacer("http://", "", "https://", "")
-	return r.Replace(pdConfig.PDServerCfg.DashboardAddress), nil
+	return pdConfig.PDServerCfg.DashboardAddress, nil
 }
 
 // EvictPDLeader evicts the PD leader

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -274,7 +275,8 @@ func (pc *PDClient) GetDashboardAddress() (string, error) {
 		return "", errors.AddStack(err)
 	}
 
-	return pdConfig.PDServerCfg.DashboardAddress, nil
+	r := strings.NewReplacer("http://", "", "https://", "")
+	return r.Replace(pdConfig.PDServerCfg.DashboardAddress), nil
 }
 
 // EvictPDLeader evicts the PD leader

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -284,7 +284,7 @@ func (s PDSpec) Status(pdList ...string) string {
 	suffix := ""
 
 	// find dashboard node
-	dashboardAddr, err := allPdAPI.GetDashboardAddress()
+	dashboardAddr, _ := allPdAPI.GetDashboardAddress()
 	if strings.HasPrefix(dashboardAddr, "http") {
 		r := strings.NewReplacer("http://", "", "https://", "")
 		dashboardAddr = r.Replace(dashboardAddr)

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -281,10 +281,14 @@ func (s PDSpec) Status(pdList ...string) string {
 	curAddr := fmt.Sprintf("%s:%d", s.Host, s.ClientPort)
 	curPdAPI := api.NewPDClient([]string{curAddr}, statusQueryTimeout, nil)
 	allPdAPI := api.NewPDClient(pdList, statusQueryTimeout, nil)
+	suffix := ""
 
 	// find dashboard node
-	dashboardAddr, _ := allPdAPI.GetDashboardAddress()
-	suffix := ""
+	dashboardAddr, err := allPdAPI.GetDashboardAddress()
+	if strings.HasPrefix(dashboardAddr, "http") {
+		r := strings.NewReplacer("http://", "", "https://", "")
+		dashboardAddr = r.Replace(dashboardAddr)
+	}
 	if dashboardAddr == curAddr {
 		suffix = "|UI"
 	}

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -278,40 +278,41 @@ type PDSpec struct {
 
 // Status queries current status of the instance
 func (s PDSpec) Status(pdList ...string) string {
-	pdapi := api.NewPDClient([]string{fmt.Sprintf("%s:%d", s.Host, s.ClientPort)},
-		statusQueryTimeout, nil)
-	healths, err := pdapi.GetHealth()
+	curAddr := fmt.Sprintf("%s:%d", s.Host, s.ClientPort)
+	curPdAPI := api.NewPDClient([]string{curAddr}, statusQueryTimeout, nil)
+	allPdAPI := api.NewPDClient(pdList, statusQueryTimeout, nil)
+
+	// find dashboard node
+	dashboardAddr, _ := allPdAPI.GetDashboardAddress()
+	suffix := ""
+	if dashboardAddr == curAddr {
+		suffix = "|UI"
+	}
+
+	healths, err := curPdAPI.GetHealth()
 	if err != nil {
-		return "Down"
+		return "Down" + suffix
 	}
 
 	// find leader node
-	leader, err := pdapi.GetLeader()
+	leader, err := curPdAPI.GetLeader()
 	if err != nil {
-		return "ERR"
+		return "ERR" + suffix
 	}
 
-	// find dashboard node
-	dashboardAddr, _ := pdapi.GetDashboardAddress()
-
 	for _, member := range healths.Healths {
-		suffix := ""
-		clientURL := member.ClientUrls[0]
 		if s.Name != member.Name {
 			continue
 		}
 		if s.Name == leader.Name {
-			suffix += "|L"
-		}
-		if clientURL == dashboardAddr {
-			suffix += "|UI"
+			suffix = "|L" + suffix
 		}
 		if member.Health {
 			return "Healthy" + suffix
 		}
 		return "Unhealthy" + suffix
 	}
-	return "N/A"
+	return "N/A" + suffix
 }
 
 // Role returns the component role of the instance


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Show dashboard node status even that node is abnormal.

![企业微信20200602034753](https://user-images.githubusercontent.com/1284531/83496594-e9807080-a4eb-11ea-908b-3a06245050ef.png)

### What is changed and how it works?

Get the dashboard address from all PD nodes instead of the node self, because when the node is down, it can't return the response.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   - Run a cluster with 3 PD nodes
   - Kill the PD node which runs the dashboard
   - Run `tiup cluster display clusterName` to see the nodes status

Side effects

 - Possible performance regression
 - Increased code complexity
