### PR TITLE
don't generate config file of prometheus if we don't start it

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -606,6 +606,10 @@ func (p *Playground) bootCluster(options *bootOptions) error {
 }
 
 func (p *Playground) renderSDFile() error {
+	// we not start monitor at all.
+	if p.monitor == nil {
+		return nil
+	}
 	cid2targets := make(map[string][]string)
 
 	_ = p.WalkInstances(func(cid string, inst instance.Instance) error {


### PR DESCRIPTION
fail to start without monitor cause monitor is nil.

introduced by https://github.com/pingcap/tiup/pull/431

but we have not released any version having this issue.