### PR TITLE
Support grafana and the build in dashboard when enable monitor

### DIFF
--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -1,3 +1,16 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tiup/components/playground/instance"
+	"github.com/pingcap/tiup/pkg/localdata"
+	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	"github.com/pingcap/tiup/pkg/utils"
+)
+
+type grafana struct {
+	host    string
+	port    int
+	version string
+
+	cmd *exec.Cmd
+}
+
+func newGrafana(version string, host string) *grafana {
+	return &grafana{
+		host:    host,
+		version: version,
+	}
+}
+
+// ref: https://grafana.com/docs/grafana/latest/administration/provisioning/
+func writeDatasourceConfig(fname string, clusterName string, p8sURL string) error {
+	err := makeSureDir(fname)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	tpl := `apiVersion: 1
+deleteDatasources:
+  - name: %s
+datasources:
+  - name: %s
+    type: prometheus
+    access: proxy
+    url: %s
+    withCredentials: false
+    isDefault: false
+    tlsAuth: false
+    tlsAuthWithCACert: false
+    version: 1
+    editable: true
+`
+
+	s := fmt.Sprintf(tpl, clusterName, clusterName, p8sURL)
+	err = ioutil.WriteFile(fname, []byte(s), 0644)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	return nil
+}
+
+// ref: templates/scripts/run_grafana.sh.tpl
+// replace the data source in json to the one we are using.
+func replaceDatasource(dashboardDir string, datasourceName string) error {
+	// for "s/\${DS_.*-CLUSTER}/datasourceName/g
+	re := regexp.MustCompile(`\${DS_.*-CLUSTER}`)
+
+	err := filepath.Walk(dashboardDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			fmt.Printf("skip scan %s failed: %v", path, err)
+			return nil
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		s := string(data)
+		s = strings.Replace(s, "test-cluster", datasourceName, -1)
+		s = strings.Replace(s, "Test-Cluster", datasourceName, -1)
+		s = strings.Replace(s, "${DS_LIGHTNING}", datasourceName, -1)
+		s = re.ReplaceAllLiteralString(s, datasourceName)
+
+		return ioutil.WriteFile(path, []byte(s), 0644)
+	})
+
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	return nil
+}
+
+func writeDashboardConfig(fname string, clusterName string, dir string) error {
+	err := makeSureDir(fname)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	tpl := `apiVersion: 1
+providers:
+  - name: %s
+    folder: %s
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    options:
+      path: %s
+`
+	s := fmt.Sprintf(tpl, clusterName, clusterName, dir)
+
+	err = ioutil.WriteFile(fname, []byte(s), 0644)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	return nil
+}
+
+func makeSureDir(fname string) error {
+	return os.MkdirAll(filepath.Dir(fname), 0755)
+}
+
+var clusterName string = "playground"
+
+// dir should contains files untar the grafana.
+func (g *grafana) start(ctx context.Context, dir string, p8sURL string) (err error) {
+	g.port, err = utils.GetFreePort(g.host, 3000)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	fname := filepath.Join(dir, "conf", "provisioning", "dashboards", "dashboard.yml")
+	err = writeDashboardConfig(fname, clusterName, filepath.Join(dir, "dashboards"))
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	fname = filepath.Join(dir, "conf", "provisioning", "datasources", "datasource.yml")
+	err = writeDatasourceConfig(fname, clusterName, p8sURL)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	tpl := `
+# The ip address to bind to, empty will bind to all interfaces
+http_addr = %s
+
+# The http port to use
+http_port = %d
+`
+	err = os.MkdirAll(filepath.Join(dir, "conf"), 0755)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	custome := fmt.Sprintf(tpl, g.host, g.port)
+	customeFName := filepath.Join(dir, "conf", "custom.ini")
+
+	err = ioutil.WriteFile(customeFName, []byte(custome), 0644)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	args := []string{
+		"tiup",
+		instance.CompVersion("grafana", v0manifest.Version(g.version)),
+		"--homepath",
+		dir,
+		"--config",
+		customeFName,
+	}
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("%s=%s", localdata.EnvNameInstanceDataDir, dir),
+	)
+
+	g.cmd = cmd
+	g.cmd.Stderr = os.Stderr
+	g.cmd.Stderr = os.Stdout
+	fmt.Println("start grafana: ", strings.Join(args, " "))
+
+	return g.cmd.Start()
+}

--- a/components/playground/grafana_test.go
+++ b/components/playground/grafana_test.go
@@ -1,3 +1,16 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/components/playground/grafana_test.go
+++ b/components/playground/grafana_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceDatasource(t *testing.T) {
+	origin := `
+a: ${DS_1-CLUSTER}
+b: test-cluster
+c: Test-Cluster
+d: ${DS_LIGHTNING}
+	`
+
+	dir, err := ioutil.TempDir("", "play_replace_test_*")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	fname := filepath.Join(dir, "a.json")
+	err = ioutil.WriteFile(fname, []byte(origin), 0644)
+	assert.Nil(t, err)
+
+	name := "myname"
+	err = replaceDatasource(dir, name)
+	assert.Nil(t, err)
+
+	data, err := ioutil.ReadFile(fname)
+	assert.Nil(t, err)
+	replaced := string(data)
+
+	n := strings.Count(replaced, name)
+	assert.Equal(t, 4, n, "replaced: %s", replaced)
+}

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -54,7 +54,8 @@ func (inst *instance) StatusAddrs() (addrs []string) {
 	return
 }
 
-func compVersion(comp string, version v0manifest.Version) string {
+// CompVersion return the format to run specified version of a component.
+func CompVersion(comp string, version v0manifest.Version) string {
 	if version.IsEmpty() {
 		return comp
 	}

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -70,7 +70,7 @@ func (inst *PDInstance) Start(ctx context.Context, version v0manifest.Version) e
 	uid := fmt.Sprintf("pd-%d", inst.ID)
 	args := []string{
 		"tiup", fmt.Sprintf("--binpath=%s", inst.BinPath),
-		compVersion("pd", version),
+		CompVersion("pd", version),
 		"--name=" + uid,
 		fmt.Sprintf("--data-dir=%s", filepath.Join(inst.Dir, "data")),
 		fmt.Sprintf("--peer-urls=http://%s:%d", inst.Host, inst.Port),

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -61,7 +61,7 @@ func (inst *TiDBInstance) Start(ctx context.Context, version v0manifest.Version)
 	}
 	args := []string{
 		"tiup", fmt.Sprintf("--binpath=%s", inst.BinPath),
-		compVersion("tidb", version),
+		CompVersion("tidb", version),
 		"-P", strconv.Itoa(inst.Port),
 		"--store=tikv",
 		fmt.Sprintf("--host=%s", inst.Host),

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -174,7 +174,7 @@ func (inst *TiFlashInstance) Start(ctx context.Context, version v0manifest.Versi
 	}
 	inst.cmd = exec.CommandContext(ctx,
 		"tiup", fmt.Sprintf("--binpath=%s", inst.BinPath),
-		compVersion("tiflash", version),
+		CompVersion("tiflash", version),
 		"server",
 		fmt.Sprintf("--config-file=%s", inst.ConfigPath),
 	)

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -65,7 +65,7 @@ func (inst *TiKVInstance) Start(ctx context.Context, version v0manifest.Version)
 	}
 	inst.cmd = exec.CommandContext(ctx,
 		"tiup", fmt.Sprintf("--binpath=%s", inst.BinPath),
-		compVersion("tikv", version),
+		CompVersion("tikv", version),
 		fmt.Sprintf("--addr=%s:%d", inst.Host, inst.Port),
 		fmt.Sprintf("--status-addr=%s:%d", inst.Host, inst.StatusPort),
 		fmt.Sprintf("--pd=%s", strings.Join(endpoints, ",")),

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,8 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	_ "net/http/pprof"
 
 	"github.com/fatih/color"
 	_ "github.com/go-sql-driver/mysql"

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	_ "net/http/pprof"
+
 	"github.com/fatih/color"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
@@ -38,7 +40,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
-	_ "net/http/pprof"
 )
 
 type bootOptions struct {
@@ -270,7 +271,7 @@ func newEtcdClient(endpoint string) (*clientv3.Client, error) {
 
 func main() {
 	if err := execute(); err != nil {
-		fmt.Println("Playground bootstrapping failed:", err)
+		fmt.Printf("Playground bootstrapping failed: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -23,7 +23,9 @@ import (
 	"path/filepath"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tiup/components/playground/instance"
 	"github.com/pingcap/tiup/pkg/localdata"
+	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -73,7 +75,7 @@ func newMonitor() *monitor {
 	return &monitor{}
 }
 
-func (m *monitor) startMonitor(ctx context.Context, host, dir string) (int, *exec.Cmd, error) {
+func (m *monitor) startMonitor(ctx context.Context, version string, host, dir string) (int, *exec.Cmd, error) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return 0, nil, err
 	}
@@ -119,7 +121,8 @@ scrape_configs:
 	}
 
 	args := []string{
-		"tiup", "prometheus",
+		"tiup",
+		instance.CompVersion("prometheus", v0manifest.Version(version)),
 		fmt.Sprintf("--config.file=%s", filepath.Join(dir, "prometheus.yml")),
 		fmt.Sprintf("--web.external-url=http://%s", addr),
 		fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port),


### PR DESCRIPTION
fix #417
Support grafana and the build in dashboard when enable monitor

also, run prometheus with the specified version cause we bind it as the same version of tidb.

```
➜  playground git:(grafana) ✗ tp --monitor
Starting component `playground`: /Users/huangjiahao/code/tiup/components/playground/playground --monitor
Playground Bootstrapping...
Starting component `prometheus`: /Users/huangjiahao/.tiup/components/prometheus/v4.0.0/prometheus/prometheus --config.file=/Users/huangjiahao/.tiup/data/S1UWrQO/prometheus/prometheus.yml --web.external-url=http://127.0.0.1:9090 --web.listen-address=0.0.0.0:9090 --storage.tsdb.path='/Users/huangjiahao/.tiup/data/S1UWrQO/prometheus/data'
start grafana:  tiup grafana --homepath /Users/huangjiahao/.tiup/data/S1UWrQO/grafana --config /Users/huangjiahao/.tiup/data/S1UWrQO/grafana/conf/custom.ini
Starting component `tikv`: /Users/huangjiahao/.tiup/components/tikv/v4.0.0/tikv-server --addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379 --config=/Users/huangjiahao/.tiup/data/S1UWrQO/tikv-0/tikv.toml --data-dir=/Users/huangjiahao/.tiup/data/S1UWrQO/tikv-0/data --log-file=/Users/huangjiahao/.tiup/data/S1UWrQO/tikv-0/tikv.log
Starting component `pd`: /Users/huangjiahao/.tiup/components/pd/v4.0.0/pd-server --name=pd-0 --data-dir=/Users/huangjiahao/.tiup/data/S1UWrQO/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --log-file=/Users/huangjiahao/.tiup/data/S1UWrQO/pd-0/pd.log --initial-cluster=pd-0=http://127.0.0.1:2380
Starting component `tidb`: /Users/huangjiahao/.tiup/components/tidb/v4.0.0/tidb-server -P 4000 --store=tikv --host=127.0.0.1 --status=10080 --path=127.0.0.1:2379 --log-file=/Users/huangjiahao/.tiup/data/S1UWrQO/tidb-0/tidb.log
......
Waiting for tikv 127.0.0.1:20160 ready
CLUSTER START SUCCESSFULLY, Enjoy it ^-^
To connect TiDB: mysql --host 127.0.0.1 --port 4000 -u root
To view the dashboard: http://127.0.0.1:2379/dashboard
To view the Prometheus: http://127.0.0.1:9090
To view the Grafana: http://127.0.0.1:3000

─────────────────────────────────────────────────
```

<img width="1789" alt="Screen Shot 2020-06-10 at 2 25 49 PM" src="https://user-images.githubusercontent.com/1681864/84238825-37215c80-ab2e-11ea-9a4f-8789595b5a12.png">
<img width="840" alt="Screen Shot 2020-06-10 at 2 26 00 PM" src="https://user-images.githubusercontent.com/1681864/84238831-3a1c4d00-ab2e-11ea-8215-a09299797111.png">
