### PR TITLE
Keep deploy dir for worker while import from ansible

### DIFF
--- a/components/dm/ansible/import.go
+++ b/components/dm/ansible/import.go
@@ -407,7 +407,12 @@ func (im *Importer) ImportFromAnsibleDir() (clusterName string, meta *spec.Metad
 					}
 				}
 
-				srv.DeployDir = instancDeployDir(spec.ComponentDMWorker, srv.Port, host.Vars["deploy_dir"], topo.GlobalOptions.DeployDir)
+				// Deploy dir MUST always keep the same and CAN NOT change.
+				// dm-worker will save the data in the wording directory and there's no configuration
+				// to specific the directory.
+				// We will always set the wd as DeployDir.
+				srv.DeployDir = deployDir
+
 				err = im.handleWorkerConfig(&srv, configFileName)
 				if err != nil {
 					return "", nil, errors.AddStack(err)

--- a/components/dm/ansible/import_test.go
+++ b/components/dm/ansible/import_test.go
@@ -175,7 +175,7 @@ func TestImportFromAnsible(t *testing.T) {
 		Host:      "172.19.0.101",
 		SSHPort:   22,
 		Port:      8262,
-		DeployDir: "",
+		DeployDir: "/home/tidb/deploy",
 		LogDir:    "/home/tidb/deploy/log",
 		Config:    map[string]interface{}{"log-level": "info"},
 	}

--- a/components/dm/command/import.go
+++ b/components/dm/command/import.go
@@ -81,10 +81,10 @@ func newImportCmd() *cobra.Command {
 
 			if !skipConfirm {
 				err = cliutil.PromptForConfirmOrAbortError(
-					"Using the Topology to deploy DM %s cluster %s, Do you want to continue? [y/N]: ",
-					clusterVersion,
-					clusterName,
-				)
+					color.HiYellowString("Using the Topology to deploy DM %s cluster %s, Please Stop the DM cluster from ansible side first.\nDo you want to continue? [y/N]: ",
+						clusterVersion,
+						clusterName,
+					))
 				if err != nil {
 					return errors.AddStack(err)
 				}
@@ -116,7 +116,9 @@ func newImportCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&ansibleDir, "dir", "d", "./", "The path to DM-Ansible directory")
 	cmd.Flags().StringVar(&inventoryFileName, "inventory", cansible.AnsibleInventoryFile, "The name of inventory file")
 	cmd.Flags().StringVarP(&rename, "rename", "r", "", "Rename the imported cluster to `NAME`")
-	cmd.Flags().StringVarP(&clusterVersion, "cluster-version", "v", "nightly", "cluster version of DM")
+	cmd.Flags().StringVarP(&clusterVersion, "cluster-version", "v", "", "cluster version of DM to deploy")
+
+	cmd.MarkFlagRequired("cluster-version")
 
 	return cmd
 }

--- a/components/dm/command/import.go
+++ b/components/dm/command/import.go
@@ -118,7 +118,10 @@ func newImportCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&rename, "rename", "r", "", "Rename the imported cluster to `NAME`")
 	cmd.Flags().StringVarP(&clusterVersion, "cluster-version", "v", "", "cluster version of DM to deploy")
 
-	cmd.MarkFlagRequired("cluster-version")
+	err := cmd.MarkFlagRequired("cluster-version")
+	if err != nil { // if no this flag
+		panic(err)
+	}
 
 	return cmd
 }

--- a/tests/tiup-dm/test_import.sh
+++ b/tests/tiup-dm/test_import.sh
@@ -61,21 +61,26 @@ su tidb <<EOF
 	ansible-playbook start.yml
 EOF
 
-
-	# stop cluster if need.
-	# ansible-playbook stop.yml
 }
 
 
 function test() {
 	deploy_by_ansible
 
+	# stop cluster
+su tidb <<EOF
+	cd /home/tidb/dm-ansible
+	ansible-playbook stop.yml
+EOF
+
+	# set up tiup root for tidb user
 	mkdir -p /home/tidb/.tiup/bin
 	cp /root/.tiup/bin/root.json /home/tidb/.tiup/bin/
 	chown -R tidb:tidb /home/tidb/.tiup
 
+	# import ans start new cluster
 su tidb <<EOF
-	tiup-dm --yes import --dir /home/tidb/dm-ansible
+	tiup-dm --yes import --dir /home/tidb/dm-ansible --cluster-version v2.0.0-rc
 	tiup-dm --yes start test-cluster
 	tiup-dm --yes destroy test-cluster
 EOF


### PR DESCRIPTION


<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
dm-worker 1.0 will write some data  at  {wd}/dm_worker_meta.
and 2.0 bootstrap need this directory(after bootstrap, this directory will be deleted by worker)
So we must always keep using the same wd when upgrade to 2.0

### What is changed and how it works?
Deploy dir MUST always keep the same and CAN NOT change.
dm-worker will save the data in the wording directory and there's no configuration
to specify the directory.
We will always set the wd as DeployDir.

also, mark `cluster-version` required instead of nightly default.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
 




Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```