### PR TITLE
cluster: allow continue editing when new topology has errors

### DIFF
--- a/pkg/cliutil/tui.go
+++ b/pkg/cliutil/tui.go
@@ -68,7 +68,7 @@ func Prompt(prompt string) string {
 	return strings.TrimSuffix(input, "\n")
 }
 
-// PromptForConfirm accepts yes / no from console by user
+// PromptForConfirm accepts yes / no from console by user, default to No
 func PromptForConfirm(format string, a ...interface{}) bool {
 	ans := Prompt(fmt.Sprintf(format, a...))
 	switch strings.TrimSpace(strings.ToLower(ans)) {
@@ -77,6 +77,11 @@ func PromptForConfirm(format string, a ...interface{}) bool {
 	default:
 		return false
 	}
+}
+
+// PromptForConfirmReverse accepts yes / no from console by user, default to Yes
+func PromptForConfirmReverse(format string, a ...interface{}) bool {
+	return !PromptForConfirm(format, a...)
 }
 
 // PromptForConfirmOrAbortError accepts yes / no from console by user, generates AbortError if user does not input yes.


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In `edit-config`, if the new topology fails parsing or validation, it just returns error and exists, changes are not saved and lost.

### What is changed and how it works?
Prompt the user to choose to continue editing or not.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
