### PR TITLE
don't wait the listen port disappear when destroy and clean

### DIFF
--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -68,7 +68,6 @@ type Instance interface {
 	InstanceSpec
 	ID() string
 	Ready(executor.Executor, int64) error
-	WaitForDown(executor.Executor, int64) error
 	InitConfig(e executor.Executor, clusterName string, clusterVersion string, deployUser string, paths meta.DirPaths) error
 	ScaleConfig(e executor.Executor, topo Topology, clusterName string, clusterVersion string, deployUser string, paths meta.DirPaths) error
 	PrepareStart() error
@@ -128,11 +127,6 @@ type BaseInstance struct {
 // Ready implements Instance interface
 func (i *BaseInstance) Ready(e executor.Executor, timeout int64) error {
 	return PortStarted(e, i.Port, timeout)
-}
-
-// WaitForDown implements Instance interface
-func (i *BaseInstance) WaitForDown(e executor.Executor, timeout int64) error {
-	return PortStopped(e, i.Port, timeout)
 }
 
 // InitConfig init the service configuration.


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
ref: https://github.com/pingcap-incubator/tiup-cluster/pull/350


### What is changed and how it works?
Remove WaitForDown when destroy and clean

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->





Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```