### PR TITLE
Display checking state using bar

### DIFF
--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/components/playground/instance"
+	"github.com/pingcap/tiup/pkg/cliutil/progress"
 	"github.com/pingcap/tiup/pkg/cluster/api"
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/localdata"
@@ -242,12 +243,12 @@ func tryConnect(dsn string) error {
 	return nil
 }
 
+// checkDB check if the addr is connectable by getting a connection from sql.DB.
 func checkDB(dbAddr string) bool {
 	dsn := fmt.Sprintf("root:@tcp(%s)/", dbAddr)
 	for i := 0; i < 60; i++ {
 		if err := tryConnect(dsn); err != nil {
 			time.Sleep(time.Second)
-			fmt.Print(".")
 		} else {
 			if i != 0 {
 				fmt.Println()
@@ -259,18 +260,30 @@ func checkDB(dbAddr string) bool {
 }
 
 func checkStoreStatus(pdClient *api.PDClient, typ, storeAddr string) error {
-	fmt.Print(color.YellowString("Waiting for %s %s ready ", typ, storeAddr))
+	prefix := color.YellowString("Waiting for %s %s ready ", typ, storeAddr)
+	bar := progress.NewSingleBar(prefix)
+	bar.StartRenderLoop()
+	defer bar.StopRenderLoop()
+
 	for i := 0; i < 180; i++ {
 		up, err := pdClient.IsUp(storeAddr)
 		if err != nil || !up {
 			time.Sleep(time.Second)
-			fmt.Print(color.YellowString("."))
 		} else {
-			fmt.Println()
+			bar.UpdateDisplay(&progress.DisplayProps{
+				Prefix: prefix,
+				Mode:   progress.ModeDone,
+			})
 			return nil
 		}
 	}
-	return fmt.Errorf(fmt.Sprintf("store %s failed to up after timeout(180s)", storeAddr))
+
+	bar.UpdateDisplay(&progress.DisplayProps{
+		Prefix: prefix,
+		Mode:   progress.ModeError,
+	})
+
+	return errors.Errorf(fmt.Sprintf("store %s failed to up after timeout(180s)", storeAddr))
 }
 
 func hasDashboard(pdAddr string) bool {

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -784,7 +784,7 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 
 	var succ []string
 	for _, db := range p.tidbs {
-		prefix := "Check DB " + db.Addr()
+		prefix := color.YellowString("Waiting for tidb %s ready ", db.Addr())
 		bar := progress.NewSingleBar(prefix)
 		bar.StartRenderLoop()
 		if s := checkDB(db.Addr()); s {

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -35,6 +35,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/components/playground/instance"
+	"github.com/pingcap/tiup/pkg/cliutil/progress"
 	"github.com/pingcap/tiup/pkg/cluster/api"
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/localdata"
@@ -401,7 +402,7 @@ func (p *Playground) sanitizeComponentConfig(cid string, cfg *instance.Config) e
 }
 
 func (p *Playground) startInstance(ctx context.Context, inst instance.Instance) error {
-	fmt.Printf("Start %s instance...\n", inst.Component())
+	fmt.Printf("Start %s instance\n", inst.Component())
 	err := inst.Start(ctx, v0manifest.Version(p.bootOptions.version))
 	if err != nil {
 		return errors.AddStack(err)
@@ -783,68 +784,75 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 
 	var succ []string
 	for _, db := range p.tidbs {
+		prefix := "Check DB " + db.Addr()
+		bar := progress.NewSingleBar(prefix)
+		bar.StartRenderLoop()
 		if s := checkDB(db.Addr()); s {
 			succ = append(succ, db.Addr())
+			bar.UpdateDisplay(&progress.DisplayProps{
+				Prefix: prefix,
+				Mode:   progress.ModeDone,
+			})
+		} else {
+			bar.UpdateDisplay(&progress.DisplayProps{
+				Prefix: prefix,
+				Mode:   progress.ModeError,
+			})
 		}
+		bar.StopRenderLoop()
 	}
 
 	if len(succ) > 0 {
 		// start TiFlash after at least one TiDB is up.
-		var lastErr error
-
-		var endpoints []string
-		for _, pd := range p.pds {
-			endpoints = append(endpoints, pd.Addr())
-		}
-		pdClient := api.NewPDClient(endpoints, 10*time.Second, nil)
-
-		// make sure TiKV are all up
-		for _, kv := range p.tikvs {
-			if err := checkStoreStatus(pdClient, "tikv", kv.StoreAddr()); err != nil {
-				lastErr = err
-				break
+		startTiFlash := func() error {
+			var endpoints []string
+			for _, pd := range p.pds {
+				endpoints = append(endpoints, pd.Addr())
 			}
-		}
+			pdClient := api.NewPDClient(endpoints, 10*time.Second, nil)
 
-		if lastErr == nil {
-			for _, flash := range p.tiflashs {
-				if err := p.startInstance(ctx, flash); err != nil {
-					lastErr = err
-					break
+			// make sure TiKV are all up
+			for _, kv := range p.tikvs {
+				if err := checkStoreStatus(pdClient, "tikv", kv.StoreAddr()); err != nil {
+					return err
 				}
 			}
-		}
 
-		if lastErr == nil {
+			for _, flash := range p.tiflashs {
+				if err := p.startInstance(ctx, flash); err != nil {
+					return err
+				}
+			}
+
 			// check if all TiFlash is up
 			for _, flash := range p.tiflashs {
 				cmd := flash.Cmd()
 				if cmd == nil {
-					lastErr = errors.Errorf("tiflash %s initialize command failed", flash.StoreAddr())
-					break
+					return errors.Errorf("tiflash %s initialize command failed", flash.StoreAddr())
 				}
 				if state := cmd.ProcessState; state != nil && state.Exited() {
-					lastErr = errors.Errorf("tiflash process exited with code: %d", state.ExitCode())
-					break
+					return errors.Errorf("tiflash process exited with code: %d", state.ExitCode())
 				}
 				if err := checkStoreStatus(pdClient, "tiflash", flash.StoreAddr()); err != nil {
-					lastErr = err
-					break
+					return err
 				}
 			}
-		}
 
-		if lastErr != nil {
-			fmt.Println(color.RedString("TiFlash failed to start. %s", lastErr))
+			return nil
 		}
-
-		if len(succ) > 0 {
-			fmt.Println(color.GreenString("CLUSTER START SUCCESSFULLY, Enjoy it ^-^"))
-			for _, dbAddr := range succ {
-				ss := strings.Split(dbAddr, ":")
-				fmt.Println(color.GreenString("To connect TiDB: mysql --host %s --port %s -u root", ss[0], ss[1]))
+		if len(p.tiflashs) > 0 {
+			err := startTiFlash()
+			if err != nil {
+				fmt.Println(color.RedString("TiFlash failed to start: %s", err))
 			}
 		}
+
+		fmt.Println(color.GreenString("CLUSTER START SUCCESSFULLY, Enjoy it ^-^"))
+		for _, dbAddr := range succ {
+			ss := strings.Split(dbAddr, ":")
+			fmt.Println(color.GreenString("To connect TiDB: mysql --host %s --port %s -u root", ss[0], ss[1]))
+		}
+
 	}
 
 	if pdAddr := p.pds[0].Addr(); hasDashboard(pdAddr) {

--- a/pkg/cliutil/progress/example_single_bar_test.go
+++ b/pkg/cliutil/progress/example_single_bar_test.go
@@ -1,0 +1,50 @@
+package progress_test
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiup/pkg/cliutil/progress"
+)
+
+func ExampleSingleBar() {
+	b := progress.NewSingleBar("Prefix")
+
+	b.UpdateDisplay(&progress.DisplayProps{
+		Prefix: "Prefix",
+		Suffix: "Suffix",
+	})
+
+	n := 3
+
+	go func() {
+		time.Sleep(time.Second)
+		for i := 0; i < n; i++ {
+			b.UpdateDisplay(&progress.DisplayProps{
+				Prefix: "Prefix" + strconv.Itoa(i),
+				Suffix: "Suffix" + strconv.Itoa(i),
+			})
+			time.Sleep(time.Second)
+		}
+	}()
+
+	b.StartRenderLoop()
+
+	time.Sleep(time.Second * time.Duration(n+1))
+
+	b.UpdateDisplay(&progress.DisplayProps{
+		Mode: progress.ModeDone,
+		// Mode:   progress.ModeError,
+		Prefix: "Prefix",
+	})
+
+	b.StopRenderLoop()
+}
+
+func TestExampleOutput(t *testing.T) {
+	if !testing.Verbose() {
+		return
+	}
+	ExampleSingleBar()
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #719 

### What is changed and how it works?
Using a single bar when checking db or kv/tiflash status.

This pr also adds an example for the single bar and simplifies code about starting tiflash by wrapping related code in a func in playground.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
<img width="336" alt="Screen Shot 2020-08-31 at 2 26 11 PM" src="https://user-images.githubusercontent.com/1681864/91689074-f87fc900-eb95-11ea-8d1c-3f80a800ebb2.png">

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```