### PR TITLE
Remove args in Command

### DIFF
--- a/components/cluster/command/deploy.go
+++ b/components/cluster/command/deploy.go
@@ -46,6 +46,7 @@ var (
 	clusterReport *telemetry2.ClusterReport
 	teleNodeInfos []*telemetry2.NodeInfo
 	teleTopology  string
+	teleCommand   []string
 )
 
 var (
@@ -92,7 +93,11 @@ func newDeploy() *cobra.Command {
 			}
 
 			logger.EnableAuditLog()
-			return deploy(args[0], args[1], args[2], opt)
+			clusterName := args[0]
+			version := args[1]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
+			teleCommand = append(teleCommand, version)
+			return deploy(clusterName, version, args[2], opt)
 		},
 	}
 

--- a/components/cluster/command/destroy.go
+++ b/components/cluster/command/destroy.go
@@ -39,6 +39,7 @@ func newDestroyCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
 				return errors.Errorf("cannot destroy non-exists cluster %s", clusterName)
 			}

--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -48,6 +48,7 @@ func newDisplayCmd() *cobra.Command {
 			}
 
 			clusterName = args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
 				return errors.Errorf("Cluster %s not found", clusterName)

--- a/components/cluster/command/edit_config.go
+++ b/components/cluster/command/edit_config.go
@@ -41,6 +41,7 @@ func newEditConfigCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
 				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
 			}

--- a/components/cluster/command/exec.go
+++ b/components/cluster/command/exec.go
@@ -42,6 +42,7 @@ func newExecCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
 				return errors.Errorf("cannot execute command on non-exists cluster %s", clusterName)
 			}

--- a/components/cluster/command/patch.go
+++ b/components/cluster/command/patch.go
@@ -49,6 +49,8 @@ func newPatchCmd() *cobra.Command {
 			if len(gOpt.Nodes) == 0 && len(gOpt.Roles) == 0 {
 				return errors.New("the flag -R or -N must be specified at least one")
 			}
+			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			return patch(args[0], args[1], gOpt, overwrite)
 		},
 	}

--- a/components/cluster/command/reload.go
+++ b/components/cluster/command/reload.go
@@ -40,6 +40,7 @@ func newReloadCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
 				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
 			}

--- a/components/cluster/command/restart.go
+++ b/components/cluster/command/restart.go
@@ -39,6 +39,7 @@ func newRestartCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
 				return errors.Errorf("cannot restart non-exists cluster %s", clusterName)
 			}

--- a/components/cluster/command/scale_in.go
+++ b/components/cluster/command/scale_in.go
@@ -41,6 +41,7 @@ func newScaleInCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if !skipConfirm {
 				if err := cliutil.PromptForConfirmOrAbortError(
 					"This operation will delete the %s nodes in `%s` and all their data.\nDo you want to continue? [y/N]:",

--- a/components/cluster/command/scale_out.go
+++ b/components/cluster/command/scale_out.go
@@ -55,6 +55,8 @@ func newScaleOutCmd() *cobra.Command {
 			}
 
 			logger.EnableAuditLog()
+			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			return scaleOut(args[0], args[1], opt)
 		},
 	}

--- a/components/cluster/command/start.go
+++ b/components/cluster/command/start.go
@@ -39,6 +39,7 @@ func newStartCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
 				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
 			}

--- a/components/cluster/command/stop.go
+++ b/components/cluster/command/stop.go
@@ -39,6 +39,7 @@ func newStopCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
 				return errors.Errorf("cannot stop non-exists cluster %s", clusterName)
 			}

--- a/components/cluster/command/upgrade.go
+++ b/components/cluster/command/upgrade.go
@@ -41,7 +41,11 @@ func newUpgradeCmd() *cobra.Command {
 			}
 
 			logger.EnableAuditLog()
-			return upgrade(args[0], args[1], gOpt)
+			clusterName := args[0]
+			version := args[1]
+			teleCommand = append(teleCommand, scrubClusterName(clusterName))
+			teleCommand = append(teleCommand, version)
+			return upgrade(clusterName, version, gOpt)
 		},
 	}
 	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force upgrade won't transfer leader")


### PR DESCRIPTION
remove args in Command.
the default will be the command names join by space, and the specified command run can append more args if need.

currently, all cluster name is hash, and the version is appended raw.
example: "command":"cluster start cluster_0cc175b9c0f1b6a831c399e269772661"
