### PR TITLE
Handle scale in of kv/pd/flash in playground

### DIFF
--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -62,12 +62,17 @@ func (inst *PDInstance) InitCluster(pds []*PDInstance) *PDInstance {
 	return inst
 }
 
+// Name return the name of pd.
+func (inst *PDInstance) Name() string {
+	return fmt.Sprintf("pd-%d", inst.ID)
+}
+
 // Start calls set inst.cmd and Start
 func (inst *PDInstance) Start(ctx context.Context, version v0manifest.Version) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}
-	uid := fmt.Sprintf("pd-%d", inst.ID)
+	uid := inst.Name()
 	args := []string{
 		"tiup", fmt.Sprintf("--binpath=%s", inst.BinPath),
 		compVersion("pd", version),

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -85,6 +85,11 @@ type replicateEnablePlacementRulesConfig struct {
 	EnablePlacementRules string `json:"enable-placement-rules"`
 }
 
+// Addr return the address of tiflash
+func (inst *TiFlashInstance) Addr() string {
+	return fmt.Sprintf("%s:%d", inst.Host, inst.Port)
+}
+
 // StatusAddrs implements Instance interface.
 func (inst *TiFlashInstance) StatusAddrs() (addrs []string) {
 	addrs = append(addrs, fmt.Sprintf("%s:%d", inst.Host, inst.StatusPort))

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -51,6 +51,11 @@ func NewTiKVInstance(binPath string, dir, host, configPath string, id int, pds [
 	}
 }
 
+// Addr return the address of tikv.
+func (inst *TiKVInstance) Addr() string {
+	return fmt.Sprintf("%s:%d", inst.Host, inst.Port)
+}
+
 // Start calls set inst.cmd and Start
 func (inst *TiKVInstance) Start(ctx context.Context, version v0manifest.Version) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {


### PR DESCRIPTION
fix #418 #419 #421

in #430, we just stop the process whatever, that ok for non-stateful component, this PR handle scale in of kv/pd/flash gracefully.

kv example:
<img width="575" alt="Screen Shot 2020-06-10 at 7 13 51 PM" src="https://user-images.githubusercontent.com/1681864/84262272-ed496e00-ab4f-11ea-8745-c79f4d3003ca.png">

pd example:
<img width="467" alt="Screen Shot 2020-06-10 at 7 17 53 PM" src="https://user-images.githubusercontent.com/1681864/84262299-f89c9980-ab4f-11ea-8d5c-ab5fc6b04c75.png">

not having test tiflash cause it support mac now, but should be same as kv.
will test it when finally all issues in [playground refactor](https://github.com/pingcap/tiup/projects/6) done.