### PR TITLE
Enable intergrate test & Fix scale-out pd

### DIFF
--- a/pkg/cluster/template/scripts/pd.go
+++ b/pkg/cluster/template/scripts/pd.go
@@ -172,6 +172,12 @@ func (c *PDScaleScript) AppendEndpoints(ends ...*PDScript) *PDScaleScript {
 	return c
 }
 
+// WithListenHost set listenHost field of PDScript
+func (c *PDScaleScript) WithListenHost(listenHost string) *PDScaleScript {
+	c.ListenHost = listenHost
+	return c
+}
+
 // Config generate the config file data.
 func (c *PDScaleScript) Config() ([]byte, error) {
 	fp := path.Join("/templates", "scripts", "run_pd_scale.sh.tpl")

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 function cmd_subtest() {
+    mkdir -p ~/.tiup/bin/
+
     version=$1
     test_cdc=$2
 
-    name="test_cmd_$version"
+    name="test_cmd_$RANDOM"
     if [ $test_cdc = true ]; then
         topo=./topo/full.yaml
     else

--- a/tests/tiup-cluster/test_cmd.sh
+++ b/tests/tiup-cluster/test_cmd.sh
@@ -5,7 +5,7 @@ set -eu
 source script/cmd_subtest.sh
 
 echo "test cluster for verision v4.0.0-rc"
-echo cmd_subtest v4.0.0-rc true
+cmd_subtest v4.0.0-rc true
 
 echo "test cluster for verision v4.0.0-rc.1"
-echo cmd_subtest v4.0.0-rc.1 false
+cmd_subtest v4.0.0-rc.1 false


### PR DESCRIPTION
Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tiup/issues/517

### What is changed and how it works?
Tiup cluster scale-out pd will fail because scale-out generates wrong run_pd.sh in scale stage.
I changed it to the correct one

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

