### PR TITLE
Fix a dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See our [doc](doc/user/README.md) for more information on how to use TiUp.
 
 Contributions of code, tests, docs, and bug reports are welcome! To get started take a look at our [open issues](https://github.com/pingcap/tiup/issues).
 
-For docs on how to build, test, and run TiUp, see our [dev docs](docs/dev/README.md).
+For docs on how to build, test, and run TiUp, see our [dev docs](doc/dev/README.md).
 
 See also the [Contribution Guide](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) in PingCAP's
 [community](https://github.com/pingcap/community) repo.


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The link in `README.md` pointing to the dev doc is not correct.

### What is changed and how it works?

Corrects the link.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code