### PR TITLE
Support upstream in tiup-server

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -23,6 +23,7 @@ import (
 
 func main() {
 	addr := "0.0.0.0:8989"
+	upstream := "https://tiup-mirrors.pingcap.com"
 	indexKey := ""
 	snapshotKey := ""
 	timestampKey := ""
@@ -35,7 +36,7 @@ func main() {
 				return cmd.Help()
 			}
 
-			s, err := newServer(args[0], indexKey, snapshotKey, timestampKey)
+			s, err := newServer(args[0], upstream, indexKey, snapshotKey, timestampKey)
 			if err != nil {
 				return err
 			}
@@ -47,6 +48,7 @@ func main() {
 	cmd.Flags().StringVarP(&indexKey, "index", "", "", "specific the private key for index")
 	cmd.Flags().StringVarP(&snapshotKey, "snapshot", "", "", "specific the private key for snapshot")
 	cmd.Flags().StringVarP(&timestampKey, "timestamp", "", "", "specific the private key for timestamp")
+	cmd.Flags().StringVarP(&upstream, "upstream", "", upstream, "specific the upstream mirror")
 
 	_ = cmd.MarkFlagRequired("index")
 	_ = cmd.MarkFlagRequired("snapshot")

--- a/server/router.go
+++ b/server/router.go
@@ -48,7 +48,7 @@ func (s *server) router() http.Handler {
 
 	r.Handle("/api/v1/tarball/{sid}", handler.UploadTarbal(s.sm))
 	r.Handle("/api/v1/component/{sid}/{name}", handler.SignComponent(s.sm, s.keys))
-	r.PathPrefix("/").Handler(s.static("/", s.root))
+	r.PathPrefix("/").Handler(s.static("/", s.root, s.upstream))
 
 	return httpRequestMiddleware(r)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -26,17 +26,19 @@ import (
 )
 
 type server struct {
-	root string
-	keys map[string]*v1manifest.KeyInfo
-	sm   session.Manager
+	root     string
+	upstream string
+	keys     map[string]*v1manifest.KeyInfo
+	sm       session.Manager
 }
 
 // NewServer returns a pointer to server
-func newServer(rootDir, indexKey, snapshotKey, timestampKey string) (*server, error) {
+func newServer(rootDir, upstream, indexKey, snapshotKey, timestampKey string) (*server, error) {
 	s := &server{
-		root: rootDir,
-		keys: make(map[string]*v1manifest.KeyInfo),
-		sm:   session.New(store.NewStore(rootDir), new(sync.Map)),
+		root:     rootDir,
+		upstream: upstream,
+		keys:     make(map[string]*v1manifest.KeyInfo),
+		sm:       session.New(store.NewStore(rootDir, upstream), new(sync.Map)),
 	}
 
 	kmap := map[string]string{

--- a/server/store/qcloud.go
+++ b/server/store/qcloud.go
@@ -15,8 +15,10 @@ package store
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
 	"sync"
@@ -36,15 +38,17 @@ var (
 type qcloudStore struct {
 	mux      sync.Mutex
 	root     string
+	upstream string
 	modified map[string]*time.Time
 }
 
-func newQCloudStore(root string) *qcloudStore {
+func newQCloudStore(root, upstream string) *qcloudStore {
 	if err := os.MkdirAll(root, 0755); err != nil {
 		log.Errorf("Create store directory: %s", err.Error())
 	}
 	return &qcloudStore{
 		root:     root,
+		upstream: upstream,
 		modified: make(map[string]*time.Time),
 	}
 }
@@ -136,13 +140,22 @@ func (t *qcloudTxn) ReadManifest(filename string, manifest interface{}) error {
 	if utils.IsExist(path.Join(t.root, filename)) {
 		filepath = path.Join(t.root, filename)
 	}
-	file, err := os.Open(filepath)
-	if err != nil {
+	var wc io.ReadCloser
+	if file, err := os.Open(filepath); err == nil {
+		wc = file
+	} else if os.IsNotExist(err) && t.store.upstream != "" {
+		if resp, err := http.Get(fmt.Sprintf("%s/%s", t.store.upstream, filename)); err == nil {
+			wc = resp.Body
+		} else {
+			return err
+		}
+	} else {
+		log.Errorf("Error on read manifest: %s, upstream: %s", err.Error(), t.store.upstream)
 		return err
 	}
-	defer file.Close()
+	defer wc.Close()
 
-	return cjson.NewDecoder(file).Decode(manifest)
+	return cjson.NewDecoder(wc).Decode(manifest)
 }
 
 func (t *qcloudTxn) ResetManifest() error {

--- a/server/store/qcloud_test.go
+++ b/server/store/qcloud_test.go
@@ -23,14 +23,14 @@ var _ = Suite(&TestQCloudStoreSuite{})
 type TestQCloudStoreSuite struct{}
 
 func (s *TestQCloudStoreSuite) TestEmptyCommit(c *C) {
-	store := NewStore("/tmp/store")
+	store := NewStore("/tmp/store", "")
 	txn, err := store.Begin()
 	c.Assert(err, IsNil)
 	c.Assert(txn.Commit(), IsNil)
 }
 
 func (s *TestQCloudStoreSuite) TestSingleWrite(c *C) {
-	store := NewStore("/tmp/store")
+	store := NewStore("/tmp/store", "")
 	txn, err := store.Begin()
 	c.Assert(err, IsNil)
 	c.Assert(txn.WriteManifest("test.json", &v1manifest.Manifest{}), IsNil)
@@ -39,7 +39,7 @@ func (s *TestQCloudStoreSuite) TestSingleWrite(c *C) {
 }
 
 func (s *TestQCloudStoreSuite) TestWrite(c *C) {
-	store := NewStore("/tmp/store")
+	store := NewStore("/tmp/store", "")
 	txn1, err := store.Begin()
 	c.Assert(err, IsNil)
 	txn2, err := store.Begin()

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -37,6 +37,6 @@ type FsTxn interface {
 }
 
 // NewStore returns a Store, curretly only qcloud supported
-func NewStore(root string) Store {
-	return newQCloudStore(root)
+func NewStore(root string, upstream string) Store {
+	return newQCloudStore(root, upstream)
 }


### PR DESCRIPTION
Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When we want to build a test mirror, we have to clone all manifests and tarballs which
waste a lot of time. This PR introduces a COW(copy-on-write) way to do this. We can
build an empty mirror and set upstream as https://tiup-mirrors.pingcap.com (the official mirror).
When requests to the test mirror, it will try to find files locally, if failed, it will fetches the upstream.