### PR TITLE
cluster: set owner to current user when decompressing tarballs

### DIFF
--- a/components/dm/spec/grafana.go
+++ b/components/dm/spec/grafana.go
@@ -187,7 +187,7 @@ func (i *GrafanaInstance) Deploy(t *task.Builder, srcPath string, deployDir stri
 			return errors.AddStack(err)
 		}
 
-		cmd := fmt.Sprintf(`tar -xzf %s -C %s && rm %s`, dstPath, tmp, dstPath)
+		cmd := fmt.Sprintf(`tar --no-same-owner -zxf %s -C %s && rm %s`, dstPath, tmp, dstPath)
 		_, stderr, err = e.Execute(cmd, false)
 		if err != nil {
 			return errors.Annotatef(err, "stderr: %s", string(stderr))

--- a/components/dm/spec/prometheus.go
+++ b/components/dm/spec/prometheus.go
@@ -165,7 +165,7 @@ func (i *MonitorInstance) Deploy(t *task.Builder, srcPath string, deployDir stri
 			return errors.AddStack(err)
 		}
 
-		cmd := fmt.Sprintf(`tar -xzf %s -C %s && rm %s`, dstPath, tmp, dstPath)
+		cmd := fmt.Sprintf(`tar --no-same-owner -zxf %s -C %s && rm %s`, dstPath, tmp, dstPath)
 		_, stderr, err = e.Execute(cmd, false)
 		if err != nil {
 			return errors.Annotatef(err, "stderr: %s", string(stderr))

--- a/pkg/cluster/operation/telemetry.go
+++ b/pkg/cluster/operation/telemetry.go
@@ -89,7 +89,7 @@ func GetNodeInfo(
 			}
 
 			// get node info by exec _telemetry node_info at remote instance.
-			cmd := fmt.Sprintf(`tar -xzf %s -C %s && rm %s`, dstPath, dstDir, dstPath)
+			cmd := fmt.Sprintf(`tar --no-same-owner -zxf %s -C %s && rm %s`, dstPath, dstDir, dstPath)
 			_, stderr, err := exec.Execute(cmd, false)
 			if err != nil {
 				return errors.Annotatef(err, "stderr: %s", string(stderr))

--- a/pkg/cluster/task/install_package.go
+++ b/pkg/cluster/task/install_package.go
@@ -45,7 +45,7 @@ func (c *InstallPackage) Execute(ctx *Context) error {
 		return errors.Annotatef(err, "failed to scp %s to %s:%s", c.srcPath, c.host, dstPath)
 	}
 
-	cmd := fmt.Sprintf(`tar -xzf %s -C %s && rm %s`, dstPath, dstDir, dstPath)
+	cmd := fmt.Sprintf(`tar --no-same-owner -zxf %s -C %s && rm %s`, dstPath, dstDir, dstPath)
 
 	_, stderr, err := exec.Execute(cmd, false)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Make sure the decompressed files are owned by the current user

### What is changed and how it works?
Add `--no-same-owner` flag to `tar` command when decompressing

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has persistent data change

Side effects
None

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```