### PR TITLE
Change the default goal in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@ FILES     := $$(find . -name "*.go")
 FAILPOINT_ENABLE  := $$(tools/bin/failpoint-ctl enable)
 FAILPOINT_DISABLE := $$(tools/bin/failpoint-ctl disable)
 
+default: build check
+
 include ./tests/Makefile
 
-default: build check
 
 # Build TiUP and all components
 build: tiup components


### PR DESCRIPTION
In GNU make, the first goal becomes the default.
so the default goal is build_integration_test in tests/Makefile
when run `make`