### PR TITLE
Pre-check deploy version of dm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,8 @@ coverage:
 	gocovmerge cover/cov.* | grep -vE ".*.pb.go|.*__failpoint_binding__.go|mock.go" > "cover/all_cov.out"
 ifeq ("$(JenkinsCI)", "1")
 	@bash <(curl -s https://codecov.io/bash) -f cover/all_cov.out -t $(CODECOV_TOKEN)
+else
+	go tool cover -html "cover/all_cov.out" -o "cover/all_cov.html"
 endif
 
 failpoint-enable: tools/bin/failpoint-ctl

--- a/components/dm/command/deploy_test.go
+++ b/components/dm/command/deploy_test.go
@@ -1,0 +1,30 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupportVersion(t *testing.T) {
+	assert := require.New(t)
+
+	tests := map[string]bool{ // version to support or not
+		"v2.0.0":        true,
+		"v3.0.0":        true,
+		"v2.0.0-beta.1": true,
+		"v2.0.0-alpha":  true,
+		"v1.0.1":        false,
+		"v1.1.1":        false,
+	}
+
+	for v, support := range tests {
+		err := supportVersion(v)
+		if support {
+			assert.Nil(err)
+		} else {
+			assert.NotNil(err)
+		}
+	}
+
+}


### PR DESCRIPTION
pre-check the deploy version must not less than v2.0
```
root@control:/tiup-cluster# tiup-dm --yes deploy  testa v1.0 ./tests/tiup-dm/topo/full_dm.yaml -i ~/.ssh/id_rsa

Error: Only support version not less than v2.0

Verbose debug logs has been written to
/tiup-cluster/logs/tiup-cluster-debug-2020-07-30-10-28-13.log.
```