### PR TITLE
More clear error msg when fail copy file

### DIFF
--- a/docker/control/bashrc
+++ b/docker/control/bashrc
@@ -15,6 +15,9 @@ alias ls='ls $LS_OPTIONS'
 alias ll='ls $LS_OPTIONS -l'
 alias l='ls $LS_OPTIONS -lA'
 
+mkdir -p ~/.tiup/bin
+file ~/.tiup/bin/roog.json || curl "https://tiup-mirrors.pingcap.com/root.json" > ~/.tiup/bin/root.json
+
 cat <<EOF
 Welcome to tiup-cluster on Docker
 ===========================

--- a/pkg/cluster/task/install_package.go
+++ b/pkg/cluster/task/install_package.go
@@ -42,7 +42,7 @@ func (c *InstallPackage) Execute(ctx *Context) error {
 
 	err := exec.Transfer(c.srcPath, dstPath, false)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "failed to scp %s to %s:%s", c.srcPath, c.host, dstPath)
 	}
 
 	cmd := fmt.Sprintf(`tar -xzf %s -C %s && rm %s`, dstPath, dstDir, dstPath)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #680

also, init the tiup env so we can use `tiup-cluster` directly in the control node

### What is changed and how it works?
Annotate the err for more direct error reason.

for why scp failed like no disk or no privilege can not know now, this may need to improve the third pkg, but the current annotate is enough for user to find out the reason.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
using a 
before:
<img width="390" alt="Screen Shot 2020-08-14 at 3 16 45 PM" src="https://user-images.githubusercontent.com/1681864/90224083-b8a0ae00-de41-11ea-8f4d-ed4a873ab2de.png">
after:
<img width="656" alt="Screen Shot 2020-08-14 at 3 16 51 PM" src="https://user-images.githubusercontent.com/1681864/90224109-c22a1600-de41-11ea-9f8c-211d63b61861.png">


Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```