### PR TITLE
Do not change the run component's wd

### DIFF
--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -186,14 +186,15 @@ func PrepareCommand(
 		}
 	}
 
-	if wd == "" {
+	instanceDir := wd
+	if instanceDir == "" {
 		// Generate a tag for current instance if the tag doesn't specified
 		if tag == "" {
 			tag = base62Tag()
 		}
-		wd = env.LocalPath(localdata.DataParentDir, tag)
+		instanceDir = env.LocalPath(localdata.DataParentDir, tag)
 	}
-	if err := os.MkdirAll(wd, 0755); err != nil {
+	if err := os.MkdirAll(instanceDir, 0755); err != nil {
 		return nil, err
 	}
 
@@ -215,7 +216,7 @@ func PrepareCommand(
 	envs := []string{
 		fmt.Sprintf("%s=%s", localdata.EnvNameHome, profile.Root()),
 		fmt.Sprintf("%s=%s", localdata.EnvNameWorkDir, tiupWd),
-		fmt.Sprintf("%s=%s", localdata.EnvNameInstanceDataDir, wd),
+		fmt.Sprintf("%s=%s", localdata.EnvNameInstanceDataDir, instanceDir),
 		fmt.Sprintf("%s=%s", localdata.EnvNameComponentDataDir, sd),
 		fmt.Sprintf("%s=%s", localdata.EnvNameComponentInstallDir, installPath),
 		fmt.Sprintf("%s=%s", localdata.EnvNameTelemetryStatus, teleMeta.Status),
@@ -238,8 +239,7 @@ func PrepareCommand(
 }
 
 func launchComponent(ctx context.Context, component string, version v0manifest.Version, binPath string, tag string, args []string, env *environment.Environment) (*localdata.Process, error) {
-	wd := os.Getenv(localdata.EnvNameInstanceDataDir)
-	c, err := PrepareCommand(ctx, component, version, binPath, tag, wd, args, env, true)
+	c, err := PrepareCommand(ctx, component, version, binPath, tag, "", args, env, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Do not change the run component's wd

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
before: (main.go exist in the current directory)
```
root@control:/tiup-cluster# tiup dmctl:nightly --config ./main.go
Starting component `dmctl`: /root/.tiup/components/dmctl/nightly/dmctl/dmctl --config ./main.go
parse cmd flags err: open ./main.go: no such file or directory
```

after:
```
root@control:/tiup-cluster# tiup dmctl:nightly --config ./main.go
Starting component `dmctl`: /root/.tiup/components/dmctl/nightly/dmctl/dmctl --config ./main.go
parse cmd flags err: Near line 0 (last key parsed ''): bare keys cannot contain '/'
Error: run `/root/.tiup/components/dmctl/nightly/dmctl/dmctl` (wd:) failed: exit status 2
```


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```