### PR TITLE
*: fix manifest update

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -107,7 +107,7 @@ func showComponentList(env *environment.Environment, opt listOptions) (*listResu
 	}
 
 	index := v1manifest.Index{}
-	exists, err := env.V1Repository().Local().LoadManifest(&index)
+	_, exists, err := env.V1Repository().Local().LoadManifest(&index)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -15,6 +15,8 @@ package repository
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -22,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	cjson "github.com/gibson042/canonicaljson-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
@@ -240,21 +243,28 @@ func (r *V1Repository) updateLocalSnapshot() (*v1manifest.Snapshot, error) {
 		return nil, errors.Trace(err)
 	}
 
+	hash := tsManifest.Signed.(*v1manifest.Timestamp).SnapshotHash()
+	bytes, err := cjson.Marshal(&snapshot)
+	if err != nil {
+		return &snapshot, err
+	}
+	hash256 := sha256.Sum256(bytes)
+
 	// TODO: check changed in fetchTimestamp by compared to the raw local snapshot instead of timestamp.
-	if !changed && snapshotExists {
+	if !changed && snapshotExists &&
+		hash.Hashes[v1manifest.SHA256] == hex.EncodeToString(hash256[:]) {
 		// Nothing has changed in the repo, return success.
 		return &snapshot, nil
 	}
 
-	hash := tsManifest.Signed.(*v1manifest.Timestamp).SnapshotHash()
 	manifest, err := r.fetchManifestWithHash(v1manifest.ManifestURLSnapshot, &snapshot, &hash)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	// Persistent the snapshot first and prevent the snapshot.json/timestamp.json inconsistent
-	// 1. timestamp.json will fetch every time
-	// 2. saved timestamp.json and crash before save snapshot.json will cause snapshot.json doesn't be updated anymore
+	// 1. timestamp.json is fetched every time
+	// 2. when interrupted after timestamp.json been saved but snapshot.json have not, the snapshot.json is not going to be updated anymore
 	err = r.local.SaveManifest(manifest, v1manifest.ManifestFilenameSnapshot)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -436,7 +446,8 @@ func (r *V1Repository) FetchComponent(item *v1manifest.VersionItem) (io.Reader, 
 	return checkHash(reader, item.Hashes[v1manifest.SHA256])
 }
 
-// FetchTimestamp downloads the timestamp file, validates it, and checks if the snapshot hash matches our local one.
+// FetchTimestamp downloads the timestamp file, validates it, and checks if the snapshot hash in it
+// has the same value of our local one. (not hashing the snapshot file itself)
 // Return weather the manifest is changed compared to the one in local ts and the FileHash of snapshot.
 func (r *V1Repository) fetchTimestamp() (changed bool, manifest *v1manifest.Manifest, err error) {
 	var ts v1manifest.Timestamp

--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -384,13 +384,13 @@ func ReadManifest(input io.Reader, role ValidManifest, keys *KeyStore) (*Manifes
 	}
 
 	decoder := json.NewDecoder(input)
-	// For prevent the signatures verify failed from specification changing
+	// To prevent signatures verification failure from specification changing
 	// we use JSON raw message decode the signed part first.
 	rawM := RawManifest{}
 	if err := decoder.Decode(&rawM); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := json.Unmarshal(rawM.Signed, role); err != nil {
+	if err := cjson.Unmarshal(rawM.Signed, role); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/server/store/qcloud.go
+++ b/server/store/qcloud.go
@@ -127,7 +127,16 @@ func (t *qcloudTxn) WriteManifest(filename string, manifest interface{}) error {
 	}
 	defer file.Close()
 
-	return cjson.NewEncoder(file).Encode(manifest)
+	bytes, err := cjson.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+
+	if _, err = file.Write(bytes); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (t *qcloudTxn) ReadManifest(filename string, manifest interface{}) error {
@@ -142,7 +151,12 @@ func (t *qcloudTxn) ReadManifest(filename string, manifest interface{}) error {
 	}
 	defer file.Close()
 
-	return cjson.NewDecoder(file).Decode(manifest)
+	bytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return err
+	}
+
+	return cjson.Unmarshal(bytes, manifest)
 }
 
 func (t *qcloudTxn) ResetManifest() error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The `snapshot.json` is not always checked to be the latest, if an operation interrupted before, there might be a new `timestamp.json` and an old `snapshot.json`, and the `snapshot.json` is not been updated before next time the `timestamp.json` is updated.

### What is changed and how it works?
1. force checking hash of `snapshot.json` every time `timestamp.json` is fetched, no matter it is updated or not, to ensure local cached `snapshot.json` matches the version in `timestamp.json`
2. use `cjson.Marshal` instead of `cjson.Encoder` when writing files, to avoid newline at the end of file

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
