### PR TITLE
Enable playground TiFlash component on Mac

### DIFF
--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -84,13 +83,6 @@ func installIfMissing(profile *localdata.Profile, component, version string) err
 }
 
 func execute() error {
-	var defaultTiflashNum int
-	if runtime.GOOS == "linux" {
-		defaultTiflashNum = 1
-	} else {
-		defaultTiflashNum = 0
-	}
-
 	opt := &bootOptions{
 		tidb: instance.Config{
 			Num: 1,
@@ -102,7 +94,7 @@ func execute() error {
 			Num: 1,
 		},
 		tiflash: instance.Config{
-			Num: defaultTiflashNum,
+			Num: 1,
 		},
 		host:    "127.0.0.1",
 		monitor: true,

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -865,7 +865,7 @@ func (p *Playground) bootCluster(options *bootOptions) error {
 
 	dumpDSN(p.tidbs)
 
-	if _, ok := failpoint.Eval(_curpkg_("terminateEarly")); ok {
+	failpoint.Inject("terminateEarly", func() error {
 		time.Sleep(20 * time.Second)
 
 		fmt.Println("Early terminated via failpoint")
@@ -887,7 +887,7 @@ func (p *Playground) bootCluster(options *bootOptions) error {
 			_ = monitorCmd.Wait()
 		}
 		return nil
-	}
+	})
 
 	go func() {
 		sc := make(chan os.Signal, 1)

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -598,12 +598,14 @@ func (p *Playground) bootCluster(options *bootOptions) error {
 			options.pd.Num, options.tikv.Num, options.pd.Num)
 	}
 
-	if options.version != "" && semver.Compare("v3.1.0", options.version) < 0 && options.tiflash.Num != 0 {
-		fmt.Println(color.YellowString("Warning: current version %s doesn't support TiFlash", options.version))
-		options.tiflash.Num = 0
-	} else if options.version != "" && runtime.GOOS == "darwin" && semver.Compare("v4.0.0", options.version) < 0 {
-		fmt.Println(color.YellowString("Warning: current version %s doesn't support TiFlash on darwin", options.version))
-		options.tiflash.Num = 0
+	if options.version != "nightly" && options.version != "" {
+		if semver.Compare("v3.1.0", options.version) > 0 && options.tiflash.Num != 0 {
+			fmt.Println(color.YellowString("Warning: current version %s doesn't support TiFlash", options.version))
+			options.tiflash.Num = 0
+		} else if runtime.GOOS == "darwin" && semver.Compare("v4.0.0", options.version) > 0 {
+			fmt.Println(color.YellowString("Warning: current version %s doesn't support TiFlash on darwin", options.version))
+			options.tiflash.Num = 0
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -603,6 +603,7 @@ func (p *Playground) bootCluster(options *bootOptions) error {
 			fmt.Println(color.YellowString("Warning: current version %s doesn't support TiFlash", options.version))
 			options.tiflash.Num = 0
 		} else if runtime.GOOS == "darwin" && semver.Compare("v4.0.0", options.version) > 0 {
+			// only runs tiflash on version later than v4.0.0 when executing on darwin
 			fmt.Println(color.YellowString("Warning: current version %s doesn't support TiFlash on darwin", options.version))
 			options.tiflash.Num = 0
 		}
@@ -641,7 +642,6 @@ func (p *Playground) bootCluster(options *bootOptions) error {
 			return errors.AddStack(err)
 		}
 	}
-	// only runs tiflash on version later than v4.0.0-rc.2 when executing on darwin
 	for i := 0; i < options.tiflash.Num; i++ {
 		_, err := p.addInstance("tiflash", options.tiflash)
 		if err != nil {

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -23,13 +23,13 @@ import (
 
 // Options represents the operation options
 type Options struct {
-	Roles      []string
-	Nodes      []string
-	Force      bool  // Option for upgrade subcommand
-	SSHTimeout int64 // timeout in seconds when connecting an SSH server
-	OptTimeout int64 // timeout in seconds for operations that support it, not to confuse with SSH timeout
-	APITimeout int64 // timeout in seconds for API operations that support it, like transfering store leader
-  IgnoreConfigCheck bool  // should we ignore the config check result after init config
+	Roles             []string
+	Nodes             []string
+	Force             bool  // Option for upgrade subcommand
+	SSHTimeout        int64 // timeout in seconds when connecting an SSH server
+	OptTimeout        int64 // timeout in seconds for operations that support it, not to confuse with SSH timeout
+	APITimeout        int64 // timeout in seconds for API operations that support it, like transfering store leader
+	IgnoreConfigCheck bool  // should we ignore the config check result after init config
 
 	// Some data will be retained when destroying instances
 	RetainDataRoles []string

--- a/pkg/utils/mock/mock.go
+++ b/pkg/utils/mock/mock.go
@@ -55,9 +55,9 @@ var points = mockPoints{m: make(map[string]interface{})}
 // On inject a failpoint
 func On(fpname string) interface{} {
 	var ret interface{}
-	if _, ok := failpoint.Eval(_curpkg_(fpname)); ok {
+	failpoint.Inject(fpname, func() {
 		ret = points.get(fpname)
-	}
+	})
 	return ret
 }
 

--- a/pkg/utils/mock/mock.go
+++ b/pkg/utils/mock/mock.go
@@ -55,9 +55,9 @@ var points = mockPoints{m: make(map[string]interface{})}
 // On inject a failpoint
 func On(fpname string) interface{} {
 	var ret interface{}
-	failpoint.Inject(fpname, func() {
+	if _, ok := failpoint.Eval(_curpkg_(fpname)); ok {
 		ret = points.get(fpname)
-	})
+	}
 	return ret
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
After all tiflash mac binary are updated to tiup mirror, this PR will be safe to test & merge.

### What is changed and how it works?
enable playground to use tiflash component on mac by default.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
