### PR TITLE
Redirect std output to log file

### DIFF
--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -47,6 +47,8 @@ type Instance interface {
 	Component() string
 	// LogFile return the log file name
 	LogFile() string
+	// Uptime show uptime.
+	Uptime() string
 	StatusAddrs() []string
 	Wait() error
 }

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -43,6 +43,10 @@ type Instance interface {
 	Pid() int
 	// Start the instance process.
 	Start(ctx context.Context, version v0manifest.Version) error
+	// Component Return the component name.
+	Component() string
+	// LogFile return the log file name
+	LogFile() string
 	StatusAddrs() []string
 	Wait() error
 }
@@ -68,4 +72,10 @@ func advertiseHost(listen string) string {
 	}
 
 	return listen
+}
+
+func logIfErr(err error) {
+	if err != nil {
+		fmt.Println(err)
+	}
 }

--- a/components/playground/instance/process.go
+++ b/components/playground/instance/process.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/localdata"
@@ -13,12 +14,14 @@ import (
 
 // Process represent process to be run by playground.
 type Process struct {
-	cmd *exec.Cmd
+	cmd       *exec.Cmd
+	startTime time.Time
 }
 
 // Start the process
 func (p *Process) Start() error {
 	// fmt.Printf("Starting `%s`: %s", filepath.Base(p.cmd.Path), strings.Join(p.cmd.Args, " "))
+	p.startTime = time.Now()
 	return p.cmd.Start()
 }
 
@@ -30,6 +33,17 @@ func (p *Process) Wait() error {
 // Pid implements Instance interface.
 func (p *Process) Pid() int {
 	return p.cmd.Process.Pid
+}
+
+// Uptime implements Instance interface.
+func (p *Process) Uptime() string {
+	s := p.cmd.ProcessState
+	if s != nil && s.Exited() {
+		return "exited"
+	}
+
+	duration := time.Since(p.startTime)
+	return duration.String()
 }
 
 func (p *Process) setOutputFile(fname string) error {

--- a/components/playground/instance/process.go
+++ b/components/playground/instance/process.go
@@ -1,0 +1,67 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/localdata"
+)
+
+// Process represent process to be run by playground.
+type Process struct {
+	cmd *exec.Cmd
+}
+
+// Start the process
+func (p *Process) Start() error {
+	// fmt.Printf("Starting `%s`: %s", filepath.Base(p.cmd.Path), strings.Join(p.cmd.Args, " "))
+	return p.cmd.Start()
+}
+
+// Wait implements Instance interface.
+func (p *Process) Wait() error {
+	return p.cmd.Wait()
+}
+
+// Pid implements Instance interface.
+func (p *Process) Pid() int {
+	return p.cmd.Process.Pid
+}
+
+func (p *Process) setOutputFile(fname string) error {
+	f, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+	p.setOutput(f)
+	return nil
+}
+
+func (p *Process) setOutput(w io.Writer) {
+	p.cmd.Stdout = w
+	p.cmd.Stderr = w
+}
+
+// NewProcess create a Process instance.
+func NewProcess(ctx context.Context, dir string, name string, arg ...string) *Process {
+	if dir == "" {
+		panic("dir must be set")
+	}
+
+	cmd := exec.CommandContext(ctx, name, arg...)
+	cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("%s=%s", localdata.EnvNameInstanceDataDir, dir),
+	)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return &Process{
+		cmd: cmd,
+	}
+}

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -105,7 +105,7 @@ func execute() error {
 			Num: defaultTiflashNum,
 		},
 		host:    "127.0.0.1",
-		monitor: false,
+		monitor: true,
 		version: "",
 	}
 
@@ -117,7 +117,7 @@ if you don't specified a version.
 Examples:
   $ tiup playground nightly                         # Start a TiDB nightly version local cluster
   $ tiup playground v3.0.10 --db 3 --pd 3 --kv 3    # Start a local cluster with 10 nodes
-  $ tiup playground nightly --monitor               # Start a local cluster with monitor system
+  $ tiup playground nightly --monitor=false         # Start a local cluster and disable monitor system
   $ tiup playground --pd.config ~/config/pd.toml    # Start a local cluster with specified configuration file,
   $ tiup playground --db.binpath /xx/tidb-server    # Start a local cluster with component binary path`,
 		SilenceUsage: true,
@@ -152,7 +152,7 @@ Examples:
 	rootCmd.Flags().StringVarP(&opt.host, "host", "", opt.host, "Playground cluster host")
 	rootCmd.Flags().StringVarP(&opt.tidb.Host, "db.host", "", opt.tidb.Host, "Playground TiDB host. If not provided, TiDB will still use `host` flag as its host")
 	rootCmd.Flags().StringVarP(&opt.pd.Host, "pd.host", "", opt.pd.Host, "Playground PD host. If not provided, PD will still use `host` flag as its host")
-	rootCmd.Flags().BoolVar(&opt.monitor, "monitor", true, "Start prometheus and grafana component")
+	rootCmd.Flags().BoolVar(&opt.monitor, "monitor", opt.monitor, "Start prometheus and grafana component")
 
 	rootCmd.Flags().StringVarP(&opt.tidb.ConfigPath, "db.config", "", opt.tidb.ConfigPath, "TiDB instance configuration file")
 	rootCmd.Flags().StringVarP(&opt.tikv.ConfigPath, "kv.config", "", opt.tikv.ConfigPath, "TiKV instance configuration file")

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -152,7 +152,7 @@ Examples:
 	rootCmd.Flags().StringVarP(&opt.host, "host", "", opt.host, "Playground cluster host")
 	rootCmd.Flags().StringVarP(&opt.tidb.Host, "db.host", "", opt.tidb.Host, "Playground TiDB host. If not provided, TiDB will still use `host` flag as its host")
 	rootCmd.Flags().StringVarP(&opt.pd.Host, "pd.host", "", opt.pd.Host, "Playground PD host. If not provided, PD will still use `host` flag as its host")
-	rootCmd.Flags().BoolVar(&opt.monitor, "monitor", false, "Start prometheus component")
+	rootCmd.Flags().BoolVar(&opt.monitor, "monitor", true, "Start prometheus and grafana component")
 
 	rootCmd.Flags().StringVarP(&opt.tidb.ConfigPath, "db.config", "", opt.tidb.ConfigPath, "TiDB instance configuration file")
 	rootCmd.Flags().StringVarP(&opt.tikv.ConfigPath, "kv.config", "", opt.tikv.ConfigPath, "TiKV instance configuration file")

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -84,13 +84,14 @@ func (p *Playground) handleDisplay(r io.Writer) (err error) {
 	t := tabby.NewCustom(w)
 
 	// TODO add more info.
-	header := []interface{}{"Pid", "Role"}
+	header := []interface{}{"Pid", "Role", "Uptime"}
 	t.AddHeader(header...)
 
 	err = p.WalkInstances(func(componentID string, ins instance.Instance) error {
 		row := make([]interface{}, len(header))
 		row[0] = strconv.Itoa(ins.Pid())
 		row[1] = componentID
+		row[2] = ins.Uptime()
 		t.AddLine(row...)
 		return nil
 	})

--- a/components/playground/utils/utils.go
+++ b/components/playground/utils/utils.go
@@ -14,8 +14,12 @@
 package utils
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"time"
+
+	"github.com/pingcap/errors"
 )
 
 // RetryOption is options for Retry()
@@ -77,4 +81,41 @@ func Retry(doFunc func() error, opts ...RetryOption) error {
 	}
 
 	return fmt.Errorf("operation exceeds the max retry attempts of %d", cfg.Attempts)
+}
+
+// TailN try get the latest n line of the file.
+func TailN(fname string, n int) (lines []string, err error) {
+	file, err := os.Open(fname)
+	if err != nil {
+		return nil, errors.AddStack(err)
+	}
+	defer file.Close()
+
+	estimateLineSize := 1024
+
+	stat, err := os.Stat(fname)
+	if err != nil {
+		return nil, errors.AddStack(err)
+	}
+
+	start := int(stat.Size()) - n*estimateLineSize
+	if start < 0 {
+		start = 0
+	}
+
+	_, err = file.Seek(int64(start), 0 /*means relative to the origin of the file*/)
+	if err != nil {
+		return nil, errors.AddStack(err)
+	}
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+
+	return
 }


### PR DESCRIPTION
1. redirect std output to the log file, only print the latest 10 lines of
output form log file if the instance quit abnormally.  maybe fix https://github.com/pingcap/tiup/issues/342
2. make the scale-in/scale-out/display not hidden and improve help
message.
3. enable monitor default. fix #491 
4. add uptime in display

example of 1:
<img width="776" alt="Screen Shot 2020-06-19 at 3 10 42 PM" src="https://user-images.githubusercontent.com/1681864/85107555-bacefd80-b240-11ea-94f0-80f6b3c00a33.png">

example of 4:
<img width="807" alt="Screen Shot 2020-06-19 at 4 32 59 PM" src="https://user-images.githubusercontent.com/1681864/85113949-b4458380-b24a-11ea-9ab6-28dab9136fda.png">
