### PR TITLE
cluster/scale-out: check for imported field earlier

### DIFF
--- a/components/cluster/command/reload.go
+++ b/components/cluster/command/reload.go
@@ -78,6 +78,7 @@ func newReloadCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force reload without transferring PD leader")
 	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only start specified nodes")
 	cmd.Flags().Int64Var(&gOpt.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")

--- a/components/cluster/command/root_test.go
+++ b/components/cluster/command/root_test.go
@@ -1,0 +1,11 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/pingcap/check"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}

--- a/components/cluster/command/scale_out_test.go
+++ b/components/cluster/command/scale_out_test.go
@@ -1,0 +1,59 @@
+package command
+
+import (
+	"github.com/pingcap/check"
+	"github.com/pingcap/tiup/pkg/cluster/spec"
+	"gopkg.in/yaml.v2"
+)
+
+type scaleOutSuite struct{}
+
+var _ = check.Suite(&scaleOutSuite{})
+
+func (s *scaleOutSuite) TestValidateNewTopo(c *check.C) {
+	topo := spec.Specification{}
+	err := yaml.Unmarshal([]byte(`
+global:
+  user: "test1"
+  ssh_port: 220
+  deploy_dir: "test-deploy"
+  data_dir: "test-data" 
+tidb_servers:
+  - host: 172.16.5.138
+    deploy_dir: "tidb-deploy"
+pd_servers:
+  - host: 172.16.5.53
+    data_dir: "pd-data"
+`), &topo)
+	c.Assert(err, check.IsNil)
+	err = validateNewTopo(&topo)
+	c.Assert(err, check.IsNil)
+
+	topo = spec.Specification{}
+	err = yaml.Unmarshal([]byte(`
+tidb_servers:
+  - host: 172.16.5.138
+    imported: true
+    deploy_dir: "tidb-deploy"
+pd_servers:
+  - host: 172.16.5.53
+    data_dir: "pd-data"
+`), &topo)
+	c.Assert(err, check.IsNil)
+	err = validateNewTopo(&topo)
+	c.Assert(err, check.NotNil)
+
+	topo = spec.Specification{}
+	err = yaml.Unmarshal([]byte(`
+global:
+  user: "test3"
+  deploy_dir: "test-deploy"
+  data_dir: "test-data"
+pd_servers:
+  - host: 172.16.5.53
+    imported: true
+`), &topo)
+	c.Assert(err, check.IsNil)
+	err = validateNewTopo(&topo)
+	c.Assert(err, check.NotNil)
+}

--- a/components/cluster/command/upgrade.go
+++ b/components/cluster/command/upgrade.go
@@ -49,7 +49,7 @@ func newUpgradeCmd() *cobra.Command {
 			return upgrade(clusterName, version, gOpt)
 		},
 	}
-	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force upgrade won't transfer leader")
+	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force upgrade without transferring PD leader")
 	cmd.Flags().Int64Var(&gOpt.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
 	cmd.Flags().BoolVarP(&gOpt.IgnoreConfigCheck, "ignore-config-check", "", false, "Ignore the config check result")
 

--- a/components/cluster/command/upgrade_test.go
+++ b/components/cluster/command/upgrade_test.go
@@ -1,14 +1,8 @@
 package command
 
 import (
-	"testing"
-
 	"github.com/pingcap/check"
 )
-
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
 
 type upgradeSuite struct{}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`imported: true` is not allowed for scale out instances, currently we check that when building scale out tasks, this might be too late for some circumstances, this PR move that check to an early stage of the process, to let it fail ASAP.

### What is changed and how it works?
Move the check to an early stage of the process.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
