### PR TITLE
Fix cdc cli

### DIFF
--- a/components/ctl/main.go
+++ b/components/ctl/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/pingcap/tiup/pkg/localdata"
@@ -85,6 +86,12 @@ func binaryPath(home, cmd string) (string, error) {
 }
 
 func run(name string, args ...string) error {
+	// Handle `cdc cli`
+	if strings.Contains(name, " ") {
+		xs := strings.Split(name, " ")
+		name = xs[0]
+		args = append(xs[1:], args...)
+	}
 	cmd := exec.Command(name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
`tiup ctl cdc` won't work since the command contains a space in `cdc cli`, the system will identify them as an indivisible whole.

### What problem does this PR solve? <!--add issue link with summary if exists-->
Split command by space.
