### PR TITLE
cluster/check: fix checking of existing cluster

### DIFF
--- a/components/cluster/command/check.go
+++ b/components/cluster/command/check.go
@@ -184,6 +184,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, op
 
 			// build checking tasks
 			t2 := task.NewBuilder().
+				// check for general system info
 				CheckSys(
 					inst.GetHost(),
 					"",
@@ -198,39 +199,46 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, op
 					topo,
 					opt.opr,
 				).
+				// check for listening port
 				Shell(
 					inst.GetHost(),
 					"ss -lnt",
 					false,
-				).CheckSys(
-				inst.GetHost(),
-				"",
-				task.CheckTypePort,
-				topo,
-				opt.opr,
-			).
+				).
+				CheckSys(
+					inst.GetHost(),
+					"",
+					task.CheckTypePort,
+					topo,
+					opt.opr,
+				).
+				// check for system limits
 				Shell(
 					inst.GetHost(),
 					"cat /etc/security/limits.conf",
 					false,
-				).CheckSys(
-				inst.GetHost(),
-				"",
-				task.CheckTypeSystemLimits,
-				topo,
-				opt.opr,
-			).
+				).
+				CheckSys(
+					inst.GetHost(),
+					"",
+					task.CheckTypeSystemLimits,
+					topo,
+					opt.opr,
+				).
+				// check for kernel params
 				Shell(
 					inst.GetHost(),
 					"sysctl -a",
 					true,
-				).CheckSys(
-				inst.GetHost(),
-				"",
-				task.CheckTypeSystemConfig,
-				topo,
-				opt.opr,
-			).
+				).
+				CheckSys(
+					inst.GetHost(),
+					"",
+					task.CheckTypeSystemConfig,
+					topo,
+					opt.opr,
+				).
+				// check for needed system service
 				CheckSys(
 					inst.GetHost(),
 					"",
@@ -238,6 +246,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, op
 					topo,
 					opt.opr,
 				).
+				// check for needed packages
 				CheckSys(
 					inst.GetHost(),
 					"",

--- a/components/cluster/command/check.go
+++ b/components/cluster/command/check.go
@@ -78,6 +78,8 @@ conflict checks with other clusters`,
 				if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) {
 					return err
 				}
+				opt.user = metadata.User
+				opt.identityFile = tidbSpec.Path(clusterName, "ssh", "id_rsa")
 
 				topo = *metadata.Topology
 			} else { // check before cluster is deployed
@@ -180,86 +182,88 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, op
 				BuildAsStep(fmt.Sprintf("  - Getting system info of %s:%d", inst.GetHost(), inst.GetSSHPort()))
 			collectTasks = append(collectTasks, t1)
 
+			// build checking tasks
+			t2 := task.NewBuilder().
+				CheckSys(
+					inst.GetHost(),
+					"",
+					task.CheckTypeSystemInfo,
+					topo,
+					opt.opr,
+				).
+				CheckSys(
+					inst.GetHost(),
+					"",
+					task.CheckTypePartitions,
+					topo,
+					opt.opr,
+				).
+				Shell(
+					inst.GetHost(),
+					"ss -lnt",
+					false,
+				).CheckSys(
+				inst.GetHost(),
+				"",
+				task.CheckTypePort,
+				topo,
+				opt.opr,
+			).
+				Shell(
+					inst.GetHost(),
+					"cat /etc/security/limits.conf",
+					false,
+				).CheckSys(
+				inst.GetHost(),
+				"",
+				task.CheckTypeSystemLimits,
+				topo,
+				opt.opr,
+			).
+				Shell(
+					inst.GetHost(),
+					"sysctl -a",
+					true,
+				).CheckSys(
+				inst.GetHost(),
+				"",
+				task.CheckTypeSystemConfig,
+				topo,
+				opt.opr,
+			).
+				CheckSys(
+					inst.GetHost(),
+					"",
+					task.CheckTypeService,
+					topo,
+					opt.opr,
+				).
+				CheckSys(
+					inst.GetHost(),
+					"",
+					task.CheckTypePackage,
+					topo,
+					opt.opr,
+				)
+
 			// if the data dir set in topology is relative, and the home dir of deploy user
 			// and the user run the check command is on different partitions, the disk detection
 			// may be using incorrect partition for validations.
 			for _, dataDir := range clusterutil.MultiDirAbs(opt.user, inst.DataDir()) {
 				// build checking tasks
-				t2 := task.NewBuilder().
-					CheckSys(
-						inst.GetHost(),
-						dataDir,
-						task.CheckTypeSystemInfo,
-						topo,
-						opt.opr,
-					).
-					CheckSys(
-						inst.GetHost(),
-						dataDir,
-						task.CheckTypePartitions,
-						topo,
-						opt.opr,
-					).
-					Shell(
-						inst.GetHost(),
-						"ss -lnt",
-						false,
-					).
-					CheckSys(
-						inst.GetHost(),
-						dataDir,
-						task.CheckTypePort,
-						topo,
-						opt.opr,
-					).
-					Shell(
-						inst.GetHost(),
-						"cat /etc/security/limits.conf",
-						false,
-					).
-					CheckSys(
-						inst.GetHost(),
-						dataDir,
-						task.CheckTypeSystemLimits,
-						topo,
-						opt.opr,
-					).
-					Shell(
-						inst.GetHost(),
-						"sysctl -a",
-						true,
-					).
-					CheckSys(
-						inst.GetHost(),
-						dataDir,
-						task.CheckTypeSystemConfig,
-						topo,
-						opt.opr,
-					).
-					CheckSys(
-						inst.GetHost(),
-						dataDir,
-						task.CheckTypeService,
-						topo,
-						opt.opr,
-					).
-					CheckSys(
-						inst.GetHost(),
-						dataDir,
-						task.CheckTypePackage,
-						topo,
-						opt.opr,
-					).
+				t2 = t2.
 					CheckSys(
 						inst.GetHost(),
 						dataDir,
 						task.CheckTypeFIO,
 						topo,
 						opt.opr,
-					).
-					BuildAsStep(fmt.Sprintf("  - Checking node %s", inst.GetHost()))
-				checkSysTasks = append(checkSysTasks, t2)
+					)
 			}
+			checkSysTasks = append(
+				checkSysTasks,
+				t2.BuildAsStep(fmt.Sprintf("  - Checking node %s", inst.GetHost())),
+			)
 
 			t3 := task.NewBuilder().
 				RootSSH(

--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -459,19 +459,20 @@ func CheckListeningPort(opt *CheckOptions, host string, topo *spec.Specification
 		}
 	})
 
-	for _, line := range strings.Split(string(rawData), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 5 || fields[0] != "LISTEN" {
-			continue
-		}
-		addr := strings.Split(fields[3], ":")
-		lp, _ := strconv.Atoi(addr[len(addr)-1])
-		for p := range ports {
+	for p := range ports {
+		for _, line := range strings.Split(string(rawData), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 5 || fields[0] != "LISTEN" {
+				continue
+			}
+			addr := strings.Split(fields[3], ":")
+			lp, _ := strconv.Atoi(addr[len(addr)-1])
 			if p == lp {
 				results = append(results, &CheckResult{
 					Name: CheckNamePortListen,
 					Err:  fmt.Errorf("port %d is already in use", lp),
 				})
+				break // ss may report multiple entries for the same port
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
 - `check` sub command is not working properly with existing cluster
 - checks are not performed for instance with no data dir defined

### What is changed and how it works?
 - Fix credential settings for existing clusters
 - Handle data dir properly
 - `ss -ltn` may report multiple records for on port (with different fd, may because of `TCP_PORT_REUSE`), only one is enough for the check

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Side effects
None

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```