### PR TITLE
cluster/import: fix copying directory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/markbates/pkger v0.16.0
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-runewidth v0.0.7
+	github.com/otiai10/copy v1.2.0
 	github.com/pelletier/go-toml v1.3.0
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/dm v1.1.0-alpha.0.20200521025928-83063141c5fd

--- a/go.sum
+++ b/go.sum
@@ -555,6 +555,14 @@ github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKw
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.0.3-0.20180606204148-bd9c31933947/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
+github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.1 h1:BCmzIS3n71sGfHB5NMNDB3lHYPz8fWSkCAErHed//qc=
+github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.3.0 h1:e5+lF2E4Y2WCIxBefVowBuB0iHrUH4HZ8q+6mGF7fJc=

--- a/pkg/repository/v1_repository_test.go
+++ b/pkg/repository/v1_repository_test.go
@@ -138,7 +138,6 @@ func TestUpdateLocalSnapshot(t *testing.T) {
 	snapshot, err = repo.updateLocalSnapshot()
 	assert.Nil(t, err)
 	assert.NotNil(t, snapshot)
-	fmt.Printf("%v\n", snapshot)
 	assert.Contains(t, local.Saved, v1manifest.ManifestFilenameSnapshot)
 
 	// test that invalid snapshot will causes an error

--- a/pkg/utils/ioutil.go
+++ b/pkg/utils/ioutil.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/otiai10/copy"
 	"github.com/pingcap/errors"
 )
 
@@ -100,8 +101,19 @@ func Untar(reader io.Reader, to string) error {
 	return nil
 }
 
-// Copy copy file from src to dst
+// Copy copies a file or directory from src to dst
 func Copy(src, dst string) error {
+	// check if src is a directory
+	fi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() {
+		// use copy.Copy to copy a directory
+		return copy.Copy(src, dst)
+	}
+
+	// for regular files
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -126,7 +138,7 @@ func Copy(src, dst string) error {
 // instead this, it's more lightweight but can not be used across devices.
 func Move(src, dst string) error {
 	if err := Copy(src, dst); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return errors.Trace(os.Remove(src))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When importing ansible deployed clusters, as "is a directory" error is reported and the process aborted. It does not broke the cluster from using, just the ansible directory remains where it is and not moved to the hidden profile directory.

This was introduced in #225 

### What is changed and how it works?
Check if `src` is a directory and use `copy.Copy()` to copy it recursively.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
