### PR TITLE
fix help bug and add version flag for tiup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -126,7 +126,7 @@ the latest stable version will be downloaded from the repository.`,
 		}
 		env, err := environment.InitEnv(repoOpts)
 		cmd, n, e := cmd.Root().Find(args)
-		if (cmd == rootCmd || e != nil) && len(n) > 0 && err != nil {
+		if (cmd == rootCmd || e != nil) && len(n) > 0 && err == nil {
 			externalHelp(env, n[0], n[1:]...)
 		} else {
 			cmd.InitDefaultHelpFlag() // make possible 'help' flag to be shown


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tiup/issues/151

### What is changed and how it works?
1. Fix the bug that `--help` can't locate component.
2. If no arg is specified (`tiup --version`), print tiup version directly.
3. If component is specified(`tiup cluster --version`), use `--version` as an argument for this component.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
