### PR TITLE
Fix data_dir of tiflash when import cluster

### DIFF
--- a/pkg/cluster/ansible/dirs_test.go
+++ b/pkg/cluster/ansible/dirs_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ansible
+
+import (
+	"github.com/pingcap/check"
+	"github.com/pingcap/tiup/pkg/cluster/spec"
+)
+
+var tiflashConfig = `
+default_profile = "default"
+display_name = "TiFlash"
+http_port = 11316
+listen_host = "0.0.0.0"
+mark_cache_size = 5368709120
+path = "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db"
+tcp_port = 11315
+tmp_path = "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db/tmp"
+
+[application]
+runAsDaemon = true
+
+[flash]
+service_addr = "172.16.5.85:11317"
+tidb_status_addr = "172.16.5.85:11310"
+[flash.flash_cluster]
+cluster_manager_path = "/data1/test-cluster/leiysky-ansible-test-deploy/bin/tiflash/flash_cluster_manager"
+log = "/data1/test-cluster/leiysky-ansible-test-deploy/log/tiflash_cluster_manager.log"
+master_ttl = 60
+refresh_interval = 20
+update_rule_interval = 5
+[flash.proxy]
+config = "/data1/test-cluster/leiysky-ansible-test-deploy/conf/tiflash-learner.toml"
+`
+
+type parseSuite struct {
+}
+
+var _ = check.Suite(&parseSuite{})
+
+func (s *parseSuite) TestParseTiflashConfigFromFileData(c *check.C) {
+	spec := new(spec.TiFlashSpec)
+	data := []byte(tiflashConfig)
+
+	err := parseTiflashConfigFromFileData(spec, data)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(spec.DataDir, check.Equals, "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db")
+	c.Assert(spec.TmpDir, check.Equals, "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db/tmp")
+}


### PR DESCRIPTION


<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #611
import command will only get data_dir from inventory.ini and start
script of tiflash and the start script contains the only config file
flag, so it can not get the truly use path and use the default value.

### What is changed and how it works?
parse the config file of tiflash to get `path` and `tmp_path` and set it in `DataDir` and `TmpDir` in spec.

### test
- unit-test
- manual-test
  * test using import command and check the spec.


