### PR TITLE
Support output verbose log for debugging

### DIFF
--- a/pkg/environment/env.go
+++ b/pkg/environment/env.go
@@ -21,13 +21,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pingcap/tiup/pkg/verbose"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/localdata"
 	"github.com/pingcap/tiup/pkg/repository"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	"github.com/pingcap/tiup/pkg/verbose"
 	"github.com/pingcap/tiup/pkg/version"
 	"golang.org/x/mod/semver"
 )

--- a/pkg/environment/env.go
+++ b/pkg/environment/env.go
@@ -19,6 +19,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
+
+	"github.com/pingcap/tiup/pkg/verbose"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/localdata"
@@ -63,6 +66,7 @@ func InitEnv(options repository.Options) (*Environment, error) {
 		return env, nil
 	}
 
+	initRepo := time.Now()
 	profile := localdata.InitProfile()
 
 	// Initialize the repository
@@ -86,6 +90,8 @@ func InitEnv(options repository.Options) (*Environment, error) {
 			return nil, errors.AddStack(err)
 		}
 	}
+
+	verbose.Log("Initialize repository finished in %s", time.Since(initRepo))
 
 	return &Environment{profile, repo, v1repo}, nil
 }

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -26,11 +26,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pingcap/tiup/pkg/verbose"
-
 	"github.com/cavaliercoder/grab"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/utils"
+	"github.com/pingcap/tiup/pkg/verbose"
 )
 
 // ErrNotFound represents the resource not exists.

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pingcap/tiup/pkg/verbose"
+
 	"github.com/cavaliercoder/grab"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/utils"
@@ -170,6 +172,10 @@ func (l *httpMirror) Open() error {
 }
 
 func (l *httpMirror) download(url string, to string, maxSize int64) (io.ReadCloser, error) {
+	defer func(start time.Time) {
+		verbose.Log("Download resource %s in %s", url, time.Since(start))
+	}(time.Now())
+
 	client := grab.NewClient()
 	req, err := grab.NewRequest(to, url)
 	if err != nil {

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -24,6 +24,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/pingcap/tiup/pkg/verbose"
 
 	"github.com/fatih/color"
 	cjson "github.com/gibson042/canonicaljson-go"
@@ -176,6 +179,10 @@ func (r *V1Repository) UpdateComponents(specs []ComponentSpec) error {
 
 // ensureManifests ensures that the snapshot, root, and index manifests are up to date and saved in r.local.
 func (r *V1Repository) ensureManifests() error {
+	defer func(start time.Time) {
+		verbose.Log("Ensure manifests finished in %s", time.Since(start))
+	}(time.Now())
+
 	// Update snapshot.
 	snapshot, err := r.updateLocalSnapshot()
 	if err != nil {
@@ -231,6 +238,10 @@ func (r *V1Repository) selectVersion(id string, versions map[string]v1manifest.V
 
 // Postcondition: if returned error is nil, then the local snapshot and timestamp are up to date and return the snapshot
 func (r *V1Repository) updateLocalSnapshot() (*v1manifest.Snapshot, error) {
+	defer func(start time.Time) {
+		verbose.Log("Update local snapshot finished in %s", time.Since(start))
+	}(time.Now())
+
 	changed, tsManifest, err := r.fetchTimestamp()
 	if v1manifest.IsSignatureError(errors.Cause(err)) {
 		// The signature is wrong, update our signatures from the root manifest and try again.
@@ -298,6 +309,10 @@ func FnameWithVersion(fname string, version uint) string {
 }
 
 func (r *V1Repository) updateLocalRoot() error {
+	defer func(start time.Time) {
+		verbose.Log("Update local root finished in %s", time.Since(start))
+	}(time.Now())
+
 	oldRoot, err := r.loadRoot()
 	if err != nil {
 		return errors.AddStack(err)
@@ -358,6 +373,10 @@ func (r *V1Repository) updateLocalRoot() error {
 
 // Precondition: the root manifest has been updated if necessary.
 func (r *V1Repository) updateLocalIndex(snapshot *v1manifest.Snapshot) error {
+	defer func(start time.Time) {
+		verbose.Log("Update local index finished in %s", time.Since(start))
+	}(time.Now())
+
 	// Update index (if needed).
 	var oldIndex v1manifest.Index
 	_, exists, err := r.local.LoadManifest(&oldIndex)
@@ -396,6 +415,10 @@ func (r *V1Repository) updateLocalIndex(snapshot *v1manifest.Snapshot) error {
 
 // Precondition: the snapshot and index manifests exist and are up to date.
 func (r *V1Repository) updateComponentManifest(id string) (*v1manifest.Component, error) {
+	defer func(start time.Time) {
+		verbose.Log("update component '%s' manifest finished in %s", id, time.Since(start))
+	}(time.Now())
+
 	// Find the component's entry in the index and snapshot manifests.
 	var index v1manifest.Index
 	_, _, err := r.local.LoadManifest(&index)
@@ -458,6 +481,10 @@ func (r *V1Repository) FetchComponent(item *v1manifest.VersionItem) (io.Reader, 
 // has the same value of our local one. (not hashing the snapshot file itself)
 // Return weather the manifest is changed compared to the one in local ts and the FileHash of snapshot.
 func (r *V1Repository) fetchTimestamp() (changed bool, manifest *v1manifest.Manifest, err error) {
+	defer func(start time.Time) {
+		verbose.Log("Fetch timestamp finished in %s", time.Since(start))
+	}(time.Now())
+
 	var ts v1manifest.Timestamp
 	manifest, err = r.fetchManifest(v1manifest.ManifestURLTimestamp, &ts, maxTimeStampSize)
 	if err != nil {

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -26,14 +26,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pingcap/tiup/pkg/verbose"
-
 	"github.com/fatih/color"
 	cjson "github.com/gibson042/canonicaljson-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
 	"github.com/pingcap/tiup/pkg/utils"
+	"github.com/pingcap/tiup/pkg/verbose"
 	"github.com/pingcap/tiup/pkg/version"
 	"golang.org/x/mod/semver"
 )

--- a/pkg/verbose/verbose.go
+++ b/pkg/verbose/verbose.go
@@ -1,0 +1,35 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verbose
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+var verbose bool
+
+func init() {
+	v := strings.ToLower(os.Getenv("TIUP_VERBOSE"))
+	verbose = v == "1" || v == "enable"
+}
+
+// Log logs verbose messages
+func Log(format string, args ...interface{}) {
+	if !verbose {
+		return
+	}
+	fmt.Println("Verbose:", fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #485 

Support output verbose log for debugging.

### What is changed and how it works?

```
➜  tiup git:(verbose-log) TIUP_VERBOSE=1 bin/tiup list
Verbose: Initialize repository finished in 1.6469ms
Verbose: Download resource https://tiup-mirrors.pingcap.com/timestamp.json in 308.4553ms
Verbose: Fetch timestamp finished in 309.4367ms
Verbose: Download resource https://tiup-mirrors.pingcap.com/snapshot.json in 251.293ms
Verbose: Update local snapshot finished in 565.8799ms
Verbose: Download resource https://tiup-mirrors.pingcap.com/2.root.json in 261.1945ms
Verbose: Update local root finished in 262.4301ms
Verbose: Update local index finished in 491.3µs
Verbose: Ensure manifests finished in 830.36ms
Verbose: Initialize repository finished in 1.2396ms
Verbose: Download resource https://tiup-mirrors.pingcap.com/timestamp.json in 232.6276ms
Verbose: Fetch timestamp finished in 233.4909ms
Verbose: Download resource https://tiup-mirrors.pingcap.com/snapshot.json in 117.9031ms
Verbose: Update local snapshot finished in 357.4803ms
Verbose: Download resource https://tiup-mirrors.pingcap.com/2.root.json in 374.8301ms
Verbose: Update local root finished in 376.1825ms
Verbose: Update local index finished in 382.2µs
Verbose: Ensure manifests finished in 735.5335ms
Verbose: update component 'tidb' manifest finished in 2.4052ms
Verbose: update component 'tikv' manifest finished in 2.3877ms
Verbose: update component 'bench' manifest finished in 917.2µs
Verbose: update component 'blackbox_exporter' manifest finished in 749.5µs
Verbose: update component 'ctl' manifest finished in 1.8509ms
Verbose: update component 'doc' manifest finished in 767.9µs
Verbose: update component 'drainer' manifest finished in 1.8289ms
Verbose: update component 'playground' manifest finished in 1.086ms
Verbose: update component 'node_exporter' manifest finished in 618.3µs
Verbose: update component 'package' manifest finished in 756.4µs
Verbose: update component 'pd' manifest finished in 2.0082ms
Verbose: update component 'prometheus' manifest finished in 2.7262ms
Verbose: update component 'alertmanager' manifest finished in 697.5µs
Verbose: update component 'client' manifest finished in 771.4µs
Verbose: update component 'cluster' manifest finished in 1.7765ms
Verbose: update component 'grafana' manifest finished in 2.0949ms
Verbose: update component 'tiflash' manifest finished in 1.0198ms
Verbose: update component 'pushgateway' manifest finished in 834.7µs
Verbose: update component 'tiup' manifest finished in 1.398ms
Verbose: update component 'cdc' manifest finished in 988.9µs
Verbose: update component 'insight' manifest finished in 803.6µs
Verbose: update component 'mirrors' manifest finished in 627µs
Verbose: update component 'pump' manifest finished in 1.7356ms
```