### PR TITLE
cluster: optimize dir conflicts check & the destroying process 

### DIFF
--- a/components/cluster/command/check.go
+++ b/components/cluster/command/check.go
@@ -63,7 +63,7 @@ conflict checks with other clusters`,
 
 			logger.EnableAuditLog()
 
-			var topo meta.TopologySpecification
+			var topo meta.ClusterSpecification
 			if opt.existCluster { // check for existing cluster
 				clusterName := args[0]
 				if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
@@ -111,7 +111,7 @@ conflict checks with other clusters`,
 }
 
 // checkSystemInfo performs series of checks and tests of the deploy server
-func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecification, opt *checkOptions) error {
+func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.ClusterSpecification, opt *checkOptions) error {
 	var (
 		collectTasks  []*task.StepDisplay
 		checkSysTasks []*task.StepDisplay

--- a/components/cluster/command/check.go
+++ b/components/cluster/command/check.go
@@ -14,6 +14,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -21,7 +22,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cliutil/prepare"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
@@ -67,10 +68,10 @@ conflict checks with other clusters`,
 			if opt.existCluster { // check for existing cluster
 				clusterName := args[0]
 				if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-					return errors.Errorf("cluster %s does not exist", clusterName)
+					return perrs.Errorf("cluster %s does not exist", clusterName)
 				}
 				metadata, err := meta.ClusterMetadata(clusterName)
-				if err != nil {
+				if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 					return err
 				}
 				topo = *metadata.Topology
@@ -278,7 +279,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.ClusterSpecificat
 			// FIXME: Map possible task errors and give suggestions.
 			return err
 		}
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	var checkResultTable [][]string
@@ -319,7 +320,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.ClusterSpecificat
 				// FIXME: Map possible task errors and give suggestions.
 				return err
 			}
-			return errors.Trace(err)
+			return perrs.Trace(err)
 		}
 	}
 

--- a/components/cluster/command/deploy.go
+++ b/components/cluster/command/deploy.go
@@ -157,7 +157,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 			WithProperty(cliutil.SuggestionFromFormat("Please specify another cluster name"))
 	}
 
-	var topo meta.TopologySpecification
+	var topo meta.ClusterSpecification
 	if err := clusterutil.ParseTopologyYaml(topoFile, &topo); err != nil {
 		return err
 	}

--- a/components/cluster/command/destroy.go
+++ b/components/cluster/command/destroy.go
@@ -14,11 +14,12 @@
 package command
 
 import (
+	"errors"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
@@ -41,12 +42,12 @@ func newDestroyCmd() *cobra.Command {
 			clusterName := args[0]
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot destroy non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot destroy non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.ClusterMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -74,11 +75,11 @@ func newDestroyCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			if err := os.RemoveAll(meta.ClusterPath(clusterName)); err != nil {
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 			log.Infof("Destroyed cluster `%s` successfully", clusterName)
 			return nil

--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -14,6 +14,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -21,7 +22,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/api"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
@@ -51,7 +52,7 @@ func newDisplayCmd() *cobra.Command {
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("Cluster %s not found", clusterName)
+				return perrs.Errorf("Cluster %s not found", clusterName)
 			}
 
 			if showDashboardOnly {
@@ -66,8 +67,8 @@ func newDisplayCmd() *cobra.Command {
 			}
 
 			metadata, err := meta.ClusterMetadata(clusterName)
-			if err != nil {
-				return errors.AddStack(err)
+			if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
+				return perrs.AddStack(err)
 			}
 			return destroyTombstoneIfNeed(clusterName, metadata, gOpt)
 		},
@@ -82,7 +83,7 @@ func newDisplayCmd() *cobra.Command {
 
 func displayDashboardInfo(clusterName string) error {
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
 		return err
 	}
 
@@ -115,7 +116,7 @@ func displayDashboardInfo(clusterName string) error {
 
 func displayClusterMeta(clusterName string, opt *operator.Options) error {
 	clsMeta, err := meta.ClusterMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
 		return err
 	}
 
@@ -138,17 +139,17 @@ func destroyTombstoneIfNeed(clusterName string, metadata *meta.ClusterMeta, opt 
 	err := ctx.SetSSHKeySet(meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 		meta.ClusterPath(clusterName, "ssh", "id_rsa.pub"))
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	err = ctx.SetClusterSSH(topo, metadata.User, gOpt.SSHTimeout)
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	nodes, err := operator.DestroyTombstone(ctx, topo, true /* returnNodesOnly */, opt)
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	if len(nodes) == 0 {
@@ -159,7 +160,7 @@ func destroyTombstoneIfNeed(clusterName string, metadata *meta.ClusterMeta, opt 
 
 	_, err = operator.DestroyTombstone(ctx, topo, false /* returnNodesOnly */, opt)
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	log.Infof("Destroy success")
@@ -169,7 +170,7 @@ func destroyTombstoneIfNeed(clusterName string, metadata *meta.ClusterMeta, opt 
 
 func displayClusterTopology(clusterName string, opt *operator.Options) error {
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
 		return err
 	}
 
@@ -184,12 +185,12 @@ func displayClusterTopology(clusterName string, opt *operator.Options) error {
 	err = ctx.SetSSHKeySet(meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 		meta.ClusterPath(clusterName, "ssh", "id_rsa.pub"))
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	err = ctx.SetClusterSSH(topo, metadata.User, gOpt.SSHTimeout)
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	filterRoles := set.NewStringSet(opt.Roles...)

--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -67,7 +67,7 @@ func newDisplayCmd() *cobra.Command {
 			}
 
 			metadata, err := meta.ClusterMetadata(clusterName)
-			if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return perrs.AddStack(err)
 			}
 			return destroyTombstoneIfNeed(clusterName, metadata, gOpt)
@@ -83,7 +83,7 @@ func newDisplayCmd() *cobra.Command {
 
 func displayDashboardInfo(clusterName string) error {
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		return err
 	}
 
@@ -116,7 +116,7 @@ func displayDashboardInfo(clusterName string) error {
 
 func displayClusterMeta(clusterName string, opt *operator.Options) error {
 	clsMeta, err := meta.ClusterMetadata(clusterName)
-	if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		return err
 	}
 
@@ -170,7 +170,7 @@ func destroyTombstoneIfNeed(clusterName string, metadata *meta.ClusterMeta, opt 
 
 func displayClusterTopology(clusterName string, opt *operator.Options) error {
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		return err
 	}
 

--- a/components/cluster/command/edit_config.go
+++ b/components/cluster/command/edit_config.go
@@ -97,7 +97,7 @@ func editTopo(clusterName string, metadata *meta.ClusterMeta) error {
 		return errors.AddStack(err)
 	}
 
-	newTopo := new(meta.TopologySpecification)
+	newTopo := new(meta.ClusterSpecification)
 	err = yaml.UnmarshalStrict(newData, newTopo)
 	if err != nil {
 		log.Infof("Failed to parse topology file: %v", err)

--- a/components/cluster/command/edit_config.go
+++ b/components/cluster/command/edit_config.go
@@ -15,12 +15,13 @@ package command
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"io/ioutil"
 	"os"
 
 	"github.com/fatih/color"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/edit"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
@@ -43,12 +44,12 @@ func newEditConfigCmd() *cobra.Command {
 			clusterName := args[0]
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot start non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.ClusterMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -66,42 +67,42 @@ func newEditConfigCmd() *cobra.Command {
 func editTopo(clusterName string, metadata *meta.ClusterMeta) error {
 	data, err := yaml.Marshal(metadata.Topology)
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	file, err := ioutil.TempFile(os.TempDir(), "*")
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	name := file.Name()
 
 	_, err = io.Copy(file, bytes.NewReader(data))
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	err = file.Close()
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	err = edit.OpenFileInEditor(name)
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	// Now user finish editing the file.
 	newData, err := ioutil.ReadFile(name)
 	if err != nil {
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	newTopo := new(meta.ClusterSpecification)
 	err = yaml.UnmarshalStrict(newData, newTopo)
 	if err != nil {
 		log.Infof("Failed to parse topology file: %v", err)
-		return errors.AddStack(err)
+		return perrs.AddStack(err)
 	}
 
 	if bytes.Equal(data, newData) {
@@ -124,7 +125,7 @@ func editTopo(clusterName string, metadata *meta.ClusterMeta) error {
 	metadata.Topology = newTopo
 	err = meta.SaveClusterMeta(clusterName, metadata)
 	if err != nil {
-		return errors.Annotate(err, "failed to save")
+		return perrs.Annotate(err, "failed to save")
 	}
 
 	log.Infof("Apply change successfully, please use `%s reload %s [-N <nodes>] [-R <roles>]` to reload config.", cliutil.OsArgs0(), clusterName)

--- a/components/cluster/command/exec.go
+++ b/components/cluster/command/exec.go
@@ -14,9 +14,11 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	"github.com/pingcap/tiup/pkg/cluster/task"
 	"github.com/pingcap/tiup/pkg/logger"
@@ -44,12 +46,12 @@ func newExecCmd() *cobra.Command {
 			clusterName := args[0]
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot execute command on non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot execute command on non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.ClusterMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -93,7 +95,7 @@ func newExecCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			// print outputs

--- a/components/cluster/command/list.go
+++ b/components/cluster/command/list.go
@@ -14,10 +14,11 @@
 package command
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	tiuputils "github.com/pingcap/tiup/pkg/utils"
@@ -50,8 +51,8 @@ func listCluster() error {
 			continue
 		}
 		metadata, err := meta.ClusterMetadata(fi.Name())
-		if err != nil {
-			return errors.Trace(err)
+		if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
+			return perrs.Trace(err)
 		}
 
 		clusterTable = append(clusterTable, []string{

--- a/components/cluster/command/patch.go
+++ b/components/cluster/command/patch.go
@@ -14,13 +14,14 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path"
 
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
@@ -47,7 +48,7 @@ func newPatchCmd() *cobra.Command {
 			}
 
 			if len(gOpt.Nodes) == 0 && len(gOpt.Roles) == 0 {
-				return errors.New("the flag -R or -N must be specified at least one")
+				return perrs.New("the flag -R or -N must be specified at least one")
 			}
 			clusterName := args[0]
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
@@ -64,15 +65,15 @@ func newPatchCmd() *cobra.Command {
 
 func patch(clusterName, packagePath string, options operator.Options, overwrite bool) error {
 	if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-		return errors.Errorf("cannot patch non-exists cluster %s", clusterName)
+		return perrs.Errorf("cannot patch non-exists cluster %s", clusterName)
 	}
 
 	if exist := tiuputils.IsExist(packagePath); !exist {
-		return errors.New("specified package not exists")
+		return perrs.New("specified package not exists")
 	}
 
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		return err
 	}
 
@@ -107,7 +108,7 @@ func patch(clusterName, packagePath string, options operator.Options, overwrite 
 			// FIXME: Map possible task errors and give suggestions.
 			return err
 		}
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	if overwrite {
@@ -147,7 +148,7 @@ func instancesToPatch(metadata *meta.ClusterMeta, options operator.Options) ([]m
 
 func checkPackage(clusterName, comp, nodeOS, arch, packagePath string) error {
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		return err
 	}
 

--- a/components/cluster/command/reload.go
+++ b/components/cluster/command/reload.go
@@ -14,8 +14,10 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
@@ -42,12 +44,12 @@ func newReloadCmd() *cobra.Command {
 			clusterName := args[0]
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot start non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.ClusterMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -61,7 +63,7 @@ func newReloadCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			log.Infof("Reloaded cluster `%s` successfully", clusterName)
@@ -150,7 +152,7 @@ func validRoles(roles []string) error {
 		}
 
 		if !match {
-			return errors.Errorf("not valid role: %s, should be one of: %v", r, meta.AllComponentNames())
+			return perrs.Errorf("not valid role: %s, should be one of: %v", r, meta.AllComponentNames())
 		}
 	}
 

--- a/components/cluster/command/restart.go
+++ b/components/cluster/command/restart.go
@@ -14,8 +14,10 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/task"
@@ -41,12 +43,12 @@ func newRestartCmd() *cobra.Command {
 			clusterName := args[0]
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot restart non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot restart non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.ClusterMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -63,7 +65,7 @@ func newRestartCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			log.Infof("Restarted cluster `%s` successfully", clusterName)

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -166,7 +166,7 @@ func printErrorMessageForErrorX(err *errorx.Error) {
 			causeErrX = c
 		} else if cause != nil {
 			if ident > 0 {
-				// Out most error may have empty message. In this case we treat it as a transparent error.
+				// The error may have empty message. In this case we treat it as a transparent error.
 				// Thus `ident == 0` can be possible.
 				msg += strings.Repeat("  ", ident) + "caused by: "
 			}

--- a/components/cluster/command/scale_in.go
+++ b/components/cluster/command/scale_in.go
@@ -82,7 +82,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 	}
 
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil && !errors.Is(err, &meta.ValidateErr{}) {
+	if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
 		// ignore conflict check error, node may be deployed by former version
 		// that lack of some certain conflict checks
 		return err

--- a/components/cluster/command/scale_in.go
+++ b/components/cluster/command/scale_in.go
@@ -81,7 +81,9 @@ func scaleIn(clusterName string, options operator.Options) error {
 	}
 
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "conflicts between") {
+		// ignore conflict check error, node may be deployed by former version
+		// that lack of some certain conflict checks
 		return err
 	}
 

--- a/components/cluster/command/scale_in.go
+++ b/components/cluster/command/scale_in.go
@@ -14,11 +14,12 @@
 package command
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
@@ -77,11 +78,11 @@ func newScaleInCmd() *cobra.Command {
 
 func scaleIn(clusterName string, options operator.Options) error {
 	if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-		return errors.Errorf("cannot scale-in non-exists cluster %s", clusterName)
+		return perrs.Errorf("cannot scale-in non-exists cluster %s", clusterName)
 	}
 
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil && !strings.Contains(err.Error(), "conflicts between") {
+	if err != nil && !errors.Is(err, &meta.ValidateErr{}) {
 		// ignore conflict check error, node may be deployed by former version
 		// that lack of some certain conflict checks
 		return err
@@ -159,7 +160,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
 		}
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	log.Infof("Scaled cluster `%s` in successfully", clusterName)

--- a/components/cluster/command/scale_in.go
+++ b/components/cluster/command/scale_in.go
@@ -82,7 +82,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 	}
 
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil && !errors.Is(perrs.Cause(err), &meta.ValidateErr{}) {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		// ignore conflict check error, node may be deployed by former version
 		// that lack of some certain conflict checks
 		return err

--- a/components/cluster/command/scale_out.go
+++ b/components/cluster/command/scale_out.go
@@ -74,7 +74,7 @@ func scaleOut(clusterName, topoFile string, opt scaleOutOptions) error {
 	}
 
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil {
+	if err != nil { // not allowing validation errors
 		return err
 	}
 

--- a/components/cluster/command/scale_out.go
+++ b/components/cluster/command/scale_out.go
@@ -80,7 +80,7 @@ func scaleOut(clusterName, topoFile string, opt scaleOutOptions) error {
 
 	// Inherit existing global configuration. We must assign the inherited values before unmarshalling
 	// because some default value rely on the global options and monitored options.
-	var newPart = meta.TopologySpecification{
+	var newPart = meta.ClusterSpecification{
 		GlobalOptions:    metadata.Topology.GlobalOptions,
 		MonitoredOptions: metadata.Topology.MonitoredOptions,
 		ServerConfigs:    metadata.Topology.ServerConfigs,
@@ -158,7 +158,7 @@ func buildScaleOutTask(
 	mergedTopo *meta.ClusterSpecification,
 	opt scaleOutOptions,
 	sshConnProps *cliutil.SSHConnectionProps,
-	newPart *meta.TopologySpecification,
+	newPart *meta.ClusterSpecification,
 	patchedComponents set.StringSet,
 	timeout int64,
 ) (task.Task, error) {

--- a/components/cluster/command/start.go
+++ b/components/cluster/command/start.go
@@ -14,8 +14,10 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/task"
@@ -41,7 +43,7 @@ func newStartCmd() *cobra.Command {
 			clusterName := args[0]
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot start non-exists cluster %s", clusterName)
 			}
 
 			return startCluster(clusterName, gOpt)
@@ -58,7 +60,7 @@ func startCluster(clusterName string, options operator.Options) error {
 	logger.EnableAuditLog()
 	log.Infof("Starting cluster %s...", clusterName)
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		return err
 	}
 
@@ -76,7 +78,7 @@ func startCluster(clusterName string, options operator.Options) error {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
 		}
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	log.Infof("Started cluster `%s` successfully", clusterName)

--- a/components/cluster/command/stop.go
+++ b/components/cluster/command/stop.go
@@ -14,8 +14,10 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/task"
@@ -41,12 +43,12 @@ func newStopCmd() *cobra.Command {
 			clusterName := args[0]
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot stop non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot stop non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.ClusterMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -63,7 +65,7 @@ func newStopCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			log.Infof("Stopped cluster `%s` successfully", clusterName)

--- a/components/cluster/command/test.go
+++ b/components/cluster/command/test.go
@@ -16,9 +16,10 @@ package command
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/spf13/cobra"
@@ -40,11 +41,11 @@ func newTestCmd() *cobra.Command {
 
 			clusterName := args[0]
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot start non-exists cluster %s", clusterName)
 			}
 
 			metadata, err := meta.ClusterMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 

--- a/components/cluster/command/test.go
+++ b/components/cluster/command/test.go
@@ -68,7 +68,7 @@ func createDB(spec meta.TiDBSpec) (db *sql.DB, err error) {
 	return
 }
 
-func writable(topo *meta.TopologySpecification) error {
+func writable(topo *meta.ClusterSpecification) error {
 	errg, _ := errgroup.WithContext(context.Background())
 
 	for _, spec := range topo.TiDBServers {

--- a/components/cluster/command/upgrade.go
+++ b/components/cluster/command/upgrade.go
@@ -14,11 +14,12 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
@@ -64,19 +65,19 @@ func versionCompare(curVersion, newVersion string) error {
 	case -1:
 		return nil
 	case 0, 1:
-		return errors.Errorf("please specify a higher version than %s", curVersion)
+		return perrs.Errorf("please specify a higher version than %s", curVersion)
 	default:
-		return errors.Errorf("unreachable")
+		return perrs.Errorf("unreachable")
 	}
 }
 
 func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 	if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-		return errors.Errorf("cannot upgrade non-exists cluster %s", clusterName)
+		return perrs.Errorf("cannot upgrade non-exists cluster %s", clusterName)
 	}
 
 	metadata, err := meta.ClusterMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		return err
 	}
 
@@ -96,7 +97,7 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 		for _, inst := range comp.Instances() {
 			version := meta.ComponentVersion(inst.ComponentName(), clusterVersion)
 			if version == "" {
-				return errors.Errorf("unsupported component: %v", inst.ComponentName())
+				return perrs.Errorf("unsupported component: %v", inst.ComponentName())
 			}
 			compInfo := componentInfo{
 				component: inst.ComponentName(),
@@ -172,15 +173,15 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
 		}
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	metadata.Version = clusterVersion
 	if err := meta.SaveClusterMeta(clusterName, metadata); err != nil {
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 	if err := os.RemoveAll(meta.ClusterPath(clusterName, "patch")); err != nil {
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	log.Infof("Upgraded cluster `%s` successfully", clusterName)

--- a/components/dms/command/destroy.go
+++ b/components/dms/command/destroy.go
@@ -14,11 +14,12 @@
 package command
 
 import (
+	"errors"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
@@ -40,12 +41,12 @@ func newDestroyCmd() *cobra.Command {
 
 			clusterName := args[0]
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot destroy non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot destroy non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.DMMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -73,11 +74,11 @@ func newDestroyCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			if err := os.RemoveAll(meta.ClusterPath(clusterName)); err != nil {
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 			log.Infof("Destroyed DM cluster `%s` successfully", clusterName)
 			return nil

--- a/components/dms/command/exec.go
+++ b/components/dms/command/exec.go
@@ -14,9 +14,11 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	"github.com/pingcap/tiup/pkg/cluster/task"
 	"github.com/pingcap/tiup/pkg/logger"
@@ -43,12 +45,12 @@ func newExecCmd() *cobra.Command {
 
 			clusterName := args[0]
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot execute command on non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot execute command on non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.DMMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -92,7 +94,7 @@ func newExecCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			// print outputs

--- a/components/dms/command/list.go
+++ b/components/dms/command/list.go
@@ -14,10 +14,11 @@
 package command
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	tiuputils "github.com/pingcap/tiup/pkg/utils"
@@ -50,8 +51,8 @@ func listCluster() error {
 			continue
 		}
 		metadata, err := meta.DMMetadata(fi.Name())
-		if err != nil {
-			return errors.Trace(err)
+		if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
+			return perrs.Trace(err)
 		}
 
 		clusterTable = append(clusterTable, []string{

--- a/components/dms/command/reload.go
+++ b/components/dms/command/reload.go
@@ -14,8 +14,10 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
@@ -41,12 +43,12 @@ func newReloadCmd() *cobra.Command {
 
 			clusterName := args[0]
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot start non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.DMMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -60,7 +62,7 @@ func newReloadCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			log.Infof("Reloaded cluster `%s` successfully", clusterName)
@@ -140,7 +142,7 @@ func validRoles(roles []string) error {
 		}
 
 		if !match {
-			return errors.Errorf("not valid role: %s, should be one of: %v", r, meta.AllDMComponentNames())
+			return perrs.Errorf("not valid role: %s, should be one of: %v", r, meta.AllDMComponentNames())
 		}
 	}
 

--- a/components/dms/command/restart.go
+++ b/components/dms/command/restart.go
@@ -14,8 +14,10 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/task"
@@ -40,12 +42,12 @@ func newRestartCmd() *cobra.Command {
 
 			clusterName := args[0]
 			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot restart non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot restart non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.DMMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -62,7 +64,7 @@ func newRestartCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			log.Infof("Restarted cluster `%s` successfully", clusterName)

--- a/components/dms/command/scale_in.go
+++ b/components/dms/command/scale_in.go
@@ -72,7 +72,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 	}
 
 	metadata, err := meta.DMMetadata(clusterName)
-	if err != nil && !errors.Is(err, &meta.ValidateErr{}) {
+	if err != nil && !errors.Is(err, meta.ValidateErr) {
 		// ignore conflict check error, node may be deployed by former version
 		// that lack of some certain conflict checks
 		return err

--- a/components/dms/command/scale_in.go
+++ b/components/dms/command/scale_in.go
@@ -14,11 +14,12 @@
 package command
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
@@ -67,11 +68,13 @@ func newScaleInCmd() *cobra.Command {
 
 func scaleIn(clusterName string, options operator.Options) error {
 	if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-		return errors.Errorf("cannot scale-in non-exists cluster %s", clusterName)
+		return perrs.Errorf("cannot scale-in non-exists cluster %s", clusterName)
 	}
 
 	metadata, err := meta.DMMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(err, &meta.ValidateErr{}) {
+		// ignore conflict check error, node may be deployed by former version
+		// that lack of some certain conflict checks
 		return err
 	}
 
@@ -128,7 +131,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
 		}
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	log.Infof("Scaled cluster `%s` in successfully", clusterName)

--- a/components/dms/command/start.go
+++ b/components/dms/command/start.go
@@ -14,8 +14,10 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/task"
@@ -36,7 +38,7 @@ func newStartCmd() *cobra.Command {
 
 			clusterName := args[0]
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot start non-exists cluster %s", clusterName)
 			}
 
 			return startCluster(clusterName, gOpt)
@@ -53,7 +55,7 @@ func startCluster(clusterName string, options operator.Options) error {
 	logger.EnableAuditLog()
 	log.Infof("Starting cluster %s...", clusterName)
 	metadata, err := meta.DMMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		return err
 	}
 
@@ -70,7 +72,7 @@ func startCluster(clusterName string, options operator.Options) error {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
 		}
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	log.Infof("Started cluster `%s` successfully", clusterName)

--- a/components/dms/command/stop.go
+++ b/components/dms/command/stop.go
@@ -14,8 +14,10 @@
 package command
 
 import (
+	"errors"
+
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/task"
@@ -36,12 +38,12 @@ func newStopCmd() *cobra.Command {
 
 			clusterName := args[0]
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot stop non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot stop non-exists cluster %s", clusterName)
 			}
 
 			logger.EnableAuditLog()
 			metadata, err := meta.DMMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -58,7 +60,7 @@ func newStopCmd() *cobra.Command {
 					// FIXME: Map possible task errors and give suggestions.
 					return err
 				}
-				return errors.Trace(err)
+				return perrs.Trace(err)
 			}
 
 			log.Infof("Stopped cluster `%s` successfully", clusterName)

--- a/components/dms/command/test.go
+++ b/components/dms/command/test.go
@@ -15,11 +15,12 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	dmpb "github.com/pingcap/dm/dm/pb"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/spf13/cobra"
@@ -40,11 +41,11 @@ func newTestCmd() *cobra.Command {
 
 			clusterName := args[0]
 			if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
+				return perrs.Errorf("cannot start non-exists cluster %s", clusterName)
 			}
 
 			metadata, err := meta.DMMetadata(clusterName)
-			if err != nil {
+			if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 				return err
 			}
 
@@ -75,7 +76,7 @@ func checkMasterOnline(addr string) error {
 	defer cancel()
 	resp, err := cli.ShowDDLLocks(ctx, req)
 	if err == nil && !resp.Result {
-		return errors.Errorf("check master ddl locks failed: %s", resp.Msg)
+		return perrs.Errorf("check master ddl locks failed: %s", resp.Msg)
 	}
 	return err
 }
@@ -93,7 +94,7 @@ func checkWorkerOnline(addr string) error {
 	defer cancel()
 	resp, err := cli.QueryStatus(ctx, req)
 	if err == nil && !resp.Result {
-		return errors.Errorf("check worker status failed: %s", resp.Msg)
+		return perrs.Errorf("check worker status failed: %s", resp.Msg)
 	}
 	return err
 }

--- a/components/dms/command/upgrade.go
+++ b/components/dms/command/upgrade.go
@@ -14,11 +14,12 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/joomcode/errorx"
-	"github.com/pingcap/errors"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/meta"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
@@ -60,19 +61,19 @@ func versionCompare(curVersion, newVersion string) error {
 	case -1:
 		return nil
 	case 0, 1:
-		return errors.Errorf("please specify a higher version than %s", curVersion)
+		return perrs.Errorf("please specify a higher version than %s", curVersion)
 	default:
-		return errors.Errorf("unreachable")
+		return perrs.Errorf("unreachable")
 	}
 }
 
 func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 	if utils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
-		return errors.Errorf("cannot upgrade non-exists cluster %s", clusterName)
+		return perrs.Errorf("cannot upgrade non-exists cluster %s", clusterName)
 	}
 
 	metadata, err := meta.DMMetadata(clusterName)
-	if err != nil {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ValidateErr) {
 		return err
 	}
 
@@ -91,7 +92,7 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 		for _, inst := range comp.Instances() {
 			version := meta.ComponentVersion(inst.ComponentName(), clusterVersion)
 			if version == "" {
-				return errors.Errorf("unsupported component: %v", inst.ComponentName())
+				return perrs.Errorf("unsupported component: %v", inst.ComponentName())
 			}
 			compInfo := componentInfo{
 				component: inst.ComponentName(),
@@ -159,15 +160,15 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
 		}
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	metadata.Version = clusterVersion
 	if err := meta.SaveDMMeta(clusterName, metadata); err != nil {
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 	if err := os.RemoveAll(meta.ClusterPath(clusterName, "patch")); err != nil {
-		return errors.Trace(err)
+		return perrs.Trace(err)
 	}
 
 	log.Infof("Upgraded cluster `%s` successfully", clusterName)

--- a/pkg/cluster/ansible/import.go
+++ b/pkg/cluster/ansible/import.go
@@ -54,7 +54,7 @@ func parseInventoryFile(invFile io.Reader) (string, *meta.ClusterMeta, *aini.Inv
 	}
 
 	clsMeta := &meta.ClusterMeta{
-		Topology: &meta.TopologySpecification{
+		Topology: &meta.ClusterSpecification{
 			GlobalOptions:    meta.GlobalOptions{},
 			MonitoredOptions: meta.MonitoredOptions{},
 			TiDBServers:      make([]meta.TiDBSpec, 0),

--- a/pkg/cluster/meta/cluster.go
+++ b/pkg/cluster/meta/cluster.go
@@ -108,7 +108,8 @@ func ClusterMetadata(clusterName string) (*ClusterMeta, error) {
 	}
 
 	if err = yaml.Unmarshal(yamlFile, &cm); err != nil {
-		return nil, errors.Trace(err)
+		// return the meta no matter there is error or not
+		return &cm, errors.Trace(err)
 	}
 	return &cm, nil
 }

--- a/pkg/cluster/meta/cluster.go
+++ b/pkg/cluster/meta/cluster.go
@@ -51,7 +51,7 @@ type ClusterMeta struct {
 	//EnableFirewall bool   `yaml:"firewall"`
 	OpsVer string `yaml:"last_ops_ver,omitempty"` // the version of ourself that updated the meta last time
 
-	Topology *TopologySpecification `yaml:"topology"`
+	Topology *ClusterSpecification `yaml:"topology"`
 }
 
 // EnsureClusterDir ensures that the cluster directory exists.

--- a/pkg/cluster/meta/logic.go
+++ b/pkg/cluster/meta/logic.go
@@ -349,9 +349,6 @@ func (i *instance) Status(pdList ...string) string {
 	return i.statusFn(pdList...)
 }
 
-// ClusterSpecification of cluster
-type ClusterSpecification = TopologySpecification
-
 // TiDBComponent represents TiDB component.
 type TiDBComponent struct{ *ClusterSpecification }
 
@@ -815,7 +812,7 @@ func (i *TiFlashInstance) DataDir() string {
 
 // InitTiFlashConfig initializes TiFlash config file
 func (i *TiFlashInstance) InitTiFlashConfig(cfg *scripts.TiFlashScript, src map[string]interface{}) (map[string]interface{}, error) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 
 	err := yaml.Unmarshal([]byte(fmt.Sprintf(`
 server_configs:
@@ -879,7 +876,7 @@ server_configs:
 
 // InitTiFlashLearnerConfig initializes TiFlash learner config file
 func (i *TiFlashInstance) InitTiFlashLearnerConfig(cfg *scripts.TiFlashScript, src map[string]interface{}) (map[string]interface{}, error) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 
 	firstDataDir := strings.Split(cfg.DataDir, ",")[0]
 

--- a/pkg/cluster/meta/logic.go
+++ b/pkg/cluster/meta/logic.go
@@ -280,6 +280,23 @@ func (i *instance) DataDir() string {
 	return dataDir.String()
 }
 
+func (i *instance) LogDir() string {
+	logDir := ""
+
+	field := reflect.ValueOf(i.InstanceSpec).FieldByName("LogDir")
+	if field.IsValid() {
+		logDir = field.Interface().(string)
+	}
+
+	if logDir == "" {
+		logDir = "log"
+	}
+	if !strings.HasPrefix(logDir, "/") {
+		logDir = filepath.Join(i.DeployDir(), logDir)
+	}
+	return logDir
+}
+
 func (i *instance) OS() string {
 	return reflect.ValueOf(i.InstanceSpec).FieldByName("OS").Interface().(string)
 }
@@ -314,23 +331,6 @@ func (i *instance) resourceControl() ResourceControl {
 	return reflect.ValueOf(i.InstanceSpec).
 		FieldByName("ResourceControl").
 		Interface().(ResourceControl)
-}
-
-func (i *instance) LogDir() string {
-	logDir := ""
-
-	field := reflect.ValueOf(i.InstanceSpec).FieldByName("LogDir")
-	if field.IsValid() {
-		logDir = field.Interface().(string)
-	}
-
-	if logDir == "" {
-		logDir = "log"
-	}
-	if !strings.HasPrefix(logDir, "/") {
-		logDir = filepath.Join(i.DeployDir(), logDir)
-	}
-	return logDir
 }
 
 func (i *instance) GetPort() int {

--- a/pkg/cluster/meta/meta.go
+++ b/pkg/cluster/meta/meta.go
@@ -55,7 +55,8 @@ func (e *ValidateErr) Is(target error) bool {
 	}
 
 	// check for interface value seperately
-	if !(reflect.ValueOf(e.value).IsValid() && reflect.ValueOf(t.value).IsValid()) {
+	if e.value != nil && t.value != nil &&
+		(!reflect.ValueOf(e.value).IsValid() && !reflect.ValueOf(t.value).IsValid()) {
 		return false
 	}
 	// not supporting non-comparable values for now

--- a/pkg/cluster/meta/meta.go
+++ b/pkg/cluster/meta/meta.go
@@ -55,12 +55,17 @@ func (e *ValidateErr) Is(target error) bool {
 	}
 
 	// check for interface value seperately
-	if !(reflect.TypeOf(e.value).Comparable() && reflect.TypeOf(t.value).Comparable()) {
+	if !(reflect.ValueOf(e.value).IsValid() && reflect.ValueOf(t.value).IsValid()) {
+		return false
+	}
+	// not supporting non-comparable values for now
+	if e.value != nil && t.value != nil &&
+		!(reflect.TypeOf(e.value).Comparable() && reflect.TypeOf(t.value).Comparable()) {
 		return false
 	}
 	return (e.ty == t.ty || t.ty == "") &&
 		(e.target == t.target || t.target == "") &&
-		(e.value == t.value || reflect.ValueOf(t.value).IsZero()) &&
+		(e.value == t.value || t.value == nil || reflect.ValueOf(t.value).IsZero()) &&
 		(e.one == t.one || t.one == "") &&
 		(e.two == t.two || t.two == "")
 }

--- a/pkg/cluster/meta/meta.go
+++ b/pkg/cluster/meta/meta.go
@@ -22,6 +22,8 @@ import (
 
 var (
 	errNS = errorx.NewNamespace("meta")
+	// ValidateErr is an empty validateErr object, useful for type checking
+	ValidateErr = &validateErr{}
 )
 
 // error types
@@ -30,8 +32,8 @@ const (
 	errTypeMismatch = "mismatch"
 )
 
-// ValidateErr is the error when meta validation fails with conflicts
-type ValidateErr struct {
+// validateErr is the error when meta validation fails with conflicts
+type validateErr struct {
 	ty     string      // conflict type
 	target string      // conflict target
 	value  interface{} // conflict value
@@ -40,16 +42,16 @@ type ValidateErr struct {
 }
 
 // Error implements the error interface
-func (e *ValidateErr) Error() string {
+func (e *validateErr) Error() string {
 	return fmt.Sprintf("%s %s for '%v' between '%s' and '%s'", e.target, e.ty, e.value, e.one, e.two)
 }
 
 // Unwrap implements the error interface
-func (e *ValidateErr) Unwrap() error { return nil }
+func (e *validateErr) Unwrap() error { return nil }
 
 // Is implements the error interface
-func (e *ValidateErr) Is(target error) bool {
-	t, ok := target.(*ValidateErr)
+func (e *validateErr) Is(target error) bool {
+	t, ok := target.(*validateErr)
 	if !ok {
 		return false
 	}

--- a/pkg/cluster/meta/meta.go
+++ b/pkg/cluster/meta/meta.go
@@ -13,8 +13,54 @@
 
 package meta
 
-import "github.com/joomcode/errorx"
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/joomcode/errorx"
+)
 
 var (
 	errNS = errorx.NewNamespace("meta")
 )
+
+// error types
+const (
+	errTypeConflict = "conflict"
+	errTypeMismatch = "mismatch"
+)
+
+// ValidateErr is the error when meta validation fails with conflicts
+type ValidateErr struct {
+	ty     string      // conflict type
+	target string      // conflict target
+	value  interface{} // conflict value
+	one    string      // object 1
+	two    string      // object 2
+}
+
+// Error implements the error interface
+func (e *ValidateErr) Error() string {
+	return fmt.Sprintf("%s %s for '%v' between '%s' and '%s'", e.target, e.ty, e.value, e.one, e.two)
+}
+
+// Unwrap implements the error interface
+func (e *ValidateErr) Unwrap() error { return nil }
+
+// Is implements the error interface
+func (e *ValidateErr) Is(target error) bool {
+	t, ok := target.(*ValidateErr)
+	if !ok {
+		return false
+	}
+
+	// check for interface value seperately
+	if !(reflect.TypeOf(e.value).Comparable() && reflect.TypeOf(t.value).Comparable()) {
+		return false
+	}
+	return (e.ty == t.ty || t.ty == "") &&
+		(e.target == t.target || t.target == "") &&
+		(e.value == t.value || reflect.ValueOf(t.value).IsZero()) &&
+		(e.one == t.one || t.one == "") &&
+		(e.two == t.two || t.two == "")
+}

--- a/pkg/cluster/meta/meta_test.go
+++ b/pkg/cluster/meta/meta_test.go
@@ -25,7 +25,7 @@ type metaSuite struct {
 var _ = check.Suite(&metaSuite{})
 
 func (s *metaSuite) TestValidateErrIs(c *check.C) {
-	err0 := &ValidateErr{
+	err0 := &validateErr{
 		ty:     "dummy",
 		target: "test",
 		one:    "one",
@@ -34,22 +34,24 @@ func (s *metaSuite) TestValidateErrIs(c *check.C) {
 	}
 	// identical errors are equal
 	c.Assert(errors.Is(err0, err0), check.IsTrue)
-	c.Assert(errors.Is(&ValidateErr{}, &ValidateErr{}), check.IsTrue)
+	c.Assert(errors.Is(ValidateErr, ValidateErr), check.IsTrue)
+	c.Assert(errors.Is(ValidateErr, &validateErr{}), check.IsTrue)
+	c.Assert(errors.Is(&validateErr{}, ValidateErr), check.IsTrue)
 	// not equal for different error types
 	c.Assert(errors.Is(err0, errors.New("")), check.IsFalse)
 	// default value matches any error
-	c.Assert(errors.Is(err0, &ValidateErr{}), check.IsTrue)
+	c.Assert(errors.Is(err0, ValidateErr), check.IsTrue)
 	// error with values are not matching default ones
-	c.Assert(errors.Is(&ValidateErr{}, err0), check.IsFalse)
+	c.Assert(errors.Is(ValidateErr, err0), check.IsFalse)
 
-	err1 := &ValidateErr{
+	err1 := &validateErr{
 		ty:     errTypeConflict,
 		target: "test",
 		one:    "one",
 		two:    "two",
 		value:  2,
 	}
-	c.Assert(errors.Is(err1, &ValidateErr{}), check.IsTrue)
+	c.Assert(errors.Is(err1, ValidateErr), check.IsTrue)
 	// errors with different values are not equal
 	c.Assert(errors.Is(err0, err1), check.IsFalse)
 	c.Assert(errors.Is(err1, err0), check.IsFalse)
@@ -59,7 +61,7 @@ func (s *metaSuite) TestValidateErrIs(c *check.C) {
 	c.Assert(errors.Is(err0, err1), check.IsFalse)
 	c.Assert(errors.Is(err1, err0), check.IsFalse)
 
-	err2 := &ValidateErr{
+	err2 := &validateErr{
 		ty:     errTypeMismatch,
 		target: "test",
 		one:    "one",
@@ -69,34 +71,36 @@ func (s *metaSuite) TestValidateErrIs(c *check.C) {
 			"key2": "2",
 		},
 	}
-	c.Assert(errors.Is(err2, &ValidateErr{}), check.IsTrue)
+	c.Assert(errors.Is(err2, ValidateErr), check.IsTrue)
+	c.Assert(errors.Is(err1, err2), check.IsFalse)
+	c.Assert(errors.Is(err2, err1), check.IsFalse)
 
-	err3 := &ValidateErr{
+	err3 := &validateErr{
 		ty:     errTypeMismatch,
 		target: "test",
 		one:    "one",
 		two:    "two",
 		value:  []float64{1.0, 2.0},
 	}
-	c.Assert(errors.Is(err3, &ValidateErr{}), check.IsTrue)
+	c.Assert(errors.Is(err3, ValidateErr), check.IsTrue)
 	// different values are not equal
 	c.Assert(errors.Is(err2, err3), check.IsFalse)
 	c.Assert(errors.Is(err3, err2), check.IsFalse)
 
-	err4 := &ValidateErr{
+	err4 := &validateErr{
 		ty:     errTypeMismatch,
 		target: "test",
 		one:    "one",
 		two:    "two",
 		value:  nil,
 	}
-	c.Assert(errors.Is(err4, &ValidateErr{}), check.IsTrue)
+	c.Assert(errors.Is(err4, ValidateErr), check.IsTrue)
 	// nil value matches any error if other fields are with the same values
 	c.Assert(errors.Is(err3, err4), check.IsTrue)
 	c.Assert(errors.Is(err4, err3), check.IsFalse)
 
 	err4.value = 0
-	c.Assert(errors.Is(err4, &ValidateErr{}), check.IsTrue)
+	c.Assert(errors.Is(err4, ValidateErr), check.IsTrue)
 	c.Assert(errors.Is(err3, err4), check.IsFalse)
 	c.Assert(errors.Is(err4, err3), check.IsFalse)
 }

--- a/pkg/cluster/meta/meta_test.go
+++ b/pkg/cluster/meta/meta_test.go
@@ -1,0 +1,102 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meta
+
+import (
+	"errors"
+
+	"github.com/pingcap/check"
+)
+
+type metaSuite struct {
+}
+
+var _ = check.Suite(&metaSuite{})
+
+func (s *metaSuite) TestValidateErrIs(c *check.C) {
+	err0 := &ValidateErr{
+		ty:     "dummy",
+		target: "test",
+		one:    "one",
+		two:    "two",
+		value:  1,
+	}
+	// identical errors are equal
+	c.Assert(errors.Is(err0, err0), check.IsTrue)
+	c.Assert(errors.Is(&ValidateErr{}, &ValidateErr{}), check.IsTrue)
+	// not equal for different error types
+	c.Assert(errors.Is(err0, errors.New("")), check.IsFalse)
+	// default value matches any error
+	c.Assert(errors.Is(err0, &ValidateErr{}), check.IsTrue)
+	// error with values are not matching default ones
+	c.Assert(errors.Is(&ValidateErr{}, err0), check.IsFalse)
+
+	err1 := &ValidateErr{
+		ty:     errTypeConflict,
+		target: "test",
+		one:    "one",
+		two:    "two",
+		value:  2,
+	}
+	c.Assert(errors.Is(err1, &ValidateErr{}), check.IsTrue)
+	// errors with different values are not equal
+	c.Assert(errors.Is(err0, err1), check.IsFalse)
+	c.Assert(errors.Is(err1, err0), check.IsFalse)
+
+	// errors with different types are not equal
+	err0.value = 2
+	c.Assert(errors.Is(err0, err1), check.IsFalse)
+	c.Assert(errors.Is(err1, err0), check.IsFalse)
+
+	err2 := &ValidateErr{
+		ty:     errTypeMismatch,
+		target: "test",
+		one:    "one",
+		two:    "two",
+		value: map[string]interface{}{
+			"key1": 1,
+			"key2": "2",
+		},
+	}
+	c.Assert(errors.Is(err2, &ValidateErr{}), check.IsTrue)
+
+	err3 := &ValidateErr{
+		ty:     errTypeMismatch,
+		target: "test",
+		one:    "one",
+		two:    "two",
+		value:  []float64{1.0, 2.0},
+	}
+	c.Assert(errors.Is(err3, &ValidateErr{}), check.IsTrue)
+	// different values are not equal
+	c.Assert(errors.Is(err2, err3), check.IsFalse)
+	c.Assert(errors.Is(err3, err2), check.IsFalse)
+
+	err4 := &ValidateErr{
+		ty:     errTypeMismatch,
+		target: "test",
+		one:    "one",
+		two:    "two",
+		value:  nil,
+	}
+	c.Assert(errors.Is(err4, &ValidateErr{}), check.IsTrue)
+	// nil value matches any error if other fields are with the same values
+	c.Assert(errors.Is(err3, err4), check.IsTrue)
+	c.Assert(errors.Is(err4, err3), check.IsFalse)
+
+	err4.value = 0
+	c.Assert(errors.Is(err4, &ValidateErr{}), check.IsTrue)
+	c.Assert(errors.Is(err3, err4), check.IsFalse)
+	c.Assert(errors.Is(err4, err3), check.IsFalse)
+}

--- a/pkg/cluster/meta/server_config_test.go
+++ b/pkg/cluster/meta/server_config_test.go
@@ -19,7 +19,7 @@ server_configs:
     performance.feedback-probability: 0.0
 `)
 
-	topo := new(TopologySpecification)
+	topo := new(ClusterSpecification)
 
 	err := yaml.Unmarshal(yamlData, topo)
 	c.Assert(err, check.IsNil)

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -699,7 +699,7 @@ func (topo *ClusterSpecification) platformConflictsDetect() error {
 			prev, exist := platformStats[host]
 			if exist {
 				if prev.os != stat.os || prev.arch != stat.arch {
-					return &ValidateErr{
+					return &validateErr{
 						ty:     errTypeMismatch,
 						target: "platform",
 						one:    fmt.Sprintf("%s:%s/%s", prev.cfg, prev.os, prev.arch),
@@ -772,7 +772,7 @@ func (topo *ClusterSpecification) portConflictsDetect() error {
 					tp := compSpec.Type().Field(j).Tag.Get("yaml")
 					prev, exist := portStats[item]
 					if exist {
-						return &ValidateErr{
+						return &validateErr{
 							ty:     errTypeConflict,
 							target: "port",
 							one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
@@ -811,7 +811,7 @@ func (topo *ClusterSpecification) portConflictsDetect() error {
 			tp := strings.Split(ft.Tag.Get("yaml"), ",")[0]
 			prev, exist := portStats[item]
 			if exist {
-				return &ValidateErr{
+				return &validateErr{
 					ty:     errTypeConflict,
 					target: "port",
 					one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
@@ -886,7 +886,7 @@ func (topo *ClusterSpecification) dirConflictsDetect() error {
 					// not checking between imported nodes
 					if exist &&
 						!(compSpec.Interface().(InstanceSpec).IsImported() && prev.imported) {
-						return &ValidateErr{
+						return &validateErr{
 							ty:     errTypeConflict,
 							target: "directory",
 							one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -939,15 +939,12 @@ func (topo *ClusterSpecification) CountDir(targetHost, dirPrefix string) int {
 					host := compSpec.FieldByName("Host").String()
 
 					switch dirType { // the same as in logic.go for (*instance)
-					case "DeployDir":
-						dir = clusterutil.Abs(topo.GlobalOptions.User, dir)
 					case "DataDir":
 						deployDir := compSpec.FieldByName("DeployDir").String()
 						// the default data_dir is relative to deploy_dir
 						if dir != "" && !strings.HasPrefix(dir, "/") {
 							dir = filepath.Join(deployDir, dir)
 						}
-						dir = clusterutil.Abs(topo.GlobalOptions.User, dir)
 					case "LogDir":
 						deployDir := compSpec.FieldByName("DeployDir").String()
 						field := compSpec.FieldByName("LogDir")
@@ -961,8 +958,8 @@ func (topo *ClusterSpecification) CountDir(targetHost, dirPrefix string) int {
 						if !strings.HasPrefix(dir, "/") {
 							dir = filepath.Join(deployDir, dir)
 						}
-						dir = clusterutil.Abs(topo.GlobalOptions.User, dir)
 					}
+					dir = clusterutil.Abs(topo.GlobalOptions.User, dir)
 					dirStats[host+dir] += 1
 				}
 			}
@@ -1117,7 +1114,10 @@ func setCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) error 
 
 			dataDir := field.Field(j).String()
 
-			if dataDir != "" { // already have a value, skip filling default values
+			// If the per-instance data_dir already have a value, skip filling default values
+			// and ignore any value in global data_dir, the default values are filled only
+			// when the pre-instance data_dir is empty
+			if dataDir != "" {
 				continue
 			}
 			// If the data dir in global options is an absolute path, append current

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -700,8 +700,13 @@ func (topo *ClusterSpecification) platformConflictsDetect() error {
 			prev, exist := platformStats[host]
 			if exist {
 				if prev.os != stat.os || prev.arch != stat.arch {
-					return errors.Errorf("platform mismatch for '%s' as in '%s:%s/%s' and '%s:%s/%s'",
-						host, prev.cfg, prev.os, prev.arch, stat.cfg, stat.os, stat.arch)
+					return &ValidateErr{
+						ty:     errTypeMismatch,
+						target: "platform",
+						one:    fmt.Sprintf("%s:%s/%s", prev.cfg, prev.os, prev.arch),
+						two:    fmt.Sprintf("%s:%s/%s", stat.cfg, stat.os, stat.arch),
+						value:  host,
+					}
 				}
 			}
 			platformStats[host] = stat
@@ -768,8 +773,13 @@ func (topo *ClusterSpecification) portConflictsDetect() error {
 					tp := compSpec.Type().Field(j).Tag.Get("yaml")
 					prev, exist := portStats[item]
 					if exist {
-						return errors.Errorf("port '%d' conflicts between '%s:%s.%s' and '%s:%s.%s'",
-							item.port, prev.cfg, item.host, prev.tp, cfg, item.host, tp)
+						return &ValidateErr{
+							ty:     errTypeConflict,
+							target: "port",
+							one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
+							two:    fmt.Sprintf("%s:%s.%s", cfg, item.host, tp),
+							value:  item.port,
+						}
 					}
 					portStats[item] = conflict{
 						tp:  tp,
@@ -802,8 +812,13 @@ func (topo *ClusterSpecification) portConflictsDetect() error {
 			tp := strings.Split(ft.Tag.Get("yaml"), ",")[0]
 			prev, exist := portStats[item]
 			if exist {
-				return errors.Errorf("port '%d' conflicts between '%s:%s.%s' and '%s:%s.%s'",
-					item.port, prev.cfg, item.host, prev.tp, cfg, item.host, tp)
+				return &ValidateErr{
+					ty:     errTypeConflict,
+					target: "port",
+					one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
+					two:    fmt.Sprintf("%s:%s.%s", cfg, item.host, tp),
+					value:  item.port,
+				}
 			}
 			portStats[item] = conflict{
 				tp:  tp,
@@ -872,8 +887,13 @@ func (topo *ClusterSpecification) dirConflictsDetect() error {
 					// not checking between imported nodes
 					if exist &&
 						!(compSpec.Interface().(InstanceSpec).IsImported() && prev.imported) {
-						return errors.Errorf("directory '%s' conflicts between '%s:%s.%s' and '%s:%s.%s'",
-							item.dir, prev.cfg, item.host, prev.tp, cfg, item.host, tp)
+						return &ValidateErr{
+							ty:     errTypeConflict,
+							target: "directory",
+							one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
+							two:    fmt.Sprintf("%s:%s.%s", cfg, item.host, tp),
+							value:  item.dir,
+						}
 					}
 					// not reporting error for nodes imported from TiDB-Ansible, but keep
 					// their dirs in the map to check if other nodes are using them

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -958,13 +958,7 @@ func (topo *ClusterSpecification) CountDir(targetHost, dirPrefix string) int {
 
 						}
 					}
-
-					_, exist := dirStats[host+dir]
-					if exist {
-						dirStats[host+dir] += 1
-					} else {
-						dirStats[host+dir] = 1
-					}
+					dirStats[host+dir] += 1
 				}
 			}
 		}

--- a/pkg/cluster/meta/topology.go
+++ b/pkg/cluster/meta/topology.go
@@ -95,8 +95,8 @@ type (
 		CDC            map[string]interface{} `yaml:"cdc"`
 	}
 
-	// TopologySpecification represents the specification of topology.yaml
-	TopologySpecification struct {
+	// ClusterSpecification represents the specification of topology.yaml
+	ClusterSpecification struct {
 		GlobalOptions    GlobalOptions      `yaml:"global,omitempty"`
 		MonitoredOptions MonitoredOptions   `yaml:"monitored,omitempty"`
 		ServerConfigs    ServerConfigs      `yaml:"server_configs,omitempty"`
@@ -607,8 +607,8 @@ func (s AlertManagerSpec) IsImported() bool {
 }
 
 // UnmarshalYAML sets default values when unmarshaling the topology file
-func (topo *TopologySpecification) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type topology TopologySpecification
+func (topo *ClusterSpecification) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type topology ClusterSpecification
 	if err := unmarshal((*topology)(topo)); err != nil {
 		return err
 	}
@@ -654,7 +654,7 @@ func findField(v reflect.Value, fieldName string) (int, bool) {
 
 // platformConflictsDetect checks for conflicts in topology for different OS / Arch
 // set to the same host / IP
-func (topo *TopologySpecification) platformConflictsDetect() error {
+func (topo *ClusterSpecification) platformConflictsDetect() error {
 	type (
 		conflict struct {
 			os   string
@@ -710,7 +710,7 @@ func (topo *TopologySpecification) platformConflictsDetect() error {
 	return nil
 }
 
-func (topo *TopologySpecification) portConflictsDetect() error {
+func (topo *ClusterSpecification) portConflictsDetect() error {
 	type (
 		usedPort struct {
 			host string
@@ -815,7 +815,7 @@ func (topo *TopologySpecification) portConflictsDetect() error {
 	return nil
 }
 
-func (topo *TopologySpecification) dirConflictsDetect() error {
+func (topo *ClusterSpecification) dirConflictsDetect() error {
 	type (
 		usedDir struct {
 			host string
@@ -888,7 +888,7 @@ func (topo *TopologySpecification) dirConflictsDetect() error {
 
 // CountDir counts for dir paths used by any instance in the cluster with the same
 // prefix, useful to find potential path conflicts
-func (topo *TopologySpecification) CountDir(dirPrefix string) int {
+func (topo *ClusterSpecification) CountDir(dirPrefix string) int {
 	dirTypes := []string{
 		"DataDir",
 		"DeployDir",
@@ -948,7 +948,7 @@ func (topo *TopologySpecification) CountDir(dirPrefix string) int {
 
 // Validate validates the topology specification and produce error if the
 // specification invalid (e.g: port conflicts or directory conflicts)
-func (topo *TopologySpecification) Validate() error {
+func (topo *ClusterSpecification) Validate() error {
 	if err := topo.platformConflictsDetect(); err != nil {
 		return err
 	}
@@ -961,7 +961,7 @@ func (topo *TopologySpecification) Validate() error {
 }
 
 // GetPDList returns a list of PD API hosts of the current cluster
-func (topo *TopologySpecification) GetPDList() []string {
+func (topo *ClusterSpecification) GetPDList() []string {
 	var pdList []string
 
 	for _, pd := range topo.PDServers {
@@ -972,15 +972,15 @@ func (topo *TopologySpecification) GetPDList() []string {
 }
 
 // GetEtcdClient load EtcdClient of current cluster
-func (topo *TopologySpecification) GetEtcdClient() (*clientv3.Client, error) {
+func (topo *ClusterSpecification) GetEtcdClient() (*clientv3.Client, error) {
 	return clientv3.New(clientv3.Config{
 		Endpoints: topo.GetPDList(),
 	})
 }
 
-// Merge returns a new TopologySpecification which sum old ones
-func (topo *TopologySpecification) Merge(that *TopologySpecification) *TopologySpecification {
-	return &TopologySpecification{
+// Merge returns a new ClusterSpecification which sum old ones
+func (topo *ClusterSpecification) Merge(that *ClusterSpecification) *ClusterSpecification {
+	return &ClusterSpecification{
 		GlobalOptions:    topo.GlobalOptions,
 		MonitoredOptions: topo.MonitoredOptions,
 		ServerConfigs:    topo.ServerConfigs,

--- a/pkg/cluster/meta/topology_dm.go
+++ b/pkg/cluster/meta/topology_dm.go
@@ -287,8 +287,13 @@ func (topo *DMTopologySpecification) platformConflictsDetect() error {
 			prev, exist := platformStats[host]
 			if exist {
 				if prev.os != stat.os || prev.arch != stat.arch {
-					return errors.Errorf("platform mismatch for '%s' as in '%s:%s/%s' and '%s:%s/%s'",
-						host, prev.cfg, prev.os, prev.arch, stat.cfg, stat.os, stat.arch)
+					return &ValidateErr{
+						ty:     errTypeMismatch,
+						target: "platform",
+						one:    fmt.Sprintf("%s:%s/%s", prev.cfg, prev.os, prev.arch),
+						two:    fmt.Sprintf("%s:%s/%s", stat.cfg, stat.os, stat.arch),
+						value:  host,
+					}
 				}
 			}
 			platformStats[host] = stat
@@ -355,8 +360,13 @@ func (topo *DMTopologySpecification) portConflictsDetect() error {
 					tp := compSpec.Type().Field(j).Tag.Get("yaml")
 					prev, exist := portStats[item]
 					if exist {
-						return errors.Errorf("port '%d' conflicts between '%s:%s.%s' and '%s:%s.%s'",
-							item.port, prev.cfg, item.host, prev.tp, cfg, item.host, tp)
+						return &ValidateErr{
+							ty:     errTypeConflict,
+							target: "port",
+							one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
+							two:    fmt.Sprintf("%s:%s.%s", cfg, item.host, tp),
+							value:  item.port,
+						}
 					}
 					portStats[item] = conflict{
 						tp:  tp,
@@ -389,8 +399,13 @@ func (topo *DMTopologySpecification) portConflictsDetect() error {
 			tp := strings.Split(ft.Tag.Get("yaml"), ",")[0]
 			prev, exist := portStats[item]
 			if exist {
-				return errors.Errorf("port '%d' conflicts between '%s:%s.%s' and '%s:%s.%s'",
-					item.port, prev.cfg, item.host, prev.tp, cfg, item.host, tp)
+				return &ValidateErr{
+					ty:     errTypeConflict,
+					target: "port",
+					one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
+					two:    fmt.Sprintf("%s:%s.%s", cfg, item.host, tp),
+					value:  item.port,
+				}
 			}
 			portStats[item] = conflict{
 				tp:  tp,
@@ -464,8 +479,13 @@ func (topo *DMTopologySpecification) dirConflictsDetect() error {
 					tp := strings.Split(compSpec.Type().Field(j).Tag.Get("yaml"), ",")[0]
 					prev, exist := dirStats[item]
 					if exist {
-						return errors.Errorf("directory '%s' conflicts between '%s:%s.%s' and '%s:%s.%s'",
-							item.dir, prev.cfg, item.host, prev.tp, cfg, item.host, tp)
+						return &ValidateErr{
+							ty:     errTypeConflict,
+							target: "directory",
+							one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
+							two:    fmt.Sprintf("%s:%s.%s", cfg, item.host, tp),
+							value:  item.dir,
+						}
 					}
 					dirStats[item] = conflict{
 						tp:  tp,

--- a/pkg/cluster/meta/topology_dm.go
+++ b/pkg/cluster/meta/topology_dm.go
@@ -564,7 +564,7 @@ func (topo *DMTopologySpecification) GetMasterList() []string {
 	return masterList
 }
 
-// Merge returns a new TopologySpecification which sum old ones
+// Merge returns a new ClusterSpecification which sum old ones
 func (topo *DMTopologySpecification) Merge(that *DMTopologySpecification) *DMTopologySpecification {
 	return &DMTopologySpecification{
 		GlobalOptions:    topo.GlobalOptions,

--- a/pkg/cluster/meta/topology_dm.go
+++ b/pkg/cluster/meta/topology_dm.go
@@ -564,7 +564,7 @@ func (topo *DMTopologySpecification) GetMasterList() []string {
 	return masterList
 }
 
-// Merge returns a new ClusterSpecification which sum old ones
+// Merge returns a new DMTopologySpecification which sum old ones
 func (topo *DMTopologySpecification) Merge(that *DMTopologySpecification) *DMTopologySpecification {
 	return &DMTopologySpecification{
 		GlobalOptions:    topo.GlobalOptions,

--- a/pkg/cluster/meta/topology_dm.go
+++ b/pkg/cluster/meta/topology_dm.go
@@ -479,6 +479,66 @@ func (topo *DMTopologySpecification) dirConflictsDetect() error {
 	return nil
 }
 
+// CountDir counts for dir paths used by any instance in the cluster with the same
+// prefix, useful to find potential path conflicts
+func (topo *DMTopologySpecification) CountDir(dirPrefix string) int {
+	dirTypes := []string{
+		"DataDir",
+		"DeployDir",
+	}
+
+	// path -> count
+	dirStats := make(map[string]int)
+	count := 0
+
+	if topo.GlobalOptions.DataDir != "" {
+		dirStats[topo.GlobalOptions.DataDir] = 1
+	}
+	if topo.GlobalOptions.DeployDir != "" {
+		dirStats[topo.GlobalOptions.DeployDir] = 1
+	}
+
+	topoSpec := reflect.ValueOf(topo).Elem()
+
+	for i := 0; i < topoSpec.NumField(); i++ {
+		if isSkipField(topoSpec.Field(i)) {
+			continue
+		}
+
+		compSpecs := topoSpec.Field(i)
+		for index := 0; index < compSpecs.Len(); index++ {
+			compSpec := compSpecs.Index(index)
+			// Directory conflicts
+			for _, dirType := range dirTypes {
+				if j, found := findField(compSpec, dirType); found {
+					dir := compSpec.Field(j).String()
+
+					// data_dir is relative to deploy_dir by default, so they can be with
+					// same (sub) paths as long as the deploy_dirs are different
+					if dir != "" && !strings.HasPrefix(dir, "/") {
+						continue
+					}
+
+					_, exist := dirStats[dir]
+					if exist {
+						dirStats[dir] += 1
+					} else {
+						dirStats[dir] = 1
+					}
+				}
+			}
+		}
+	}
+
+	for k, v := range dirStats {
+		if strings.HasPrefix(k, dirPrefix) {
+			count += v
+		}
+	}
+
+	return count
+}
+
 // Validate validates the topology specification and produce error if the
 // specification invalid (e.g: port conflicts or directory conflicts)
 func (topo *DMTopologySpecification) Validate() error {

--- a/pkg/cluster/meta/topology_dm.go
+++ b/pkg/cluster/meta/topology_dm.go
@@ -288,7 +288,7 @@ func (topo *DMTopologySpecification) platformConflictsDetect() error {
 			prev, exist := platformStats[host]
 			if exist {
 				if prev.os != stat.os || prev.arch != stat.arch {
-					return &ValidateErr{
+					return &validateErr{
 						ty:     errTypeMismatch,
 						target: "platform",
 						one:    fmt.Sprintf("%s:%s/%s", prev.cfg, prev.os, prev.arch),
@@ -361,7 +361,7 @@ func (topo *DMTopologySpecification) portConflictsDetect() error {
 					tp := compSpec.Type().Field(j).Tag.Get("yaml")
 					prev, exist := portStats[item]
 					if exist {
-						return &ValidateErr{
+						return &validateErr{
 							ty:     errTypeConflict,
 							target: "port",
 							one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
@@ -400,7 +400,7 @@ func (topo *DMTopologySpecification) portConflictsDetect() error {
 			tp := strings.Split(ft.Tag.Get("yaml"), ",")[0]
 			prev, exist := portStats[item]
 			if exist {
-				return &ValidateErr{
+				return &validateErr{
 					ty:     errTypeConflict,
 					target: "port",
 					one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),
@@ -480,7 +480,7 @@ func (topo *DMTopologySpecification) dirConflictsDetect() error {
 					tp := strings.Split(compSpec.Type().Field(j).Tag.Get("yaml"), ",")[0]
 					prev, exist := dirStats[item]
 					if exist {
-						return &ValidateErr{
+						return &validateErr{
 							ty:     errTypeConflict,
 							target: "directory",
 							one:    fmt.Sprintf("%s:%s.%s", prev.cfg, item.host, prev.tp),

--- a/pkg/cluster/meta/topology_dm.go
+++ b/pkg/cluster/meta/topology_dm.go
@@ -530,15 +530,12 @@ func (topo *DMTopologySpecification) CountDir(targetHost, dirPrefix string) int 
 					host := compSpec.FieldByName("Host").String()
 
 					switch dirType { // the same as in logic.go for (*instance)
-					case "DeployDir":
-						dir = clusterutil.Abs(topo.GlobalOptions.User, dir)
 					case "DataDir":
 						deployDir := compSpec.FieldByName("DeployDir").String()
 						// the default data_dir is relative to deploy_dir
 						if dir != "" && !strings.HasPrefix(dir, "/") {
 							dir = filepath.Join(deployDir, dir)
 						}
-						dir = clusterutil.Abs(topo.GlobalOptions.User, dir)
 					case "LogDir":
 						deployDir := compSpec.FieldByName("DeployDir").String()
 						field := compSpec.FieldByName("LogDir")
@@ -552,8 +549,8 @@ func (topo *DMTopologySpecification) CountDir(targetHost, dirPrefix string) int 
 						if !strings.HasPrefix(dir, "/") {
 							dir = filepath.Join(deployDir, dir)
 						}
-						dir = clusterutil.Abs(topo.GlobalOptions.User, dir)
 					}
+					dir = clusterutil.Abs(topo.GlobalOptions.User, dir)
 					dirStats[host+dir] += 1
 				}
 			}

--- a/pkg/cluster/meta/topology_dm_test.go
+++ b/pkg/cluster/meta/topology_dm_test.go
@@ -111,7 +111,7 @@ dm-worker_servers:
     data_dir: "/test-1"
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "directory '/test-1' conflicts between 'dm-master_servers:172.16.5.138.deploy_dir' and 'dm-worker_servers:172.16.5.138.data_dir'")
+	c.Assert(err.Error(), Equals, "directory conflict for '/test-1' between 'dm-master_servers:172.16.5.138.deploy_dir' and 'dm-worker_servers:172.16.5.138.data_dir'")
 
 	err = yaml.Unmarshal([]byte(`
 global:
@@ -145,7 +145,7 @@ dm-worker_servers:
     port: 1234
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "port '1234' conflicts between 'dm-master_servers:172.16.5.138.peer_port' and 'dm-worker_servers:172.16.5.138.port'")
+	c.Assert(err.Error(), Equals, "port conflict for '1234' between 'dm-master_servers:172.16.5.138.peer_port' and 'dm-worker_servers:172.16.5.138.port'")
 
 	topo = DMTopologySpecification{}
 	err = yaml.Unmarshal([]byte(`
@@ -159,7 +159,7 @@ dm-worker_servers:
     status_port: 2345
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "port '1234' conflicts between 'dm-master_servers:172.16.5.138.port' and 'monitored:172.16.5.138.node_exporter_port'")
+	c.Assert(err.Error(), Equals, "port conflict for '1234' between 'dm-master_servers:172.16.5.138.port' and 'monitored:172.16.5.138.node_exporter_port'")
 
 }
 
@@ -190,7 +190,7 @@ dm-worker_servers:
   - host: 172.16.5.138
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' as in 'dm-master_servers:linux/arm64' and 'dm-worker_servers:linux/amd64'")
+	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' between 'dm-master_servers:linux/arm64' and 'dm-worker_servers:linux/amd64'")
 
 	// different os defined for the same host
 	topo = DMTopologySpecification{}
@@ -205,7 +205,7 @@ dm-worker_servers:
   - host: 172.16.5.138
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' as in 'dm-master_servers:darwin/arm64' and 'dm-worker_servers:linux/arm64'")
+	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' between 'dm-master_servers:darwin/arm64' and 'dm-worker_servers:linux/arm64'")
 
 }
 

--- a/pkg/cluster/meta/topology_dm_test.go
+++ b/pkg/cluster/meta/topology_dm_test.go
@@ -208,3 +208,27 @@ dm-worker_servers:
 	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' as in 'dm-master_servers:darwin/arm64' and 'dm-worker_servers:linux/arm64'")
 
 }
+
+func (s *metaSuiteDM) TestCountDir(c *C) {
+	topo := DMTopologySpecification{}
+
+	err := yaml.Unmarshal([]byte(`
+global:
+  user: "test1"
+  ssh_port: 220
+  deploy_dir: "test-deploy"
+  data_dir: "/test-data" 
+dm-master_servers:
+  - host: 172.16.5.138
+    deploy_dir: "master-deploy"
+    data_dir: "test-1"
+dm-worker_servers:
+  - host: 172.16.5.53
+    data_dir: "test-1"
+`), &topo)
+	c.Assert(err, IsNil)
+	cnt := topo.CountDir("172.16.5.53", "test-deploy/dm-worker-8262")
+	c.Assert(cnt, Equals, 1)
+	cnt = topo.CountDir("172.16.5.138", "/test-data/test-1")
+	c.Assert(cnt, Equals, 1)
+}

--- a/pkg/cluster/meta/topology_dm_test.go
+++ b/pkg/cluster/meta/topology_dm_test.go
@@ -217,18 +217,17 @@ global:
   user: "test1"
   ssh_port: 220
   deploy_dir: "test-deploy"
-  data_dir: "/test-data" 
 dm-master_servers:
   - host: 172.16.5.138
     deploy_dir: "master-deploy"
-    data_dir: "test-1"
+    data_dir: "/test-data/data-1"
 dm-worker_servers:
   - host: 172.16.5.53
     data_dir: "test-1"
 `), &topo)
 	c.Assert(err, IsNil)
 	cnt := topo.CountDir("172.16.5.53", "test-deploy/dm-worker-8262")
-	c.Assert(cnt, Equals, 1)
-	cnt = topo.CountDir("172.16.5.138", "/test-data/test-1")
-	c.Assert(cnt, Equals, 1)
+	c.Assert(cnt, Equals, 3)
+	cnt = topo.CountDir("172.16.5.138", "/test-data/data")
+	c.Assert(cnt, Equals, 0)
 }

--- a/pkg/cluster/meta/topology_test.go
+++ b/pkg/cluster/meta/topology_test.go
@@ -131,7 +131,7 @@ pd_servers:
     data_dir: "/test-1"
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "directory '/test-1' conflicts between 'tidb_servers:172.16.5.138.deploy_dir' and 'pd_servers:172.16.5.138.data_dir'")
+	c.Assert(err.Error(), Equals, "directory conflict for '/test-1' between 'tidb_servers:172.16.5.138.deploy_dir' and 'pd_servers:172.16.5.138.data_dir'")
 
 	err = yaml.Unmarshal([]byte(`
 global:
@@ -167,7 +167,7 @@ pd_servers:
     log_dir: /home/tidb/deploy/log
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "directory '/home/tidb/deploy' conflicts between 'tidb_servers:172.16.4.190.deploy_dir' and 'pd_servers:172.16.4.190.deploy_dir'")
+	c.Assert(err.Error(), Equals, "directory conflict for '/home/tidb/deploy' between 'tidb_servers:172.16.4.190.deploy_dir' and 'pd_servers:172.16.4.190.deploy_dir'")
 }
 
 func (s *metaSuite) TestPortConflicts(c *C) {
@@ -186,7 +186,7 @@ tikv_servers:
     status_port: 1234
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "port '1234' conflicts between 'tidb_servers:172.16.5.138.port' and 'tikv_servers:172.16.5.138.status_port'")
+	c.Assert(err.Error(), Equals, "port conflict for '1234' between 'tidb_servers:172.16.5.138.port' and 'tikv_servers:172.16.5.138.status_port'")
 
 	topo = ClusterSpecification{}
 	err = yaml.Unmarshal([]byte(`
@@ -200,7 +200,7 @@ tikv_servers:
     status_port: 2345
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "port '1234' conflicts between 'tidb_servers:172.16.5.138.port' and 'monitored:172.16.5.138.node_exporter_port'")
+	c.Assert(err.Error(), Equals, "port conflict for '1234' between 'tidb_servers:172.16.5.138.port' and 'monitored:172.16.5.138.node_exporter_port'")
 
 }
 
@@ -231,7 +231,7 @@ tikv_servers:
   - host: 172.16.5.138
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' as in 'tidb_servers:linux/arm64' and 'tikv_servers:linux/amd64'")
+	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' between 'tidb_servers:linux/arm64' and 'tikv_servers:linux/amd64'")
 
 	// different os defined for the same host
 	topo = ClusterSpecification{}
@@ -246,7 +246,7 @@ tikv_servers:
   - host: 172.16.5.138
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' as in 'tidb_servers:darwin/arm64' and 'tikv_servers:linux/arm64'")
+	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' between 'tidb_servers:darwin/arm64' and 'tikv_servers:linux/arm64'")
 
 }
 

--- a/pkg/cluster/meta/topology_test.go
+++ b/pkg/cluster/meta/topology_test.go
@@ -168,6 +168,36 @@ pd_servers:
 `), &topo)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "directory conflict for '/home/tidb/deploy' between 'tidb_servers:172.16.4.190.deploy_dir' and 'pd_servers:172.16.4.190.deploy_dir'")
+
+	// two imported tidb pass the validation, two pd servers don't
+	err = yaml.Unmarshal([]byte(`
+global:
+  user: "test2"
+  ssh_port: 220
+  deploy_dir: deploy
+  data_dir: /data
+tidb_servers:
+  - host: 172.16.4.190
+    imported: true
+    port: 3306
+    deploy_dir: /home/tidb/deploy1
+  - host: 172.16.4.190
+    imported: true
+    status_port: 3307
+    deploy_dir: /home/tidb/deploy1
+pd_servers:
+  - host: 172.16.4.190
+    imported: true
+    name: pd_ip-172-16-4-190
+    deploy_dir: /home/tidb/deploy
+  - host: 172.16.4.190
+    name: pd_ip-172-16-4-190-2
+    client_port: 2381
+    peer_port: 2382
+    deploy_dir: /home/tidb/deploy
+`), &topo)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "directory conflict for '/home/tidb/deploy' between 'pd_servers:172.16.4.190.deploy_dir' and 'pd_servers:172.16.4.190.deploy_dir'")
 }
 
 func (s *metaSuite) TestPortConflicts(c *C) {

--- a/pkg/cluster/meta/topology_test.go
+++ b/pkg/cluster/meta/topology_test.go
@@ -288,19 +288,18 @@ global:
   user: "test1"
   ssh_port: 220
   deploy_dir: "test-deploy"
-  data_dir: "/test-data"
 tikv_servers:
   - host: 172.16.5.138
-    data_dir: "test-1"
+    data_dir: "/test-data/data-1"
 pd_servers:
   - host: 172.16.5.138
-    data_dir: "test-1"
+    data_dir: "/test-data/data-2"
 `), &topo)
 	c.Assert(err, IsNil)
-	cnt := topo.CountDir("172.16.5.138", "test-deploy/pd-2379")
-	c.Assert(cnt, Equals, 1)
-	cnt = topo.CountDir("172.16.5.138", "/test-data/test-1")
+	cnt := topo.CountDir("172.16.5.138", "/home/test1/test-deploy/pd-2379")
 	c.Assert(cnt, Equals, 2)
+	cnt = topo.CountDir("172.16.5.138", "/test-data/data")
+	c.Assert(cnt, Equals, 0)
 
 	err = yaml.Unmarshal([]byte(`
 global:
@@ -322,7 +321,7 @@ pd_servers:
 `), &topo)
 	c.Assert(err, IsNil)
 	cnt = topo.CountDir("172.16.4.190", "/home/tidb/deploy")
-	c.Assert(cnt, Equals, 4)
+	c.Assert(cnt, Equals, 5)
 }
 
 func (s *metaSuite) TestGlobalConfig(c *C) {

--- a/pkg/cluster/meta/topology_test.go
+++ b/pkg/cluster/meta/topology_test.go
@@ -33,13 +33,13 @@ func TestMeta(t *testing.T) {
 
 func (s *metaSuite) TestDefaultDataDir(c *C) {
 	// Test with without global DataDir.
-	topo := new(TopologySpecification)
+	topo := new(ClusterSpecification)
 	topo.TiKVServers = append(topo.TiKVServers, TiKVSpec{Host: "1.1.1.1", Port: 22})
 	data, err := yaml.Marshal(topo)
 	c.Assert(err, IsNil)
 
 	// Check default value.
-	topo = new(TopologySpecification)
+	topo = new(ClusterSpecification)
 	err = yaml.Unmarshal(data, topo)
 	c.Assert(err, IsNil)
 	c.Assert(topo.GlobalOptions.DataDir, Equals, "data")
@@ -48,21 +48,21 @@ func (s *metaSuite) TestDefaultDataDir(c *C) {
 	// Can keep the default value.
 	data, err = yaml.Marshal(topo)
 	c.Assert(err, IsNil)
-	topo = new(TopologySpecification)
+	topo = new(ClusterSpecification)
 	err = yaml.Unmarshal(data, topo)
 	c.Assert(err, IsNil)
 	c.Assert(topo.GlobalOptions.DataDir, Equals, "data")
 	c.Assert(topo.TiKVServers[0].DataDir, Equals, "data")
 
 	// Test with global DataDir.
-	topo = new(TopologySpecification)
+	topo = new(ClusterSpecification)
 	topo.GlobalOptions.DataDir = "/gloable_data"
 	topo.TiKVServers = append(topo.TiKVServers, TiKVSpec{Host: "1.1.1.1", Port: 22})
 	topo.TiKVServers = append(topo.TiKVServers, TiKVSpec{Host: "1.1.1.2", Port: 33, DataDir: "/my_data"})
 	data, err = yaml.Marshal(topo)
 	c.Assert(err, IsNil)
 
-	topo = new(TopologySpecification)
+	topo = new(ClusterSpecification)
 	err = yaml.Unmarshal(data, topo)
 	c.Assert(err, IsNil)
 	c.Assert(topo.GlobalOptions.DataDir, Equals, "/gloable_data")
@@ -71,7 +71,7 @@ func (s *metaSuite) TestDefaultDataDir(c *C) {
 }
 
 func (s *metaSuite) TestGlobalOptions(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 global:
   user: "test1"
@@ -97,7 +97,7 @@ pd_servers:
 }
 
 func (s *metaSuite) TestDataDirAbsolute(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 global:
   user: "test1"
@@ -115,7 +115,7 @@ pd_servers:
 }
 
 func (s *metaSuite) TestDirectoryConflicts(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 global:
   user: "test1"
@@ -149,7 +149,7 @@ pd_servers:
 }
 
 func (s *metaSuite) TestPortConflicts(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 global:
   user: "test1"
@@ -166,7 +166,7 @@ tikv_servers:
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "port '1234' conflicts between 'tidb_servers:172.16.5.138.port' and 'tikv_servers:172.16.5.138.status_port'")
 
-	topo = TopologySpecification{}
+	topo = ClusterSpecification{}
 	err = yaml.Unmarshal([]byte(`
 monitored:
   node_exporter_port: 1234
@@ -184,7 +184,7 @@ tikv_servers:
 
 func (s *metaSuite) TestPlatformConflicts(c *C) {
 	// aarch64 and arm64 are equal
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 global:
   os: "linux"
@@ -198,7 +198,7 @@ tikv_servers:
 	c.Assert(err, IsNil)
 
 	// different arch defined for the same host
-	topo = TopologySpecification{}
+	topo = ClusterSpecification{}
 	err = yaml.Unmarshal([]byte(`
 global:
   os: "linux"
@@ -212,7 +212,7 @@ tikv_servers:
 	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' as in 'tidb_servers:linux/arm64' and 'tikv_servers:linux/amd64'")
 
 	// different os defined for the same host
-	topo = TopologySpecification{}
+	topo = ClusterSpecification{}
 	err = yaml.Unmarshal([]byte(`
 global:
   os: "linux"
@@ -229,7 +229,7 @@ tikv_servers:
 }
 
 func (s *metaSuite) TestGlobalConfig(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 global:
   user: "test1"
@@ -334,7 +334,7 @@ tidb_servers:
 }
 
 func (s *metaSuite) TestGlobalConfigPatch(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 tikv_sata_config: &tikv_sata_config
   config.item1: 100
@@ -364,7 +364,7 @@ tikv_servers:
 }
 
 func (s *metaSuite) TestLogDir(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 tidb_servers:
   - host: 172.16.5.138
@@ -376,7 +376,7 @@ tidb_servers:
 }
 
 func (s *metaSuite) TestMonitorLogDir(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 monitored:
     deploy_dir: "test-deploy"
@@ -393,7 +393,7 @@ monitored:
 }
 
 func (s *metaSuite) TestMerge2Toml(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 server_configs:
   tikv:
@@ -430,7 +430,7 @@ item6 = 600
 }
 
 func (s *metaSuite) TestMerge2Toml2(c *C) {
-	topo := TopologySpecification{}
+	topo := ClusterSpecification{}
 	err := yaml.Unmarshal([]byte(`
 global:
   user: test4
@@ -519,7 +519,7 @@ split-merge-interval = "1h"
 }
 
 func (s *metaSuite) TestMergeImported(c *C) {
-	spec := TopologySpecification{}
+	spec := ClusterSpecification{}
 
 	// values set in topology specification of the cluster
 	err := yaml.Unmarshal([]byte(`

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -193,7 +193,7 @@ func DestroyClusterTombstone(
 			return nil, errors.AddStack(err)
 		}
 
-		err = DestroyComponent(getter, instances, options.OptTimeout)
+		err = DestroyComponent(getter, instances, spec, options.OptTimeout)
 		if err != nil {
 			return nil, errors.AddStack(err)
 		}
@@ -232,7 +232,7 @@ func DestroyClusterTombstone(
 			return nil, errors.AddStack(err)
 		}
 
-		err = DestroyComponent(getter, instances, options.OptTimeout)
+		err = DestroyComponent(getter, instances, spec, options.OptTimeout)
 		if err != nil {
 			return nil, errors.AddStack(err)
 		}
@@ -269,7 +269,7 @@ func DestroyClusterTombstone(
 			return nil, errors.AddStack(err)
 		}
 
-		err = DestroyComponent(getter, instances, options.OptTimeout)
+		err = DestroyComponent(getter, instances, spec, options.OptTimeout)
 		if err != nil {
 			return nil, errors.AddStack(err)
 		}
@@ -307,7 +307,7 @@ func DestroyClusterTombstone(
 			return nil, errors.AddStack(err)
 		}
 
-		err = DestroyComponent(getter, instances, options.OptTimeout)
+		err = DestroyComponent(getter, instances, spec, options.OptTimeout)
 		if err != nil {
 			return nil, errors.AddStack(err)
 		}

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -167,7 +167,7 @@ func DestroyMonitored(getter ExecutorGetter, inst meta.Instance, options meta.Mo
 
 // topologySpecification is an interface used to get essential information of a cluster
 type topologySpecification interface {
-	CountDir(string) int // count how many time a path is used by instances in cluster
+	CountDir(string, string) int // count how many time a path is used by instances in cluster
 }
 
 // DestroyComponent destroy the instances.
@@ -195,13 +195,13 @@ func DestroyComponent(getter ExecutorGetter, instances []meta.Instance, cls topo
 			meta.ComponentDMMaster,
 			meta.ComponentDMWorker,
 			meta.ComponentDMPortal:
-			if cls.CountDir(ins.DataDir()) == 1 {
+			if cls.CountDir(ins.GetHost(), ins.DataDir()) == 1 {
 				// only delete path if it is not used by any other instance in the cluster
 				delPaths = append(delPaths, ins.DataDir())
 			}
 		case meta.ComponentTiFlash:
 			for _, dataDir := range strings.Split(ins.DataDir(), ",") {
-				if cls.CountDir(dataDir) == 1 {
+				if cls.CountDir(ins.GetHost(), dataDir) == 1 {
 					// only delete path if it is not used by any other instance in the cluster
 					delPaths = append(delPaths, dataDir)
 				}
@@ -222,10 +222,10 @@ func DestroyComponent(getter ExecutorGetter, instances []meta.Instance, cls topo
 		// host, so not deleting it.
 		if !ins.IsImported() {
 			// only delete path if it is not used by any other instance in the cluster
-			if cls.CountDir(ins.DeployDir()) == 1 {
+			if cls.CountDir(ins.GetHost(), ins.DeployDir()) == 1 {
 				delPaths = append(delPaths, ins.DeployDir())
 			}
-			if logDir := ins.LogDir(); !strings.HasPrefix(ins.DeployDir(), logDir) && cls.CountDir(logDir) == 1 {
+			if logDir := ins.LogDir(); !strings.HasPrefix(ins.DeployDir(), logDir) && cls.CountDir(ins.GetHost(), logDir) == 1 {
 				delPaths = append(delPaths, logDir)
 			}
 		} else {

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -165,13 +165,13 @@ func DestroyMonitored(getter ExecutorGetter, inst meta.Instance, options meta.Mo
 	return nil
 }
 
-// clusterSpec is an interface used to get essential information of a cluster
-type clusterSpec interface {
+// topologySpecification is an interface used to get essential information of a cluster
+type topologySpecification interface {
 	CountDir(string) int // count how many time a path is used by instances in cluster
 }
 
 // DestroyComponent destroy the instances.
-func DestroyComponent(getter ExecutorGetter, instances []meta.Instance, cls clusterSpec, timeout int64) error {
+func DestroyComponent(getter ExecutorGetter, instances []meta.Instance, cls topologySpecification, timeout int64) error {
 	if len(instances) <= 0 {
 		return nil
 	}

--- a/pkg/cluster/operation/scale_in.go
+++ b/pkg/cluster/operation/scale_in.go
@@ -126,7 +126,7 @@ func ScaleInCluster(
 				if err := StopComponent(getter, []meta.Instance{instance}); err != nil {
 					log.Warnf("failed to stop %s: %v", component.Name(), err)
 				}
-				if err := DestroyComponent(getter, []meta.Instance{instance}, options.OptTimeout); err != nil {
+				if err := DestroyComponent(getter, []meta.Instance{instance}, spec, options.OptTimeout); err != nil {
 					log.Warnf("failed to destroy %s: %v", component.Name(), err)
 				}
 
@@ -237,7 +237,7 @@ func ScaleInCluster(
 				if err := StopComponent(getter, []meta.Instance{instance}); err != nil {
 					return errors.Annotatef(err, "failed to stop %s", component.Name())
 				}
-				if err := DestroyComponent(getter, []meta.Instance{instance}, options.OptTimeout); err != nil {
+				if err := DestroyComponent(getter, []meta.Instance{instance}, spec, options.OptTimeout); err != nil {
 					return errors.Annotatef(err, "failed to destroy %s", component.Name())
 				}
 			} else {
@@ -332,7 +332,7 @@ func ScaleInDMCluster(
 				if err := StopComponent(getter, []meta.Instance{instance}); err != nil {
 					log.Warnf("failed to stop %s: %v", component.Name(), err)
 				}
-				if err := DestroyComponent(getter, []meta.Instance{instance}, options.OptTimeout); err != nil {
+				if err := DestroyComponent(getter, []meta.Instance{instance}, spec, options.OptTimeout); err != nil {
 					log.Warnf("failed to destroy %s: %v", component.Name(), err)
 				}
 
@@ -371,7 +371,7 @@ func ScaleInDMCluster(
 			if err := StopComponent(getter, []meta.Instance{instance}); err != nil {
 				return errors.Annotatef(err, "failed to stop %s", component.Name())
 			}
-			if err := DestroyComponent(getter, []meta.Instance{instance}, options.OptTimeout); err != nil {
+			if err := DestroyComponent(getter, []meta.Instance{instance}, spec, options.OptTimeout); err != nil {
 				return errors.Annotatef(err, "failed to destroy %s", component.Name())
 			}
 

--- a/pkg/cluster/task/update_meta.go
+++ b/pkg/cluster/task/update_meta.go
@@ -33,7 +33,7 @@ func (u *UpdateMeta) Execute(ctx *Context) error {
 	// make a copy
 	newMeta := &meta.ClusterMeta{}
 	*newMeta = *u.metadata
-	newMeta.Topology = &meta.TopologySpecification{
+	newMeta.Topology = &meta.ClusterSpecification{
 		GlobalOptions:    u.metadata.Topology.GlobalOptions,
 		MonitoredOptions: u.metadata.Topology.MonitoredOptions,
 		ServerConfigs:    u.metadata.Topology.ServerConfigs,

--- a/pkg/cluster/template/scripts/tidb.go
+++ b/pkg/cluster/template/scripts/tidb.go
@@ -24,14 +24,14 @@ import (
 
 // TiDBScript represent the data to generate TiDB config
 type TiDBScript struct {
-	IP            string
+	IP         string
 	ListenHost string
-	Port          int
-	StatusPort    int
-	DeployDir     string
-	LogDir        string
-	NumaNode      string
-	Endpoints     []*PDScript
+	Port       int
+	StatusPort int
+	DeployDir  string
+	LogDir     string
+	NumaNode   string
+	Endpoints  []*PDScript
 }
 
 // NewTiDBScript returns a TiDBScript with given arguments

--- a/pkg/cluster/template/scripts/tikv.go
+++ b/pkg/cluster/template/scripts/tikv.go
@@ -24,15 +24,15 @@ import (
 
 // TiKVScript represent the data to generate TiKV config
 type TiKVScript struct {
-	IP            string
+	IP         string
 	ListenHost string
-	Port          int
-	StatusPort    int
-	DeployDir     string
-	DataDir       string
-	LogDir        string
-	NumaNode      string
-	Endpoints     []*PDScript
+	Port       int
+	StatusPort int
+	DeployDir  string
+	DataDir    string
+	LogDir     string
+	NumaNode   string
+	Endpoints  []*PDScript
 }
 
 // NewTiKVScript returns a TiKVScript with given arguments

--- a/pkg/set/string_set.go
+++ b/pkg/set/string_set.go
@@ -62,3 +62,12 @@ func (s StringSet) Difference(rhs StringSet) StringSet {
 	}
 	return newSet
 }
+
+// Slice converts the set to a slice
+func (s StringSet) Slice() []string {
+	res := make([]string, 0)
+	for val := range s {
+		res = append(res, val)
+	}
+	return res
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If user `scale-out` a node with `data_dir` or `deploy_dir` manually set to the same as imported node, the dir conflict check is not working for it. Also, when `scale-in` this node, the dir is deleted and the imported node is also effected. 

### What is changed and how it works?
1. Add dir paths of imported node to the conflict check list, but not reporting error for imported nodes, thus other (non-imported) nodes will fail the check if they have same dir as imported ones.
2. Optimize the component destroying process, only delete a dir path when there is no other nodes share this path

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Increased code complexity
