### PR TITLE
Support yank a single version on client side

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -230,7 +231,7 @@ func newMirrorModifyCmd() *cobra.Command {
 	yanked := false
 
 	cmd := &cobra.Command{
-		Use:  "modify <comp-name> [flags]",
+		Use:  "modify <component>[:version] [flags]",
 		Long: "modify component attributes (hidden, standalone, yanked)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -253,7 +254,14 @@ func newMirrorModifyCmd() *cobra.Command {
 				return err
 			}
 
-			m, err := env.V1Repository().FetchComponentManifest(args[0])
+			spec := strings.Split(args[0], ":")
+			component := spec[0]
+			version := ""
+			if len(spec) > 1 {
+				version = spec[1]
+			}
+
+			m, err := env.V1Repository().FetchComponentManifest(component)
 			if err != nil {
 				return err
 			}
@@ -261,7 +269,7 @@ func newMirrorModifyCmd() *cobra.Command {
 			if endpoint == "" {
 				endpoint = environment.Mirror()
 			}
-			e := remote.NewEditor(endpoint, args[0]).WithDesc(desc)
+			e := remote.NewEditor(endpoint, component).WithDesc(desc).WithVersion(version)
 			flagSet := set.NewStringSet()
 			cmd.Flags().Visit(func(f *pflag.Flag) {
 				flagSet.Insert(f.Name)

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -254,14 +253,8 @@ func newMirrorModifyCmd() *cobra.Command {
 				return err
 			}
 
-			spec := strings.Split(args[0], ":")
-			component := spec[0]
-			version := ""
-			if len(spec) > 1 {
-				version = spec[1]
-			}
-
-			m, err := env.V1Repository().FetchComponentManifest(component)
+			comp, ver := environment.ParseCompVersion(args[0])
+			m, err := env.V1Repository().FetchComponentManifest(comp)
 			if err != nil {
 				return err
 			}
@@ -269,7 +262,7 @@ func newMirrorModifyCmd() *cobra.Command {
 			if endpoint == "" {
 				endpoint = environment.Mirror()
 			}
-			e := remote.NewEditor(endpoint, component).WithDesc(desc).WithVersion(version)
+			e := remote.NewEditor(endpoint, comp).WithDesc(desc).WithVersion(ver.String())
 			flagSet := set.NewStringSet()
 			cmd.Flags().Visit(func(f *pflag.Flag) {
 				flagSet.Insert(f.Name)

--- a/pkg/repository/remote/modify.go
+++ b/pkg/repository/remote/modify.go
@@ -23,6 +23,7 @@ import (
 
 // Editor defines the methods to modify a component attrs
 type Editor interface {
+	WithVersion(version string) Editor
 	WithDesc(desc string) Editor
 	Standalone(bool) Editor
 	Hide(bool) Editor
@@ -33,6 +34,7 @@ type Editor interface {
 type editor struct {
 	endpoint    string
 	component   string
+	version     string
 	description string
 	options     map[string]bool
 }
@@ -44,6 +46,12 @@ func NewEditor(endpoint, component string) Editor {
 		component: component,
 		options:   make(map[string]bool),
 	}
+}
+
+// WithVersion set version field
+func (e *editor) WithVersion(version string) Editor {
+	e.version = version
+	return e
 }
 
 // WithDesc set description field

--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -79,7 +79,7 @@ var ManifestsConfig = map[string]ty{
 	ManifestTypeComponent: {
 		Filename:  "",
 		Versioned: true,
-		Expire:    time.Hour * 24 * 365, // 1y
+		Expire:    time.Hour * 24 * 365 * 5, // 5y
 		Threshold: 1,
 	},
 	ManifestTypeSnapshot: {

--- a/pkg/repository/v1manifest/types_test.go
+++ b/pkg/repository/v1manifest/types_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1manifest
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert"
+)
+
+func TestComponentList(t *testing.T) {
+	manifest := &Index{
+		Components: map[string]ComponentItem{
+			"comp1": ComponentItem{},
+			"comp2": ComponentItem{Yanked: true},
+		},
+	}
+
+	list := manifest.ComponentList()
+	assert.Equal(t, len(list), 1)
+	_, ok := list["comp1"]
+	assert.True(t, ok)
+
+	list = manifest.ComponentListWithYanked()
+	assert.Equal(t, len(list), 2)
+	_, ok = list["comp1"]
+	assert.True(t, ok)
+	_, ok = list["comp2"]
+	assert.True(t, ok)
+}
+
+func TestVersionList(t *testing.T) {
+	manifest := &Component{
+		Platforms: map[string]map[string]VersionItem{
+			"linux/amd64": {
+				"v1.0.0": {Entry: "test"},
+				"v1.1.1": {Entry: "test", Yanked: true},
+			},
+			"any/any": {
+				"v1.0.0": {Entry: "test"},
+				"v1.1.1": {Entry: "test", Yanked: true},
+			},
+		},
+	}
+
+	versions := manifest.VersionList("linux/amd64")
+	assert.Equal(t, len(versions), 1)
+	_, ok := versions["v1.0.0"]
+	assert.True(t, ok)
+
+	versions = manifest.VersionListWithYanked("linux/amd64")
+	assert.Equal(t, len(versions), 2)
+	_, ok = versions["v1.0.0"]
+	assert.True(t, ok)
+	_, ok = versions["v1.1.1"]
+	assert.True(t, ok)
+
+	versions = manifest.VersionList("windows/amd64")
+	assert.Equal(t, len(versions), 1)
+	_, ok = versions["v1.0.0"]
+	assert.True(t, ok)
+
+	manifest = &Component{
+		Platforms: map[string]map[string]VersionItem{
+			"linux/amd64": {
+				"v1.0.0": {Entry: "test"},
+				"v1.1.1": {Entry: "test", Yanked: true},
+			},
+		},
+	}
+
+	versions = manifest.VersionList("windows/amd64")
+	assert.Equal(t, len(versions), 0)
+}

--- a/tests/tiup/tiup.toml
+++ b/tests/tiup/tiup.toml
@@ -1,0 +1,1 @@
+mirror = "https://tiup-mirrors.pingcap.com"


### PR DESCRIPTION
At this time tiup only supports yank a whole component (include all versions). 
In some scenes, we should yank a single version (for example, we push a wrong version).
This PR makes it possible to yank a single version.