### PR TITLE
Add help msg of EDITOR

### DIFF
--- a/components/cluster/command/edit_config.go
+++ b/components/cluster/command/edit_config.go
@@ -35,7 +35,7 @@ import (
 func newEditConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit-config <cluster-name>",
-		Short: "Edit TiDB cluster config",
+		Short: "Edit TiDB cluster config.\nWill use editor from environment variable `EDITOR`, default use vi",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return cmd.Help()


### PR DESCRIPTION
Add help msg of EDITOR

```
➜  tiup git:(editor) ✗ ./bin/tiup-cluster edit-config -h
Edit TiDB cluster config.
Will use editor from environment variable `EDITOR`, default use vi

Usage:
  tiup-cluster edit-config <cluster-name> [flags]

Flags:
  -h, --help   help for edit-config

Global Flags:
      --ssh-timeout int    Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection. (default 5)
      --wait-timeout int   Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit. (default 120)
  -y, --yes                Skip all confirmations and assumes 'yes'
```