### PR TITLE
cluster: ignore not found error when deleting something via PD API

### DIFF
--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"sort"
 	"time"
@@ -432,7 +433,7 @@ func (pc *PDClient) RemoveStoreEvict(host string) error {
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
 		body, statusCode, err := pc.httpClient.Delete(endpoint, nil)
 		if err != nil {
-			if statusCode == 404 || bytes.Contains(body, []byte("scheduler not found")) {
+			if statusCode == http.StatusNotFound || bytes.Contains(body, []byte("scheduler not found")) {
 				log.Debugf("Store leader evicting scheduler does not exist, ignore.")
 				return body, nil
 			}
@@ -467,7 +468,7 @@ func (pc *PDClient) DelPD(name string, retryOpt *clusterutil.RetryOption) error 
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
 		body, statusCode, err := pc.httpClient.Delete(endpoint, nil)
 		if err != nil {
-			if statusCode == 404 || bytes.Contains(body, []byte("not found, pd")) {
+			if statusCode == http.StatusNotFound || bytes.Contains(body, []byte("not found, pd")) {
 				log.Debugf("PD node does not exist, ignore: %s", body)
 				return body, nil
 			}
@@ -572,7 +573,7 @@ func (pc *PDClient) DelStore(host string, retryOpt *clusterutil.RetryOption) err
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
 		body, statusCode, err := pc.httpClient.Delete(endpoint, nil)
 		if err != nil {
-			if statusCode == 404 || bytes.Contains(body, []byte("not found")) {
+			if statusCode == http.StatusNotFound || bytes.Contains(body, []byte("not found")) {
 				log.Debugf("store %d %s does not exist, ignore: %s", storeID, host, body)
 				return body, nil
 			}

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -465,8 +465,16 @@ func (pc *PDClient) DelPD(name string, retryOpt *clusterutil.RetryOption) error 
 	endpoints := pc.getEndpoints(cmd)
 
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, _, err := pc.httpClient.Delete(endpoint, nil)
-		return body, err
+		body, statusCode, err := pc.httpClient.Delete(endpoint, nil)
+		if err != nil {
+			if statusCode == 404 || bytes.Contains(body, []byte("not found, pd")) {
+				log.Debugf("PD node does not exist, ignore: %s", body)
+				return body, nil
+			}
+			return body, err
+		}
+		log.Debugf("Delete PD %s from the cluster success", name)
+		return body, nil
 	})
 	if err != nil {
 		return errors.AddStack(err)
@@ -562,8 +570,16 @@ func (pc *PDClient) DelStore(host string, retryOpt *clusterutil.RetryOption) err
 	endpoints := pc.getEndpoints(cmd)
 
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, _, err := pc.httpClient.Delete(endpoint, nil)
-		return body, err
+		body, statusCode, err := pc.httpClient.Delete(endpoint, nil)
+		if err != nil {
+			if statusCode == 404 || bytes.Contains(body, []byte("not found")) {
+				log.Debugf("store %d %s does not exist, ignore: %s", storeID, host, body)
+				return body, nil
+			}
+			return body, err
+		}
+		log.Debugf("Delete store %d %s from the cluster success", storeID, host)
+		return body, nil
 	})
 	if err != nil {
 		return errors.AddStack(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When deleting some identity from the cluster via PD API, it's ok to ignore not found error, as that's what we want. This would make it easier to keep `scale-in` operation idempotent.

### What is changed and how it works?
Check for PD API response and ignore not found errors.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch
