### PR TITLE
Fix `cluster deploy xxx nightly`

### DIFF
--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -635,6 +635,9 @@ func (r *V1Repository) ComponentVersion(id, version string) (*v1manifest.Version
 	if err != nil {
 		return nil, err
 	}
+	if v0manifest.Version(version).IsNightly() && manifest.Nightly != "" {
+		version = manifest.Nightly
+	}
 	vi := manifest.VersionItem(r.PlatformString(), version)
 	if vi == nil {
 		return nil, fmt.Errorf("version %s on %s for component %s not found", version, r.PlatformString(), id)


### PR DESCRIPTION
The cluster component can't deploy nightly version since the
ComponentVersion method of V1Repository tries to find "nightly"
directly in component manifests. It should read the field nightly
and redirect to the real nightly version.

Signed-off-by: lucklove <gnu.crazier@gmail.com>