### PR TITLE
display: update state displaying for offline tikv node

### DIFF
--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -279,7 +279,7 @@ func formatInstanceStatus(status string) string {
 		return color.RedString(status)
 	case startsWith("up"):
 		return color.GreenString(status)
-	case startsWith("offline", "tombstone", "disconnected"):
+	case startsWith("tombstone", "disconnected"), strings.Contains(status, "offline"):
 		return color.YellowString(status)
 	default:
 		return status

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -226,7 +226,11 @@ func checkStoreStatus(storeAddr string, pdList ...string) string {
 		}
 	}
 	if latestStore != nil {
-		return latestStore.Store.StateName
+		state := latestStore.Store.StateName
+		if strings.ToLower(state) == "offline" {
+			state = "Pending Offline" // avoid misleading
+		}
+		return state
 	}
 	return "N/A"
 }

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -226,11 +226,7 @@ func checkStoreStatus(storeAddr string, pdList ...string) string {
 		}
 	}
 	if latestStore != nil {
-		state := latestStore.Store.StateName
-		if strings.ToLower(state) == "offline" {
-			state = "Pending Offline" // avoid misleading
-		}
-		return state
+		return latestStore.Store.StateName
 	}
 	return "N/A"
 }
@@ -238,7 +234,11 @@ func checkStoreStatus(storeAddr string, pdList ...string) string {
 // Status queries current status of the instance
 func (s TiKVSpec) Status(pdList ...string) string {
 	storeAddr := fmt.Sprintf("%s:%d", s.Host, s.Port)
-	return checkStoreStatus(storeAddr, pdList...)
+	state := checkStoreStatus(storeAddr, pdList...)
+	if s.Offline && strings.ToLower(state) == "offline" {
+		state = "Pending Offline" // avoid misleading
+	}
+	return state
 }
 
 // Role returns the component role of the instance

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -370,7 +370,11 @@ type TiFlashSpec struct {
 // Status queries current status of the instance
 func (s TiFlashSpec) Status(pdList ...string) string {
 	storeAddr := fmt.Sprintf("%s:%d", s.Host, s.FlashServicePort)
-	return checkStoreStatus(storeAddr, pdList...)
+	state := checkStoreStatus(storeAddr, pdList...)
+	if s.Offline && strings.ToLower(state) == "offline" {
+		state = "Pending Offline" // avoid misleading
+	}
+	return state
 }
 
 // Role returns the component role of the instance


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The raw store state returned from TiKV is misleading, the "offline" is a state that the store is being transferred to other node and "tombstone" is when the offline is really complete.

There is risk that user misunderstand the meaning of "Offline" and use `--force` arg to scale in other instances in the cluster, which may lead to data loss.

### What is changed and how it works?
Set the displayed state to "Pending Offline" for better understanding.
