### PR TITLE
enlarge the pd api timeout time to fix the pd nodes statuses are not stable

### DIFF
--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// Timeout in second when quering node status
-	statusQueryTimeout = 2 * time.Second
+	statusQueryTimeout = 10 * time.Second
 )
 
 // general role names


### PR DESCRIPTION


<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

resolve a part of #472 

### What is changed and how it works?

Enlarge the PD API query timeout duration from 2 seconds to 10 seconds, because when there are some PD nodes are down, the `/pd/health` API will usually cost more than 2 seconds.

Before:

![企业微信20200609114307](https://user-images.githubusercontent.com/1284531/84128062-a3d72100-aa72-11ea-86fc-0879a269bf61.png)

After:

![image](https://user-images.githubusercontent.com/1284531/84128257-ed277080-aa72-11ea-8b91-8af989840207.png)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

