### PR TITLE
cluster: properly pass --wait-timeout to systemd operations

### DIFF
--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -119,7 +119,9 @@ func init() {
 	cliutil.BeautifyCobraUsageAndHelp(rootCmd)
 
 	rootCmd.PersistentFlags().Int64Var(&gOpt.SSHTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection.")
-	rootCmd.PersistentFlags().Int64Var(&gOpt.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+	// the value of wait-timeout is also used for `systemctl` commands, as the default timeout of systemd for
+	// start/stop operations is 90s, the default value of this argument is better be longer than that
+	rootCmd.PersistentFlags().Int64Var(&gOpt.OptTimeout, "wait-timeout", 120, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 	rootCmd.PersistentFlags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip all confirmations and assumes 'yes'")
 
 	rootCmd.AddCommand(

--- a/pkg/cluster/operation/scale_in.go
+++ b/pkg/cluster/operation/scale_in.go
@@ -135,7 +135,7 @@ func ScaleInCluster(
 				}
 
 				// just try stop and destroy
-				if err := StopComponent(getter, []spec.Instance{instance}); err != nil {
+				if err := StopComponent(getter, []spec.Instance{instance}, options.OptTimeout); err != nil {
 					log.Warnf("failed to stop %s: %v", component.Name(), err)
 				}
 				if err := DestroyComponent(getter, []spec.Instance{instance}, cluster, options); err != nil {
@@ -226,7 +226,7 @@ func ScaleInCluster(
 			}
 
 			if !asyncOfflineComps.Exist(instance.ComponentName()) {
-				if err := StopComponent(getter, []spec.Instance{instance}); err != nil {
+				if err := StopComponent(getter, []spec.Instance{instance}, options.OptTimeout); err != nil {
 					return errors.Annotatef(err, "failed to stop %s", component.Name())
 				}
 				if err := DestroyComponent(getter, []spec.Instance{instance}, cluster, options); err != nil {
@@ -365,7 +365,7 @@ func ScaleInDMCluster(
 					continue
 				}
 				// just try stop and destroy
-				if err := StopComponent(getter, []meta.Instance{instance}); err != nil {
+				if err := StopComponent(getter, []meta.Instance{instance}, options.OptTimeout); err != nil {
 					log.Warnf("failed to stop %s: %v", component.Name(), err)
 				}
 				if err := DestroyComponent(getter, []meta.Instance{instance}, spec, options); err != nil {
@@ -404,7 +404,7 @@ func ScaleInDMCluster(
 				continue
 			}
 
-			if err := StopComponent(getter, []meta.Instance{instance}); err != nil {
+			if err := StopComponent(getter, []meta.Instance{instance}, options.OptTimeout); err != nil {
 				return errors.Annotatef(err, "failed to stop %s", component.Name())
 			}
 			if err := DestroyComponent(getter, []meta.Instance{instance}, spec, options); err != nil {

--- a/pkg/cluster/operation/upgrade.go
+++ b/pkg/cluster/operation/upgrade.go
@@ -68,7 +68,7 @@ func Upgrade(
 						}
 					}
 
-					if err := stopInstance(getter, instance); err != nil {
+					if err := stopInstance(getter, instance, options.OptTimeout); err != nil {
 						return errors.Annotatef(err, "failed to stop %s", instance.GetHost())
 					}
 					if err := startInstance(getter, instance, options.OptTimeout); err != nil {
@@ -96,7 +96,7 @@ func Upgrade(
 						}
 					}
 
-					if err := stopInstance(getter, instance); err != nil {
+					if err := stopInstance(getter, instance, options.OptTimeout); err != nil {
 						return errors.Annotatef(err, "failed to stop %s", instance.GetHost())
 					}
 					if err := startInstance(getter, instance, options.OptTimeout); err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The systemd module uses a hard-coded 100s timeout and ignores the `--wait-timeout` global argument.

### What is changed and how it works?
Properly pass the value of `--wait-timeout` to systemd module, so that the SSH execute timeout of `systemctl` operations has the timeout specified with `--wait-timeout`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
