### PR TITLE
Support pump&drainer in playground

### DIFF
--- a/components/playground/command.go
+++ b/components/playground/command.go
@@ -45,7 +45,6 @@ type Command struct {
 	instance.Config
 }
 
-// nolint
 func buildCommands(tp CommandType, opt *bootOptions) (cmds []Command) {
 	for i := 0; i < opt.pd.Num; i++ {
 		c := Command{
@@ -61,6 +60,15 @@ func buildCommands(tp CommandType, opt *bootOptions) (cmds []Command) {
 			CommandType: tp,
 			ComponentID: "tikv",
 			Config:      opt.tikv,
+		}
+
+		cmds = append(cmds, c)
+	}
+	for i := 0; i < opt.pump.Num; i++ {
+		c := Command{
+			CommandType: tp,
+			ComponentID: "pump",
+			Config:      opt.pump,
 		}
 
 		cmds = append(cmds, c)
@@ -83,6 +91,15 @@ func buildCommands(tp CommandType, opt *bootOptions) (cmds []Command) {
 
 		cmds = append(cmds, c)
 	}
+	for i := 0; i < opt.drainer.Num; i++ {
+		c := Command{
+			CommandType: tp,
+			ComponentID: "drainer",
+			Config:      opt.drainer,
+		}
+
+		cmds = append(cmds, c)
+	}
 	return
 }
 
@@ -100,16 +117,25 @@ func newScaleOut() *cobra.Command {
 	cmd.Flags().IntVarP(&opt.tikv.Num, "kv", "", opt.tikv.Num, "TiKV instance number")
 	cmd.Flags().IntVarP(&opt.pd.Num, "pd", "", opt.pd.Num, "PD instance number")
 	cmd.Flags().IntVarP(&opt.tiflash.Num, "tiflash", "", opt.tiflash.Num, "TiFlash instance number")
+	cmd.Flags().IntVarP(&opt.pump.Num, "pump", "", opt.pump.Num, "Pump instance number")
+	cmd.Flags().IntVarP(&opt.drainer.Num, "drainer", "", opt.pump.Num, "Drainer instance number")
+
 	cmd.Flags().StringVarP(&opt.tidb.Host, "db.host", "", opt.tidb.Host, "Playground TiDB host. If not provided, TiDB will still use `host` flag as its host")
 	cmd.Flags().StringVarP(&opt.pd.Host, "pd.host", "", opt.pd.Host, "Playground PD host. If not provided, PD will still use `host` flag as its host")
+
 	cmd.Flags().StringVarP(&opt.tidb.ConfigPath, "db.config", "", opt.tidb.ConfigPath, "TiDB instance configuration file")
 	cmd.Flags().StringVarP(&opt.tikv.ConfigPath, "kv.config", "", opt.tikv.ConfigPath, "TiKV instance configuration file")
 	cmd.Flags().StringVarP(&opt.pd.ConfigPath, "pd.config", "", opt.pd.ConfigPath, "PD instance configuration file")
 	cmd.Flags().StringVarP(&opt.tidb.ConfigPath, "tiflash.config", "", opt.tidb.ConfigPath, "TiFlash instance configuration file")
+	cmd.Flags().StringVarP(&opt.pump.ConfigPath, "pump.config", "", opt.pump.ConfigPath, "Pump instance configuration file")
+	cmd.Flags().StringVarP(&opt.drainer.ConfigPath, "drainer.config", "", opt.drainer.ConfigPath, "Drainer instance configuration file")
+
 	cmd.Flags().StringVarP(&opt.tidb.BinPath, "db.binpath", "", opt.tidb.BinPath, "TiDB instance binary path")
 	cmd.Flags().StringVarP(&opt.tikv.BinPath, "kv.binpath", "", opt.tikv.BinPath, "TiKV instance binary path")
 	cmd.Flags().StringVarP(&opt.pd.BinPath, "pd.binpath", "", opt.pd.BinPath, "PD instance binary path")
 	cmd.Flags().StringVarP(&opt.tiflash.BinPath, "tiflash.binpath", "", opt.tiflash.BinPath, "TiFlash instance binary path")
+	cmd.Flags().StringVarP(&opt.pump.BinPath, "pump.binpath", "", opt.pump.BinPath, "Pump instance binary path")
+	cmd.Flags().StringVarP(&opt.drainer.BinPath, "drainer.binpath", "", opt.drainer.BinPath, "Drainer instance binary path")
 
 	return cmd
 }

--- a/components/playground/instance/drainer.go
+++ b/components/playground/instance/drainer.go
@@ -1,3 +1,16 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package instance
 
 import (

--- a/components/playground/instance/drainer.go
+++ b/components/playground/instance/drainer.go
@@ -1,0 +1,93 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pingcap/tiup/pkg/localdata"
+	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	"github.com/pingcap/tiup/pkg/utils"
+)
+
+// Drainer represent a drainer instance.
+type Drainer struct {
+	instance
+	pds []*PDInstance
+	cmd *exec.Cmd
+}
+
+var _ Instance = &Drainer{}
+
+// NewDrainer create a Drainer instance.
+func NewDrainer(binPath string, dir, host, configPath string, id int, pds []*PDInstance) *Drainer {
+	return &Drainer{
+		instance: instance{
+			BinPath:    binPath,
+			ID:         id,
+			Dir:        dir,
+			Host:       host,
+			Port:       utils.MustGetFreePort(host, 8250),
+			ConfigPath: configPath,
+		},
+		pds: pds,
+	}
+}
+
+// Addr return the address of Drainer.
+func (d *Drainer) Addr() string {
+	return fmt.Sprintf("%s:%d", advertiseHost(d.Host), d.Port)
+}
+
+// NodeID return the node id of drainer.
+func (d *Drainer) NodeID() string {
+	return fmt.Sprintf("drainer_%d", d.ID)
+}
+
+// Start implements Instance interface.
+func (d *Drainer) Start(ctx context.Context, version v0manifest.Version) error {
+	if err := os.MkdirAll(d.Dir, 0755); err != nil {
+		return err
+	}
+
+	var urls []string
+	for _, pd := range d.pds {
+		urls = append(urls, fmt.Sprintf("http://%s:%d", pd.Host, pd.StatusPort))
+	}
+
+	args := []string{
+		"tiup", fmt.Sprintf("--binpath=%s", d.BinPath),
+		CompVersion("drainer", version),
+		fmt.Sprintf("--node-id=%s", d.NodeID()),
+		fmt.Sprintf("--addr=%s:%d", d.Host, d.Port),
+		fmt.Sprintf("--advertise-addr=%s:%d", advertiseHost(d.Host), d.Port),
+		fmt.Sprintf("--pd-urls=%s", strings.Join(urls, ",")),
+		fmt.Sprintf("--log-file=%s", filepath.Join(d.Dir, "drainer.log")),
+	}
+	if d.ConfigPath != "" {
+		args = append(args, fmt.Sprintf("--config=%s", d.ConfigPath))
+	}
+
+	d.cmd = exec.CommandContext(ctx, args[0], args[1:]...)
+	d.cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("%s=%s", localdata.EnvNameInstanceDataDir, d.Dir),
+	)
+	d.cmd.Stderr = os.Stderr
+	d.cmd.Stdout = os.Stdout
+
+	return d.cmd.Start()
+}
+
+// Wait implements Instance interface.
+func (d *Drainer) Wait() error {
+	return d.cmd.Wait()
+}
+
+// Pid implements Instance interface.
+func (d *Drainer) Pid() int {
+	return d.cmd.Process.Pid
+}

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -61,3 +61,11 @@ func CompVersion(comp string, version v0manifest.Version) string {
 	}
 	return fmt.Sprintf("%v:%v", comp, version)
 }
+
+func advertiseHost(listen string) string {
+	if listen == "0.0.0.0" {
+		return "localhost"
+	}
+
+	return listen
+}

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -79,9 +79,9 @@ func (inst *PDInstance) Start(ctx context.Context, version v0manifest.Version) e
 		"--name=" + uid,
 		fmt.Sprintf("--data-dir=%s", filepath.Join(inst.Dir, "data")),
 		fmt.Sprintf("--peer-urls=http://%s:%d", inst.Host, inst.Port),
-		fmt.Sprintf("--advertise-peer-urls=http://%s:%d", inst.Host, inst.Port),
+		fmt.Sprintf("--advertise-peer-urls=http://%s:%d", advertiseHost(inst.Host), inst.Port),
 		fmt.Sprintf("--client-urls=http://%s:%d", inst.Host, inst.StatusPort),
-		fmt.Sprintf("--advertise-client-urls=http://%s:%d", inst.Host, inst.StatusPort),
+		fmt.Sprintf("--advertise-client-urls=http://%s:%d", advertiseHost(inst.Host), inst.StatusPort),
 		fmt.Sprintf("--log-file=%s", filepath.Join(inst.Dir, "pd.log")),
 	}
 	if inst.ConfigPath != "" {
@@ -92,15 +92,15 @@ func (inst *PDInstance) Start(ctx context.Context, version v0manifest.Version) e
 		endpoints := make([]string, 0)
 		for _, pd := range inst.initEndpoints {
 			uid := fmt.Sprintf("pd-%d", pd.ID)
-			endpoints = append(endpoints, fmt.Sprintf("%s=http://%s:%d", uid, inst.Host, pd.Port))
-			args = append(args, fmt.Sprintf("--initial-cluster=%s", strings.Join(endpoints, ",")))
+			endpoints = append(endpoints, fmt.Sprintf("%s=http://%s:%d", uid, advertiseHost(inst.Host), pd.Port))
 		}
+		args = append(args, fmt.Sprintf("--initial-cluster=%s", strings.Join(endpoints, ",")))
 	} else if len(inst.joinEndpoints) > 0 {
 		endpoints := make([]string, 0)
 		for _, pd := range inst.joinEndpoints {
-			endpoints = append(endpoints, fmt.Sprintf("http://%s:%d", inst.Host, pd.Port))
-			args = append(args, fmt.Sprintf("--join=%s", strings.Join(endpoints, ",")))
+			endpoints = append(endpoints, fmt.Sprintf("http://%s:%d", advertiseHost(inst.Host), pd.Port))
 		}
+		args = append(args, fmt.Sprintf("--join=%s", strings.Join(endpoints, ",")))
 	} else {
 		return errors.Errorf("must set the init or join instances.")
 	}
@@ -127,5 +127,5 @@ func (inst *PDInstance) Pid() int {
 
 // Addr return the listen address of PD
 func (inst *PDInstance) Addr() string {
-	return fmt.Sprintf("%s:%d", inst.Host, inst.StatusPort)
+	return fmt.Sprintf("%s:%d", advertiseHost(inst.Host), inst.StatusPort)
 }

--- a/components/playground/instance/pump.go
+++ b/components/playground/instance/pump.go
@@ -1,3 +1,16 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package instance
 
 import (

--- a/components/playground/instance/pump.go
+++ b/components/playground/instance/pump.go
@@ -1,0 +1,114 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pingcap/tiup/pkg/localdata"
+	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	"github.com/pingcap/tiup/pkg/utils"
+)
+
+// Pump represent a pump instance.
+type Pump struct {
+	instance
+	pds []*PDInstance
+	cmd *exec.Cmd
+}
+
+var _ Instance = &Pump{}
+
+// NewPump create a Pump instance.
+func NewPump(binPath string, dir, host, configPath string, id int, pds []*PDInstance) *Pump {
+	return &Pump{
+		instance: instance{
+			BinPath:    binPath,
+			ID:         id,
+			Dir:        dir,
+			Host:       host,
+			Port:       utils.MustGetFreePort(host, 8249),
+			ConfigPath: configPath,
+		},
+		pds: pds,
+	}
+}
+
+// NodeID return the node id of pump.
+func (p *Pump) NodeID() string {
+	return fmt.Sprintf("pump_%d", p.ID)
+}
+
+// Ready return nil when pump is ready to serve.
+func (p *Pump) Ready(ctx context.Context) error {
+	url := fmt.Sprintf("http://%s:%d/status", p.Host, p.Port)
+
+	for {
+		resp, err := http.Get(url)
+		if err == nil && resp.StatusCode == 200 {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+			// just retry
+		}
+	}
+}
+
+// Addr return the address of Pump.
+func (p *Pump) Addr() string {
+	return fmt.Sprintf("%s:%d", advertiseHost(p.Host), p.Port)
+}
+
+// Start implements Instance interface.
+func (p *Pump) Start(ctx context.Context, version v0manifest.Version) error {
+	if err := os.MkdirAll(p.Dir, 0755); err != nil {
+		return err
+	}
+
+	var urls []string
+	for _, pd := range p.pds {
+		urls = append(urls, fmt.Sprintf("http://%s:%d", pd.Host, pd.StatusPort))
+	}
+
+	args := []string{
+		"tiup", fmt.Sprintf("--binpath=%s", p.BinPath),
+		CompVersion("pump", version),
+		fmt.Sprintf("--node-id=%s", p.NodeID()),
+		fmt.Sprintf("--addr=%s:%d", p.Host, p.Port),
+		fmt.Sprintf("--advertise-addr=%s:%d", advertiseHost(p.Host), p.Port),
+		fmt.Sprintf("--pd-urls=%s", strings.Join(urls, ",")),
+		fmt.Sprintf("--log-file=%s", filepath.Join(p.Dir, "pump.log")),
+	}
+	if p.ConfigPath != "" {
+		args = append(args, fmt.Sprintf("--config=%s", p.ConfigPath))
+	}
+
+	p.cmd = exec.CommandContext(ctx, args[0], args[1:]...)
+	p.cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("%s=%s", localdata.EnvNameInstanceDataDir, p.Dir),
+	)
+	p.cmd.Stderr = os.Stderr
+	p.cmd.Stdout = os.Stdout
+
+	return p.cmd.Start()
+}
+
+// Wait implements Instance interface.
+func (p *Pump) Wait() error {
+	return p.cmd.Wait()
+}
+
+// Pid implements Instance interface.
+func (p *Pump) Pid() int {
+	return p.cmd.Process.Pid
+}

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -104,11 +104,11 @@ func (inst *TiFlashInstance) Start(ctx context.Context, version v0manifest.Versi
 	}
 	endpoints := make([]string, 0, len(inst.pds))
 	for _, pd := range inst.pds {
-		endpoints = append(endpoints, fmt.Sprintf("%s:%d", inst.Host, pd.StatusPort))
+		endpoints = append(endpoints, fmt.Sprintf("%s:%d", advertiseHost(inst.Host), pd.StatusPort))
 	}
 	tidbStatusAddrs := make([]string, 0, len(inst.dbs))
 	for _, db := range inst.dbs {
-		tidbStatusAddrs = append(tidbStatusAddrs, fmt.Sprintf("%s:%d", db.Host, uint64(db.StatusPort)))
+		tidbStatusAddrs = append(tidbStatusAddrs, fmt.Sprintf("%s:%d", advertiseHost(db.Host), uint64(db.StatusPort)))
 	}
 	wd, err := filepath.Abs(inst.Dir)
 	if err != nil {
@@ -209,7 +209,7 @@ func (inst *TiFlashInstance) Cmd() *exec.Cmd {
 
 // StoreAddr return the store address of TiFlash
 func (inst *TiFlashInstance) StoreAddr() string {
-	return fmt.Sprintf("%s:%d", inst.Host, inst.ServicePort)
+	return fmt.Sprintf("%s:%d", advertiseHost(inst.Host), inst.ServicePort)
 }
 
 func (inst *TiFlashInstance) checkConfig(deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -66,12 +66,13 @@ func (inst *TiKVInstance) Start(ctx context.Context, version v0manifest.Version)
 	}
 	endpoints := make([]string, 0, len(inst.pds))
 	for _, pd := range inst.pds {
-		endpoints = append(endpoints, fmt.Sprintf("http://%s:%d", inst.Host, pd.StatusPort))
+		endpoints = append(endpoints, fmt.Sprintf("http://%s:%d", advertiseHost(inst.Host), pd.StatusPort))
 	}
 	inst.cmd = exec.CommandContext(ctx,
 		"tiup", fmt.Sprintf("--binpath=%s", inst.BinPath),
 		CompVersion("tikv", version),
 		fmt.Sprintf("--addr=%s:%d", inst.Host, inst.Port),
+		fmt.Sprintf("--advertise-addr=%s:%d", advertiseHost(inst.Host), inst.Port),
 		fmt.Sprintf("--status-addr=%s:%d", inst.Host, inst.StatusPort),
 		fmt.Sprintf("--pd=%s", strings.Join(endpoints, ",")),
 		fmt.Sprintf("--config=%s", inst.ConfigPath),
@@ -99,7 +100,7 @@ func (inst *TiKVInstance) Pid() int {
 
 // StoreAddr return the store address of TiKV
 func (inst *TiKVInstance) StoreAddr() string {
-	return fmt.Sprintf("%s:%d", inst.Host, inst.Port)
+	return fmt.Sprintf("%s:%d", advertiseHost(inst.Host), inst.Port)
 }
 
 func (inst *TiKVInstance) checkConfig() error {

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -47,6 +47,8 @@ type bootOptions struct {
 	tidb    instance.Config
 	tikv    instance.Config
 	tiflash instance.Config
+	pump    instance.Config
+	drainer instance.Config
 	host    string
 	monitor bool
 }
@@ -144,18 +146,27 @@ Examples:
 	rootCmd.Flags().IntVarP(&opt.tikv.Num, "kv", "", opt.tikv.Num, "TiKV instance number")
 	rootCmd.Flags().IntVarP(&opt.pd.Num, "pd", "", opt.pd.Num, "PD instance number")
 	rootCmd.Flags().IntVarP(&opt.tiflash.Num, "tiflash", "", opt.tiflash.Num, "TiFlash instance number")
+	rootCmd.Flags().IntVarP(&opt.pump.Num, "pump", "", opt.pump.Num, "Pump instance number")
+	rootCmd.Flags().IntVarP(&opt.drainer.Num, "drainer", "", opt.drainer.Num, "Drainer instance number")
+
 	rootCmd.Flags().StringVarP(&opt.host, "host", "", opt.host, "Playground cluster host")
 	rootCmd.Flags().StringVarP(&opt.tidb.Host, "db.host", "", opt.tidb.Host, "Playground TiDB host. If not provided, TiDB will still use `host` flag as its host")
 	rootCmd.Flags().StringVarP(&opt.pd.Host, "pd.host", "", opt.pd.Host, "Playground PD host. If not provided, PD will still use `host` flag as its host")
 	rootCmd.Flags().BoolVar(&opt.monitor, "monitor", false, "Start prometheus component")
+
 	rootCmd.Flags().StringVarP(&opt.tidb.ConfigPath, "db.config", "", opt.tidb.ConfigPath, "TiDB instance configuration file")
 	rootCmd.Flags().StringVarP(&opt.tikv.ConfigPath, "kv.config", "", opt.tikv.ConfigPath, "TiKV instance configuration file")
 	rootCmd.Flags().StringVarP(&opt.pd.ConfigPath, "pd.config", "", opt.pd.ConfigPath, "PD instance configuration file")
 	rootCmd.Flags().StringVarP(&opt.tidb.ConfigPath, "tiflash.config", "", opt.tidb.ConfigPath, "TiFlash instance configuration file")
+	rootCmd.Flags().StringVarP(&opt.pump.ConfigPath, "pump.config", "", opt.pump.ConfigPath, "Pump instance configuration file")
+	rootCmd.Flags().StringVarP(&opt.drainer.ConfigPath, "drainer.config", "", opt.drainer.ConfigPath, "Drainer instance configuration file")
+
 	rootCmd.Flags().StringVarP(&opt.tidb.BinPath, "db.binpath", "", opt.tidb.BinPath, "TiDB instance binary path")
 	rootCmd.Flags().StringVarP(&opt.tikv.BinPath, "kv.binpath", "", opt.tikv.BinPath, "TiKV instance binary path")
 	rootCmd.Flags().StringVarP(&opt.pd.BinPath, "pd.binpath", "", opt.pd.BinPath, "PD instance binary path")
 	rootCmd.Flags().StringVarP(&opt.tiflash.BinPath, "tiflash.binpath", "", opt.tiflash.BinPath, "TiFlash instance binary path")
+	rootCmd.Flags().StringVarP(&opt.pump.BinPath, "pump.binpath", "", opt.pump.BinPath, "Pump instance binary path")
+	rootCmd.Flags().StringVarP(&opt.drainer.BinPath, "drainer.binpath", "", opt.drainer.BinPath, "Drainer instance binary path")
 
 	rootCmd.AddCommand(newDisplay())
 	rootCmd.AddCommand(newScaleOut())


### PR DESCRIPTION
fix #422 

this pr also fix the issue when --host is set as "0.0.0.0".
according to the doc:https://pingcap.com/docs-cn/dev/tiup/tiup-playground/
```
      --host string              设置每个组件的监听地址（默认为 127.0.0.1），如果要提供给别的电脑访问，可设置为 0.0.0.0
```

this actually can't work cause many advertise addr also use "0.0.0.0:<port>"


Note the default config of drainer is replicate to 127.0.0.1:3306, user must set up the downstream itself or provide the custom config for drainer, or drainer will fail to run.

usage example:
run MySQL local at port 3306.

start a playground with:
- tp --pump 3 --drainer 1

check the replication works

in another terminal
- scale-in one pump
- scale-in one drainer
- scale-out one pump
- scale-out one drainer
<img width="835" alt="Screen Shot 2020-06-12 at 4 04 24 PM" src="https://user-images.githubusercontent.com/1681864/84481198-52c06a80-acc8-11ea-84ba-ba0894256800.png">
