### PR TITLE
Add nightly release time and platorms in list command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -190,8 +190,13 @@ func showComponentVersions(env *environment.Environment, component string, opt l
 
 	for plat, versions := range comp.Platforms {
 		for ver, verinfo := range versions {
-			platforms[ver] = append(platforms[ver], plat)
-			released[ver] = verinfo.Released
+			if v0manifest.Version(ver).IsNightly() && ver == comp.Nightly {
+				platforms[version.NightlyVersion] = append(platforms[version.NightlyVersion], plat)
+				released[version.NightlyVersion] = verinfo.Released
+			} else {
+				platforms[ver] = append(platforms[ver], plat)
+				released[ver] = verinfo.Released
+			}
 		}
 	}
 	verList := []string{}


### PR DESCRIPTION
Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR adds release time and platforms for nightly.
Before this PR, this nightly release and platforms is empty:
```
JoshuadeMacBook-Pro:tidb-foresight joshua$ tiup list ctl
Available versions for ctl:
Version      Installed  Release                    Platforms
-------      ---------  -------                    ---------
nightly
v3.0.1                  2020-04-27T19:39:08+08:00  darwin/amd64,linux/amd64,linux/arm64
```
After this PR, it will show the latest nightly version info:
```
JoshuadeMacBook-Pro:tidb-foresight joshua$ tiup list ctl
Available versions for ctl:
Version      Installed  Release                    Platforms
-------      ---------  -------                    ---------
nightly                 2020-06-03T21:20:01+08:00  darwin/amd64,linux/amd64,linux/arm64
v3.0.1                  2020-04-27T19:39:08+08:00  darwin/amd64,linux/amd64,linux/arm64
```