### PR TITLE
move init mirror to preRun for `tiup mirror clone`

### DIFF
--- a/components/cluster/command/scale_in.go
+++ b/components/cluster/command/scale_in.go
@@ -49,6 +49,15 @@ func newScaleInCmd() *cobra.Command {
 					color.HiYellowString(clusterName)); err != nil {
 					return err
 				}
+
+				if gOpt.Force {
+					if err := cliutil.PromptForConfirmOrAbortError(
+						"Forcing scale in is unsafe and may result in data lost for stateful components.\nDo you want to continue? [y/N]:",
+					); err != nil {
+						return err
+					}
+				}
+
 				log.Infof("Scale-in nodes...")
 			}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
move init mirror to preRun for `tiup mirror clone`. tiup --help and --version commands (expect `tiup mirror clone --help`) don't need init environment and connect to network any more.

### What is changed and how it works?
Don't parse args for `tiup mirror clone` at beginning. Do it in running progress.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
