### PR TITLE
Dont hint user to update component when user specify version

### DIFF
--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -145,7 +145,7 @@ func PrepareCommand(
 		return nil, err
 	}
 
-	if len(checkUpdate) > 0 && checkUpdate[0] {
+	if version.IsEmpty() && len(checkUpdate) > 0 && checkUpdate[0] {
 		latestV, _, err := env.V1Repository().LatestStableVersion(component)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The following hint is weired.

```
root@control:/tiup-cluster# tiup tidb:nightly
The component `tidb` is not installed; downloading from repository.
download https://tiup-mirrors.pingcap.com/tidb-v5.0.0-nightly-20200729-linux-amd64.tar.gz 42.07 MiB / 42.07 MiB 100.00% 7.34 MiB p/s
Found tidb newer version:
    The latest version:         v4.0.3
    Local installed version:    nightly
    Update current component:   tiup update tidb
    Update all components:      tiup update --all
Starting component `tidb`: /root/.tiup/components/tidb/nightly/tidb-server
[2020/07/29 07:11:43.278 +00:00] [INFO] [printer.go:33] ["Welcome to TiDB."] ["Release Version"=v4.0.0-beta.2-852-g1e7454c81] [Edition=Community] ["Git Commit Hash"=1e7454c81d1f4fae464e835d1a4023a911cfa87b] ["Git Branch"=master] ["UTC Build Time"="2020-07-28 01:36:23"] [GoVersion=go1.13] ["Race Enabled"=false] ["Check Table Before Drop"=false] ["TiKV Min Version"=v3.0.0-60965b006877ca7234adaced7890d7b029ed1306]
[2020/07/29 07:11:43.278 +00:00] [INFO] [trackerRecorder.go:28] ["Mem Profile Tracker started"]
```

### What is changed and how it works?

Dont hint user to update component when user specify version