### PR TITLE
executor/ssh: fix PATH for non-shell executors

### DIFF
--- a/pkg/cluster/executor/ssh.go
+++ b/pkg/cluster/executor/ssh.go
@@ -128,12 +128,12 @@ func (e *SSHExecutor) Execute(cmd string, sudo bool, timeout ...time.Duration) (
 		cmd = fmt.Sprintf("sudo -H -u root bash -c \"%s\"", cmd)
 	}
 
+	// set a basic PATH in case it's empty on login
+	cmd = fmt.Sprintf("PATH=$PATH:/usr/bin:/usr/sbin %s", cmd)
+
 	if e.Locale != "" {
 		cmd = fmt.Sprintf("export LANG=%s; %s", e.Locale, cmd)
 	}
-
-	// set a basic PATH in case it's empty on login
-	cmd = fmt.Sprintf("PATH=$PATH:/usr/bin:/usr/sbin %s", cmd)
 
 	// run command on remote host
 	// default timeout is 60s in easyssh-proxy


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If the command is executed without shell, the PATH might be empty.

### What is changed and how it works?
Fix the order of setting LANG and PATH values

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

