### PR TITLE
Publish: use mirror address as default endpoint

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -193,7 +193,7 @@ func delComp(repo, id, version string) error {
 // the `repo publish` sub command
 func newMirrorPublishCmd() *cobra.Command {
 	var privPath string
-	endpoint := "http://127.0.0.1:8989"
+	endpoint := environment.Mirror()
 	goos := runtime.GOOS
 	goarch := runtime.GOARCH
 	desc := ""

--- a/pkg/repository/remote/upload.go
+++ b/pkg/repository/remote/upload.go
@@ -58,7 +58,7 @@ type transporter struct {
 // New returns a Transporter
 func New(endpoint, component, version, entry string) Transporter {
 	return &transporter{
-		endpoint:  endpoint,
+		endpoint:  strings.TrimSuffix(endpoint, "/"),
 		component: component,
 		entry:     entry,
 		os:        runtime.GOOS,


### PR DESCRIPTION
Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The command `tiup mirror publish` need a flag --repo to specific the remote tiup-server. However, in real use the remote server address will be the mirror address, so we make them same in flag default options
