### PR TITLE
Fix PD config incompatible when retrieving dashboard address

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/golang/protobuf v1.3.4
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
+	github.com/jeremywohl/flatten v1.0.1
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/joomcode/errorx v1.0.1
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,8 @@ github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80s
 github.com/jackc/pgx v3.6.1+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
+github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
+github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/gorm v1.9.12/go.mod h1:vhTjlKSJUTWNtcbQtrMBFCxy7eXTzeCAzfL5fBZT/Qs=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #637 

Fix PD config incompatible when retrieving dashboard address

Manual test:
```
➜  tiup git:(pr/638) bin/tiup-cluster display simple
TiDB Cluster: simple
TiDB Version: v4.0.3
ID                     Role  Host             Ports        OS/Arch       Status  Data Dir  Deploy Dir
--                     ----  ----             -----        -------       ------  --------  ----------
192.168.137.101:2379   pd    192.168.137.101  2379/2380    linux/x86_64  Up      data      deploy/pd-2379
192.168.137.102:2379   pd    192.168.137.102  2379/2380    linux/x86_64  Up|L    data      deploy/pd-2379
192.168.137.103:2379   pd    192.168.137.103  2379/2380    linux/x86_64  Up|UI   data      deploy/pd-2379
192.168.137.101:4000   tidb  192.168.137.101  4000/10080   linux/x86_64  Up      -         deploy/tidb-4000
192.168.137.101:20160  tikv  192.168.137.101  20160/20180  linux/x86_64  Up      data      deploy/tikv-20160
192.168.137.102:20160  tikv  192.168.137.102  20160/20180  linux/x86_64  Up      data      deploy/tikv-20160
192.168.137.103:20160  tikv  192.168.137.103  20160/20180  linux/x86_64  Up      data      deploy/tikv-20160
➜  tiup git:(pr/638) bin/tiup-cluster display simple --dashboard
http://192.168.137.103:2379/dashboard/
```