### PR TITLE
Fix scale-in of tiflash in playground

### DIFF
--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -86,7 +86,7 @@ type replicateEnablePlacementRulesConfig struct {
 
 // Addr return the address of tiflash
 func (inst *TiFlashInstance) Addr() string {
-	return fmt.Sprintf("%s:%d", inst.Host, inst.Port)
+	return fmt.Sprintf("%s:%d", inst.Host, inst.ServicePort)
 }
 
 // StatusAddrs implements Instance interface.


### PR DESCRIPTION
Should use service port instead of `Port`

test:
<img width="861" alt="Screen Shot 2020-06-28 at 10 54 19 AM" src="https://user-images.githubusercontent.com/1681864/85936488-ed0de880-b92d-11ea-9ee0-6fd4cc712e36.png">
