### PR TITLE
Fix init config with check config

### DIFF
--- a/pkg/cluster/spec/server_config.go
+++ b/pkg/cluster/spec/server_config.go
@@ -170,12 +170,12 @@ func mergeImported(importConfig []byte, specConfigs ...map[string]interface{}) (
 func checkConfig(e executor.Executor, componentName, clusterVersion, nodeOS, arch, config string, paths meta.DirPaths) error {
 	repo, err := clusterutil.NewRepository(nodeOS, arch)
 	if err != nil {
-		return err
+		return perrs.Annotate(ErrorCheckConfig, err.Error())
 	}
 	ver := ComponentVersion(componentName, clusterVersion)
 	entry, err := repo.ComponentBinEntry(componentName, ver)
 	if err != nil {
-		return err
+		return perrs.Annotate(ErrorCheckConfig, err.Error())
 	}
 
 	binPath := path.Join(paths.Deploy, "bin", entry)


### PR DESCRIPTION
Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The scale-in process doesn't need to check config at all. But it still fails when other errors in the config check stage threw.

### What is changed and how it works?
All errors  in the config check stage should be config check error

