### PR TITLE
Simplify PD node status

### DIFF
--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -272,14 +272,12 @@ func formatInstanceStatus(status string) string {
 	}
 
 	switch {
-	case startsWith("healthy|l"): // healthy|l, healthy|l|ui
+	case startsWith("up|l"): // up|l, up|l|ui
 		return color.HiGreenString(status)
-	case startsWith("healthy"): // healthy, healthy|ui
-		return color.GreenString(status)
-	case startsWith("unhealthy", "down", "err"): // unhealthy/down/err, unhealthy/down/err|ui
-		return color.RedString(status)
 	case startsWith("up"):
 		return color.GreenString(status)
+	case startsWith("down", "err"): // down, down|ui
+		return color.RedString(status)
 	case startsWith("tombstone", "disconnected"), strings.Contains(status, "offline"):
 		return color.YellowString(status)
 	default:

--- a/components/dms/command/display.go
+++ b/components/dms/command/display.go
@@ -246,15 +246,26 @@ func displayClusterTopology(clusterName string, opt *operator.Options) error {
 }
 
 func formatInstanceStatus(status string) string {
-	switch strings.ToLower(status) {
-	case "up", "healthy", "free":
-		return color.GreenString(status)
-	case "healthy|l", "bound": // master leader
+	lowercaseStatus := strings.ToLower(status)
+
+	startsWith := func(prefixs ...string) bool {
+		for _, prefix := range prefixs {
+			if strings.HasPrefix(lowercaseStatus, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch {
+	case startsWith("up|l"): // up|l, up|l|ui
 		return color.HiGreenString(status)
-	case "offline", "tombstone", "disconnected":
-		return color.YellowString(status)
-	case "down", "unhealthy", "err":
+	case startsWith("up"):
+		return color.GreenString(status)
+	case startsWith("down", "err"): // down, down|ui
 		return color.RedString(status)
+	case startsWith("tombstone", "disconnected"), strings.Contains(status, "offline"):
+		return color.YellowString(status)
 	default:
 		return status
 	}

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -111,7 +111,7 @@ func (pc *PDClient) getEndpoints(cmd string) (endpoints []string) {
 	return
 }
 
-// CheckHeath checks the health of PD node
+// CheckHealth checks the health of PD node
 func (pc *PDClient) CheckHealth() error {
 	endpoints := pc.getEndpoints(pdPingURI)
 

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -64,7 +64,7 @@ func (pc *PDClient) GetURL(addr string) string {
 
 // nolint (some is unused now)
 var (
-	pdHealthURI         = "pd/health"
+	pdPingURI           = "pd/ping"
 	pdMembersURI        = "pd/api/v1/members"
 	pdStoresURI         = "pd/api/v1/stores"
 	pdStoreURI          = "pd/api/v1/store"
@@ -102,11 +102,6 @@ func tryURLs(endpoints []string, f func(endpoint string) ([]byte, error)) ([]byt
 	return bytes, err
 }
 
-// PDHealthInfo is the member health info from PD's API
-type PDHealthInfo struct {
-	Healths []pdserverapi.Health
-}
-
 func (pc *PDClient) getEndpoints(cmd string) (endpoints []string) {
 	for _, addr := range pc.addrs {
 		endpoint := fmt.Sprintf("%s/%s", pc.GetURL(addr), cmd)
@@ -116,11 +111,9 @@ func (pc *PDClient) getEndpoints(cmd string) (endpoints []string) {
 	return
 }
 
-// GetHealth queries the health info from PD server
-func (pc *PDClient) GetHealth() (*PDHealthInfo, error) {
-	endpoints := pc.getEndpoints(pdHealthURI)
-
-	healths := []pdserverapi.Health{}
+// CheckHeath checks the health of PD node
+func (pc *PDClient) CheckHealth() error {
+	endpoints := pc.getEndpoints(pdPingURI)
 
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
 		body, err := pc.httpClient.Get(endpoint)
@@ -128,14 +121,14 @@ func (pc *PDClient) GetHealth() (*PDHealthInfo, error) {
 			return body, err
 		}
 
-		return body, json.Unmarshal(body, &healths)
+		return body, nil
 	})
 
 	if err != nil {
-		return nil, errors.AddStack(err)
+		return errors.AddStack(err)
 	}
 
-	return &PDHealthInfo{healths}, nil
+	return nil
 }
 
 // GetStores queries the stores info from PD server

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -279,6 +279,7 @@ type PDSpec struct {
 // Status queries current status of the instance
 func (s PDSpec) Status(pdList ...string) string {
 	curAddr := fmt.Sprintf("%s:%d", s.Host, s.ClientPort)
+	curPdAPI := api.NewPDClient([]string{curAddr}, statusQueryTimeout, nil)
 	allPdAPI := api.NewPDClient(pdList, statusQueryTimeout, nil)
 	suffix := ""
 
@@ -292,15 +293,13 @@ func (s PDSpec) Status(pdList ...string) string {
 		suffix = "|UI"
 	}
 
-	// "Down" means all PD nodes don't work,
-	// while "Unhealthy" means current PD node doesn't work
-	healths, err := allPdAPI.GetHealth()
+	healths, err := curPdAPI.GetHealth()
 	if err != nil {
 		return "Down" + suffix
 	}
 
 	// find leader node
-	leader, err := allPdAPI.GetLeader()
+	leader, err := curPdAPI.GetLeader()
 	if err != nil {
 		return "ERR" + suffix
 	}

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -293,7 +293,8 @@ func (s PDSpec) Status(pdList ...string) string {
 		suffix = "|UI"
 	}
 
-	healths, err := curPdAPI.GetHealth()
+	// check health
+	err := curPdAPI.CheckHealth()
 	if err != nil {
 		return "Down" + suffix
 	}
@@ -303,20 +304,10 @@ func (s PDSpec) Status(pdList ...string) string {
 	if err != nil {
 		return "ERR" + suffix
 	}
-
-	for _, member := range healths.Healths {
-		if s.Name != member.Name {
-			continue
-		}
-		if s.Name == leader.Name {
-			suffix = "|L" + suffix
-		}
-		if member.Health {
-			return "Healthy" + suffix
-		}
-		return "Unhealthy" + suffix
+	if s.Name == leader.Name {
+		suffix = "|L" + suffix
 	}
-	return "N/A" + suffix
+	return "Up" + suffix
 }
 
 // Role returns the component role of the instance

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -279,7 +279,6 @@ type PDSpec struct {
 // Status queries current status of the instance
 func (s PDSpec) Status(pdList ...string) string {
 	curAddr := fmt.Sprintf("%s:%d", s.Host, s.ClientPort)
-	curPdAPI := api.NewPDClient([]string{curAddr}, statusQueryTimeout, nil)
 	allPdAPI := api.NewPDClient(pdList, statusQueryTimeout, nil)
 	suffix := ""
 
@@ -293,13 +292,15 @@ func (s PDSpec) Status(pdList ...string) string {
 		suffix = "|UI"
 	}
 
-	healths, err := curPdAPI.GetHealth()
+	// "Down" means all PD nodes don't work,
+	// while "Unhealthy" means current PD node doesn't work
+	healths, err := allPdAPI.GetHealth()
 	if err != nil {
 		return "Down" + suffix
 	}
 
 	// find leader node
-	leader, err := curPdAPI.GetLeader()
+	leader, err := allPdAPI.GetLeader()
 	if err != nil {
 		return "ERR" + suffix
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Resolve a part of #472 

Currently, the "Unhealthy" PD node is recognized as "Down" status, and the "Unhealthy" status never displays.

### What is changed and how it works?

Differ the "Down" and "Unhealthy" status for PD node, when all nodes don't work, recognize them as "Down", else recognize the not work node as "Unhealthy".

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Deploy a cluster with 3 PD nodes, pause 1 node.

![企业微信20200609114349](https://user-images.githubusercontent.com/1284531/84135162-37f9b600-aa7c-11ea-803e-41719577b4a1.png)

Before:

![企业微信20200609114229](https://user-images.githubusercontent.com/1284531/84135181-3fb95a80-aa7c-11ea-817b-e62a8734d9b7.png)

After:

![image](https://user-images.githubusercontent.com/1284531/84135313-6a0b1800-aa7c-11ea-85c0-6d519ff8fb0a.png)

Pause 2 PD nodes:

![image](https://user-images.githubusercontent.com/1284531/84135385-7f804200-aa7c-11ea-9c65-19e29a27103a.png)




