### PR TITLE
Fix custom config of grafana

### DIFF
--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -167,6 +167,7 @@ func (g *grafana) start(ctx context.Context, dir string, p8sURL string) (err err
 	}
 
 	tpl := `
+[server]
 # The ip address to bind to, empty will bind to all interfaces
 http_addr = %s
 

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -125,7 +125,7 @@ scrape_configs:
 		instance.CompVersion("prometheus", v0manifest.Version(version)),
 		fmt.Sprintf("--config.file=%s", filepath.Join(dir, "prometheus.yml")),
 		fmt.Sprintf("--web.external-url=http://%s", addr),
-		fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port),
+		fmt.Sprintf("--web.listen-address=%s:%d", host, port),
 		fmt.Sprintf("--storage.tsdb.path='%s'", filepath.Join(dir, "data")),
 	}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)


### PR DESCRIPTION
fix #534  also, for Prometheus, listen on the specified host.
we call GetFreePort with the specified host.

Note that we can listen on both "0.0.0.0" and some specified ip like "127.0.0.1"
