### PR TITLE
Reorder imported config priority

### DIFF
--- a/pkg/cluster/meta/drainer.go
+++ b/pkg/cluster/meta/drainer.go
@@ -107,7 +107,7 @@ func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		return err
 	}
 
-	specConfig := spec.Config
+	globalConfig := i.topo.ServerConfigs.Drainer
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -124,14 +124,13 @@ func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		if err != nil {
 			return err
 		}
-		mergedConfig, err := mergeImported(importConfig, spec.Config)
+		globalConfig, err = mergeImported(importConfig, globalConfig)
 		if err != nil {
 			return err
 		}
-		specConfig = mergedConfig
 	}
 
-	if err := i.mergeServerConfig(e, i.topo.ServerConfigs.Drainer, specConfig, paths); err != nil {
+	if err := i.mergeServerConfig(e, globalConfig, spec.Config, paths); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/meta/logic.go
+++ b/pkg/cluster/meta/logic.go
@@ -407,7 +407,7 @@ func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		return err
 	}
 
-	specConfig := spec.Config
+	globalConfig := i.instance.topo.ServerConfigs.TiDB
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -424,14 +424,13 @@ func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		if err != nil {
 			return err
 		}
-		mergedConfig, err := mergeImported(importConfig, spec.Config)
+		globalConfig, err = mergeImported(importConfig, globalConfig)
 		if err != nil {
 			return err
 		}
-		specConfig = mergedConfig
 	}
 
-	if err := i.mergeServerConfig(e, i.instance.topo.ServerConfigs.TiDB, specConfig, paths); err != nil {
+	if err := i.mergeServerConfig(e, globalConfig, spec.Config, paths); err != nil {
 		return err
 	}
 
@@ -515,7 +514,7 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		return err
 	}
 
-	specConfig := spec.Config
+	globalConfig := i.instance.topo.ServerConfigs.TiKV
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -532,14 +531,13 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		if err != nil {
 			return err
 		}
-		mergedConfig, err := mergeImported(importConfig, spec.Config)
+		globalConfig, err = mergeImported(importConfig, globalConfig)
 		if err != nil {
 			return err
 		}
-		specConfig = mergedConfig
 	}
 
-	if err := i.mergeServerConfig(e, i.instance.topo.ServerConfigs.TiKV, specConfig, paths); err != nil {
+	if err := i.mergeServerConfig(e, globalConfig, spec.Config, paths); err != nil {
 		return err
 	}
 
@@ -636,7 +634,7 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clusterVe
 		spec.Config["pd-server.metric-storage"] = fmt.Sprintf("http://%s:%d", prom.Host, prom.Port)
 	}
 
-	specConfig := spec.Config
+	globalConfig := i.instance.topo.ServerConfigs.PD
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -653,14 +651,13 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clusterVe
 		if err != nil {
 			return err
 		}
-		mergedConfig, err := mergeImported(importConfig, spec.Config)
+		globalConfig, err = mergeImported(importConfig, globalConfig)
 		if err != nil {
 			return err
 		}
-		specConfig = mergedConfig
 	}
 
-	if err := i.mergeServerConfig(e, i.instance.topo.ServerConfigs.PD, specConfig, paths); err != nil {
+	if err := i.mergeServerConfig(e, globalConfig, spec.Config, paths); err != nil {
 		return err
 	}
 
@@ -942,7 +939,6 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		return err
 	}
 
-	specLernerConfig := spec.LearnerConfig
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -959,14 +955,13 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		if err != nil {
 			return err
 		}
-		mergedConfig, err := mergeImported(importConfig, spec.LearnerConfig)
+		conf, err = mergeImported(importConfig, conf)
 		if err != nil {
 			return err
 		}
-		specLernerConfig = mergedConfig
 	}
 
-	err = i.mergeTiFlashLearnerServerConfig(e, conf, specLernerConfig, paths)
+	err = i.mergeTiFlashLearnerServerConfig(e, conf, spec.LearnerConfig, paths)
 	if err != nil {
 		return err
 	}
@@ -976,7 +971,6 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		return err
 	}
 
-	specConfig := spec.Config
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -993,13 +987,13 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		if err != nil {
 			return err
 		}
-		specConfig, err = mergeImported(importConfig, spec.Config)
+		conf, err = mergeImported(importConfig, conf)
 		if err != nil {
 			return err
 		}
 	}
 
-	return i.mergeServerConfig(e, conf, specConfig, paths)
+	return i.mergeServerConfig(e, conf, spec.Config, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling

--- a/pkg/cluster/meta/logic_dm.go
+++ b/pkg/cluster/meta/logic_dm.go
@@ -281,7 +281,7 @@ func (i *DMMasterInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		return err
 	}
 
-	specConfig := spec.Config
+	globalConfig := i.dmInstance.topo.ServerConfigs.Master
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -298,14 +298,13 @@ func (i *DMMasterInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		if err != nil {
 			return err
 		}
-		mergedConfig, err := mergeImported(importConfig, spec.Config)
+		globalConfig, err = mergeImported(importConfig, globalConfig)
 		if err != nil {
 			return err
 		}
-		specConfig = mergedConfig
 	}
 
-	if err := i.mergeServerConfig(e, i.dmInstance.topo.ServerConfigs.Master, specConfig, paths); err != nil {
+	if err := i.mergeServerConfig(e, globalConfig, spec.Config, paths); err != nil {
 		return err
 	}
 
@@ -417,7 +416,7 @@ func (i *DMWorkerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		return err
 	}
 
-	specConfig := spec.Config
+	globalConfig := i.topo.ServerConfigs.Worker
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -434,14 +433,13 @@ func (i *DMWorkerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		if err != nil {
 			return err
 		}
-		mergedConfig, err := mergeImported(importConfig, spec.Config)
+		globalConfig, err = mergeImported(importConfig, globalConfig)
 		if err != nil {
 			return err
 		}
-		specConfig = mergedConfig
 	}
 
-	return i.mergeServerConfig(e, i.topo.ServerConfigs.Worker, specConfig, paths)
+	return i.mergeServerConfig(e, globalConfig, spec.Config, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling
@@ -526,7 +524,7 @@ func (i *DMPortalInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		return err
 	}
 
-	specConfig := spec.Config
+	globalConfig := i.topo.ServerConfigs.Portal
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -543,14 +541,13 @@ func (i *DMPortalInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		if err != nil {
 			return err
 		}
-		mergedConfig, err := mergeImported(importConfig, spec.Config)
+		globalConfig, err = mergeImported(importConfig, globalConfig)
 		if err != nil {
 			return err
 		}
-		specConfig = mergedConfig
 	}
 
-	return i.mergeServerConfig(e, i.topo.ServerConfigs.Portal, specConfig, paths)
+	return i.mergeServerConfig(e, globalConfig, spec.Config, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling

--- a/pkg/cluster/meta/pump.go
+++ b/pkg/cluster/meta/pump.go
@@ -104,7 +104,7 @@ func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		return err
 	}
 
-	specConfig := spec.Config
+	globalConfig := i.topo.ServerConfigs.Pump
 	// merge config files for imported instance
 	if i.IsImported() {
 		configPath := ClusterPath(
@@ -121,12 +121,11 @@ func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		if err != nil {
 			return err
 		}
-		mergedConfig, err := mergeImported(importConfig, spec.Config)
+		globalConfig, err = mergeImported(importConfig, globalConfig)
 		if err != nil {
 			return err
 		}
-		specConfig = mergedConfig
 	}
 
-	return i.mergeServerConfig(e, i.topo.ServerConfigs.Pump, specConfig, paths)
+	return i.mergeServerConfig(e, globalConfig, spec.Config, paths)
 }

--- a/pkg/cluster/meta/topology_test.go
+++ b/pkg/cluster/meta/topology_test.go
@@ -575,13 +575,13 @@ item6 = 600
 itemx = "valuex"
 itemy = 1000
 [config2.item4]
-item7 = 780
+item7 = 700
 `
 
-	merge1, err := mergeImported(config, spec.TiKVServers[0].Config)
+	merge1, err := mergeImported(config, spec.ServerConfigs.TiKV)
 	c.Assert(err, IsNil)
 
-	merge2, err := merge2Toml(ComponentTiKV, spec.ServerConfigs.TiKV, merge1)
+	merge2, err := merge2Toml(ComponentTiKV, merge1, spec.TiKVServers[0].Config)
 	c.Assert(err, IsNil)
 	c.Assert(string(merge2), DeepEquals, expected)
 }


### PR DESCRIPTION
The tiup config should always have higher priority
than tiup-ansible ones.

Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR gives tiup config higher priority than imported tidb-ansible config to reduce
the confusion.

### What is changed and how it works?
I changed the merge methods and let it accept more than one overwrites, it will overwrite the orig with the overwrites one by one, so the latter overwrites have higher priority.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test