### PR TITLE
Fix timeout when target directory exists and there is lots of content

### DIFF
--- a/pkg/cluster/clusterutil/clusterutil.go
+++ b/pkg/cluster/clusterutil/clusterutil.go
@@ -30,6 +30,10 @@ func Abs(user, path string) string {
 func MultiDirAbs(user, paths string) []string {
 	var dirs []string
 	for _, path := range strings.Split(paths, ",") {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
 		dirs = append(dirs, Abs(user, path))
 	}
 	return dirs

--- a/pkg/cluster/clusterutil/clusterutil_test.go
+++ b/pkg/cluster/clusterutil/clusterutil_test.go
@@ -1,0 +1,26 @@
+package clusterutil
+
+import (
+	"github.com/pingcap/check"
+)
+
+type utilSuite struct{}
+
+var _ = check.Suite(&utilSuite{})
+
+func (s *utilSuite) TestMultiDirAbs(c *check.C) {
+	paths := MultiDirAbs("tidb", "")
+	c.Assert(len(paths), check.Equals, 0)
+
+	paths = MultiDirAbs("tidb", " ")
+	c.Assert(len(paths), check.Equals, 0)
+
+	paths = MultiDirAbs("tidb", "a ")
+	c.Assert(len(paths), check.Equals, 1)
+	c.Assert(paths[0], check.Equals, "/home/tidb/a")
+
+	paths = MultiDirAbs("tidb", "a , /tmp/b")
+	c.Assert(len(paths), check.Equals, 2)
+	c.Assert(paths[0], check.Equals, "/home/tidb/a")
+	c.Assert(paths[1], check.Equals, "/tmp/b")
+}


### PR DESCRIPTION
Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When the user specifies a directory which contains lots of content (200GB for example) as log/data directory, the chown -R command will wait a long time to timeout.

### What is changed and how it works?
`chown -R` -> `chown`