### PR TITLE
Fix showing  misleading usage for cluster and dm

### DIFF
--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -121,9 +121,6 @@ func init() {
 
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			return tiupmeta.GlobalEnv().V1Repository().Mirror().Close()
 		},

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -96,9 +96,6 @@ func init() {
 
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			return tiupmeta.GlobalEnv().V1Repository().Mirror().Close()
 		},

--- a/components/dm/main.go
+++ b/components/dm/main.go
@@ -13,8 +13,12 @@
 
 package main
 
-import "github.com/pingcap/tiup/components/dm/command"
+import (
+	"github.com/pingcap/tiup/components/dm/command"
+	"github.com/pingcap/tiup/pkg/cliutil"
+)
 
 func main() {
+	cliutil.RegisterArg0("tiup dm")
 	command.Execute()
 }

--- a/pkg/cliutil/cliutil.go
+++ b/pkg/cliutil/cliutil.go
@@ -39,10 +39,17 @@ var templateFuncs = template.FuncMap{
 	"OsArgs0": OsArgs0,
 }
 
+// FIXME: We should use TiUp's arg0 instead of hardcode
+var arg0 = "tiup cluster"
+
+// RegisterArg0 register arg0
+func RegisterArg0(s string) {
+	arg0 = s
+}
+
 func args() []string {
 	if wd := os.Getenv(localdata.EnvNameWorkDir); wd != "" {
-		// FIXME: We should use TiUp's arg0 instead of hardcode
-		return append([]string{"tiup cluster"}, os.Args[1:]...)
+		return append([]string{arg0}, os.Args[1:]...)
 	}
 	return os.Args
 }
@@ -117,7 +124,7 @@ func SuggestionFromFormat(format string, a ...interface{}) (errorx.Property, str
 // BeautifyCobraUsageAndHelp beautifies cobra usages and help.
 func BeautifyCobraUsageAndHelp(rootCmd *cobra.Command) {
 	s := `Usage:{{if .Runnable}}
-  {{ColorCommand}}{{tiupUseLine .UseLine}}{{ColorReset}}{{end}}{{if .HasAvailableSubCommands}}
+  {{ColorCommand}}{{.UseLine}}{{ColorReset}}{{end}}{{if .HasAvailableSubCommands}}
   {{ColorCommand}}{{tiupCmdPath .Use}} [command]{{ColorReset}}{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
@@ -140,19 +147,9 @@ Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 
 Use "{{ColorCommand}}{{tiupCmdPath .Use}} help [command]{{ColorReset}}" for more information about a command.{{end}}
 `
-	cobra.AddTemplateFunc("tiupUseLine", cmdUseLine)
 	cobra.AddTemplateFunc("tiupCmdPath", cmdPath)
 
 	rootCmd.SetUsageTemplate(s)
-}
-
-// cmdUseLine is a customized cobra.Command.UseLine()
-func cmdUseLine(useline string) string {
-	i := strings.Index(useline, " ")
-	if i > 0 {
-		return OsArgs0() + useline[i:]
-	}
-	return useline
 }
 
 // cmdPath is a customized cobra.Command.CommandPath()


### PR DESCRIPTION
Set the magic arg0 for dm. Remove RunE for both cluster and dm because
they are just not runable. Remove the wrong custom UseLine although we nolonger
show it.(the raw useline we get "tiup cluster [flags]", the custom
useline will be "tiup cluster cluster [flags]")

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix https://github.com/pingcap/tiup/issues/703

### What is changed and how it works?
    Set the magic arg0 for dm. Remove RunE for both cluster and dm because
    they are just not runable. Remove the wrong custom UseLine although we nolonger
    show it.(the raw useline we get "tiup cluster [flags]", the custom
    useline will be "tiup cluster cluster [flags]")

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
 
<img width="279" alt="Screen Shot 2020-08-26 at 7 17 43 PM" src="https://user-images.githubusercontent.com/1681864/91298672-0074ed00-e7d3-11ea-8f67-ba3a7bf26d7c.png">
<img width="224" alt="Screen Shot 2020-08-26 at 7 18 00 PM" src="https://user-images.githubusercontent.com/1681864/91298676-02d74700-e7d3-11ea-85a3-a9d6746d2ce9.png">




Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```