### PR TITLE
Do not overwrite alertmanager.yml for dm when InitConfig

### DIFF
--- a/components/dm/spec/alertmanager.go
+++ b/components/dm/spec/alertmanager.go
@@ -15,11 +15,15 @@ package spec
 
 import (
 	"fmt"
+	"io/ioutil"
 	"path/filepath"
 
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/cluster"
 	"github.com/pingcap/tiup/pkg/cluster/executor"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	cspec "github.com/pingcap/tiup/pkg/cluster/spec"
+	"github.com/pingcap/tiup/pkg/cluster/task"
 	"github.com/pingcap/tiup/pkg/cluster/template/config"
 	"github.com/pingcap/tiup/pkg/cluster/template/scripts"
 	"github.com/pingcap/tiup/pkg/meta"
@@ -69,6 +73,39 @@ type AlertManagerInstance struct {
 	topo *Topology
 }
 
+var _ cluster.DeployerInstance = &AlertManagerInstance{}
+
+// Deploy implements DeployerInstance interface.
+func (i *AlertManagerInstance) Deploy(t *task.Builder, srcPath string, deployDir string, version string, clusterName string, clusterVersion string) {
+	t.CopyComponent(
+		i.ComponentName(),
+		i.OS(),
+		i.Arch(),
+		version,
+		srcPath,
+		i.GetHost(),
+		deployDir,
+	).Func("CopyConfig", func(ctx *task.Context) error {
+		tempDir, err := ioutil.TempDir("", "tiup-*")
+		if err != nil {
+			return errors.AddStack(err)
+		}
+		// transfer config
+		e := ctx.Get(i.GetHost())
+		fp := filepath.Join(tempDir, fmt.Sprintf("alertmanager_%s.yml", i.GetHost()))
+		if err := config.NewAlertManagerConfig().ConfigToFile(fp); err != nil {
+			return err
+		}
+		dst := filepath.Join(deployDir, "conf", "alertmanager.yml")
+		err = e.Transfer(fp, dst, false)
+		if err != nil {
+			return errors.Annotatef(err, "failed to transfer %s to %s@%s", fp, i.GetHost(), dst)
+		}
+		return nil
+	})
+
+}
+
 // InitConfig implement Instance interface
 func (i *AlertManagerInstance) InitConfig(e executor.Executor, clusterName, clusterVersion, deployUser string, paths meta.DirPaths) error {
 	if err := i.BaseInstance.InitConfig(e, i.topo.GlobalOptions, deployUser, paths); err != nil {
@@ -94,13 +131,7 @@ func (i *AlertManagerInstance) InitConfig(e executor.Executor, clusterName, clus
 		return err
 	}
 
-	// transfer config
-	fp = filepath.Join(paths.Cache, fmt.Sprintf("alertmanager_%s.yml", i.GetHost()))
-	if err := config.NewAlertManagerConfig().ConfigToFile(fp); err != nil {
-		return err
-	}
-	dst = filepath.Join(paths.Deploy, "conf", "alertmanager.yml")
-	return e.Transfer(fp, dst, false)
+	return nil
 }
 
 // ScaleConfig deploy temporary config on scaling

--- a/components/dm/spec/grafana.go
+++ b/components/dm/spec/grafana.go
@@ -158,13 +158,13 @@ func (i *GrafanaInstance) ScaleConfig(e executor.Executor, topo spec.Topology,
 var _ cluster.DeployerInstance = &GrafanaInstance{}
 
 // Deploy implements DeployerInstance interface.
-func (i *GrafanaInstance) Deploy(t *task.Builder, deployDir string, version string, clusterName string, clusterVersion string) {
+func (i *GrafanaInstance) Deploy(t *task.Builder, srcPath string, deployDir string, version string, clusterName string, clusterVersion string) {
 	t.CopyComponent(
 		i.ComponentName(),
 		i.OS(),
 		i.Arch(),
 		version,
-		"", // use default srcPath
+		srcPath,
 		i.GetHost(),
 		deployDir,
 	).Shell( // rm the json file which relate to tidb cluster and useless.

--- a/components/dm/spec/prometheus.go
+++ b/components/dm/spec/prometheus.go
@@ -135,13 +135,13 @@ func (i *MonitorInstance) ScaleConfig(e executor.Executor, topo spec.Topology,
 var _ cluster.DeployerInstance = &MonitorInstance{}
 
 // Deploy implements DeployerInstance interface.
-func (i *MonitorInstance) Deploy(t *task.Builder, deployDir string, version string, _ string, clusterVersion string) {
+func (i *MonitorInstance) Deploy(t *task.Builder, srcPath string, deployDir string, version string, _ string, clusterVersion string) {
 	t.CopyComponent(
 		i.ComponentName(),
 		i.OS(),
 		i.Arch(),
 		version,
-		"", // use default srcPath
+		srcPath,
 		i.GetHost(),
 		deployDir,
 	).Shell( // rm the rules file which relate to tidb cluster and useless.

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -730,20 +730,24 @@ func (m *Manager) Upgrade(clusterName string, clusterVersion string, opt operato
 			// backup files of the old version
 			tb = tb.BackupComponent(inst.ComponentName(), base.Version, inst.GetHost(), deployDir)
 
-			// copy dependency component if needed
-			switch inst.ComponentName() {
-			case spec.ComponentTiSpark:
-				tb = tb.DeploySpark(inst, version, "" /* default srcPath */, deployDir, m.bindVersion)
-			default:
-				tb = tb.CopyComponent(
-					inst.ComponentName(),
-					inst.OS(),
-					inst.Arch(),
-					version,
-					"", // use default srcPath
-					inst.GetHost(),
-					deployDir,
-				)
+			if deployerInstance, ok := inst.(DeployerInstance); ok {
+				deployerInstance.Deploy(tb, "", deployDir, version, clusterName, clusterVersion)
+			} else {
+				// copy dependency component if needed
+				switch inst.ComponentName() {
+				case spec.ComponentTiSpark:
+					tb = tb.DeploySpark(inst, version, "" /* default srcPath */, deployDir, m.bindVersion)
+				default:
+					tb = tb.CopyComponent(
+						inst.ComponentName(),
+						inst.OS(),
+						inst.Arch(),
+						version,
+						"", // use default srcPath
+						inst.GetHost(),
+						deployDir,
+					)
+				}
 			}
 
 			tb.InitConfig(
@@ -885,7 +889,7 @@ type DeployOptions struct {
 
 // DeployerInstance is a instance can deploy to a target deploy directory.
 type DeployerInstance interface {
-	Deploy(b *task.Builder, deployDir string, version string, clusterName string, clusterVersion string)
+	Deploy(b *task.Builder, srcPath string, deployDir string, version string, clusterName string, clusterVersion string)
 }
 
 // Deploy a cluster.
@@ -1040,7 +1044,7 @@ func (m *Manager) Deploy(
 			Mkdir(globalOptions.User, inst.GetHost(), dataDirs...)
 
 		if deployerInstance, ok := inst.(DeployerInstance); ok {
-			deployerInstance.Deploy(t, deployDir, version, clusterName, clusterVersion)
+			deployerInstance.Deploy(t, "", deployDir, version, clusterName, clusterVersion)
 		} else {
 			// copy dependency component if needed
 			switch inst.ComponentName() {
@@ -1738,20 +1742,24 @@ func buildScaleOutTask(
 			srcPath = specManager.Path(clusterName, spec.PatchDirName, inst.ComponentName()+".tar.gz")
 		}
 
-		// copy dependency component if needed
-		switch inst.ComponentName() {
-		case spec.ComponentTiSpark:
-			tb = tb.DeploySpark(inst, version, srcPath, deployDir, m.bindVersion)
-		default:
-			tb.CopyComponent(
-				inst.ComponentName(),
-				inst.OS(),
-				inst.Arch(),
-				version,
-				srcPath,
-				inst.GetHost(),
-				deployDir,
-			)
+		if deployerInstance, ok := inst.(DeployerInstance); ok {
+			deployerInstance.Deploy(tb, srcPath, deployDir, version, clusterName, version)
+		} else {
+			// copy dependency component if needed
+			switch inst.ComponentName() {
+			case spec.ComponentTiSpark:
+				tb = tb.DeploySpark(inst, version, srcPath, deployDir, m.bindVersion)
+			default:
+				tb.CopyComponent(
+					inst.ComponentName(),
+					inst.OS(),
+					inst.Arch(),
+					version,
+					srcPath,
+					inst.GetHost(),
+					deployDir,
+				)
+			}
 		}
 
 		t := tb.ScaleConfig(clusterName,


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when reload or scale the altermanager.yml will be overwritten. 

### What is changed and how it works?
never overwrite altermanager.yml, only init the example config when deploying the instance.

also, handle the custom deploying an instant in upgrade and scale-out
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
deploy a cluster and update the config -> try reload -> check config file not overwritten

```release-note
NONE
```