### PR TITLE
server: renew manifests on update

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -199,7 +199,7 @@ func newMirrorPublishCmd() *cobra.Command {
 	desc := ""
 
 	cmd := &cobra.Command{
-		Use:   "publish <comp-name> <version> <tarbal> <entry>",
+		Use:   "publish <comp-name> <version> <tarball> <entry>",
 		Short: "Publish a component",
 		Long:  "Publish a component to the repository",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/server/handler/error.go
+++ b/server/handler/error.go
@@ -52,8 +52,8 @@ var (
 	ErrorSessionMissing = newHandlerError(http.StatusNotFound, "SESSION NOT FOUND", "session with specified identity not found")
 	// ErrorManifestMissing indicates that the specified component doesn't have manifest yet
 	ErrorManifestMissing = newHandlerError(http.StatusNotFound, "MANIFEST NOT FOUND", "that component doesn't have manifest yet")
-	// ErrorInvalidTarbal indicates that the tarbal is not valid (eg. too large)
-	ErrorInvalidTarbal = newHandlerError(http.StatusBadRequest, "INVALID TARBAL", "the tarbal content is not valid")
+	// ErrorInvalidTarball indicates that the tarball is not valid (eg. too large)
+	ErrorInvalidTarball = newHandlerError(http.StatusBadRequest, "INVALID TARBALL", "the tarball content is not valid")
 	// ErrorInternalError indicates that an internal error happened
 	ErrorInternalError = newHandlerError(http.StatusInternalServerError, "INTERNAL ERROR", "an internal error happened")
 	// ErrorManifestConflict indicates that the uploaded manifest is not new enough

--- a/server/handler/tarball.go
+++ b/server/handler/tarball.go
@@ -25,22 +25,22 @@ import (
 // MaxFileSize is the max size content can be uploaded
 const MaxFileSize = 32 * 1024 * 1024
 
-// UploadTarbal handle tarbal upload
+// UploadTarbal handle tarball upload
 func UploadTarbal(sm session.Manager) http.Handler {
-	return &tarbalUploader{sm}
+	return &tarballUploader{sm}
 }
 
-type tarbalUploader struct {
+type tarballUploader struct {
 	sm session.Manager
 }
 
-func (h *tarbalUploader) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *tarballUploader) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fn.Wrap(h.upload).ServeHTTP(w, r)
 }
 
-func (h *tarbalUploader) upload(r *http.Request) (*simpleResponse, statusError) {
+func (h *tarballUploader) upload(r *http.Request) (*simpleResponse, statusError) {
 	sid := mux.Vars(r)["sid"]
-	log.Infof("Uploading tarbal, sid: %s", sid)
+	log.Infof("Uploading tarball, sid: %s", sid)
 
 	if err := h.sm.Begin(sid); err != nil {
 		if err == session.ErrorSessionConflict {
@@ -61,18 +61,18 @@ func (h *tarbalUploader) upload(r *http.Request) (*simpleResponse, statusError) 
 
 	if err := r.ParseMultipartForm(MaxFileSize); err != nil {
 		// TODO: log error here
-		return nil, ErrorInvalidTarbal
+		return nil, ErrorInvalidTarball
 	}
 
 	file, handler, err := r.FormFile("file")
 	if err != nil {
 		// TODO: log error here
-		return nil, ErrorInvalidTarbal
+		return nil, ErrorInvalidTarball
 	}
 	defer file.Close()
 
 	if err := txn.Write(handler.Filename, file); err != nil {
-		log.Errorf("Error to write tarbal: %s", err.Error())
+		log.Errorf("Error to write tarball: %s", err.Error())
 		return nil, ErrorInternalError
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Manifests are not renewed when updating via server

### What is changed and how it works?
Reset expire time of manifests based on the time it is updated

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
