### PR TITLE
Set Pdeathsig to kill subprocess if playground dead

### DIFF
--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tiup/components/playground/instance"
 	"github.com/pingcap/tiup/pkg/environment"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
@@ -201,7 +202,7 @@ http_port = %d
 	}
 
 	env := environment.GlobalEnv()
-	cmd, err := tiupexec.PrepareCommand(ctx, "grafana", v0manifest.Version(g.version), "", "", dir, dir, args, env)
+	cmd, err := tiupexec.PrepareCommand(ctx, "grafana", v0manifest.Version(g.version), "", "", dir, dir, args, instance.SysProcAttr, env)
 	if err != nil {
 		return errors.AddStack(err)
 	}

--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -202,7 +202,17 @@ http_port = %d
 	}
 
 	env := environment.GlobalEnv()
-	cmd, err := tiupexec.PrepareCommand(ctx, "grafana", v0manifest.Version(g.version), "", "", dir, dir, args, instance.SysProcAttr, env)
+	params := &tiupexec.PrepareCommandParams{
+		Ctx:         ctx,
+		Component:   "grafana",
+		Version:     v0manifest.Version(g.version),
+		InstanceDir: dir,
+		WD:          dir,
+		Args:        args,
+		SysProcAttr: instance.SysProcAttr,
+		Env:         env,
+	}
+	cmd, err := tiupexec.PrepareCommand(params)
 	if err != nil {
 		return errors.AddStack(err)
 	}

--- a/components/playground/instance/proc_attr_default.go
+++ b/components/playground/instance/proc_attr_default.go
@@ -1,0 +1,21 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build !linux
+
+package instance
+
+import "syscall"
+
+// SysProcAttr to be use for every Process we start.
+var SysProcAttr *syscall.SysProcAttr = nil

--- a/components/playground/instance/proc_attr_linux.go
+++ b/components/playground/instance/proc_attr_linux.go
@@ -1,0 +1,23 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build linux
+
+package instance
+
+import "syscall"
+
+// SysProcAttr to be use for every Process we start.
+var SysProcAttr = &syscall.SysProcAttr{
+	Pdeathsig: syscall.SIGKILL,
+}

--- a/components/playground/instance/process.go
+++ b/components/playground/instance/process.go
@@ -91,7 +91,18 @@ func NewComponentProcess(ctx context.Context, dir, binPath, component string, ve
 	}
 
 	env := environment.GlobalEnv()
-	cmd, err := tiupexec.PrepareCommand(ctx, component, version, binPath, "", dir, dir, arg, SysProcAttr, env)
+	params := &tiupexec.PrepareCommandParams{
+		Ctx:         ctx,
+		Component:   component,
+		Version:     version,
+		BinPath:     binPath,
+		InstanceDir: dir,
+		WD:          dir,
+		Args:        arg,
+		SysProcAttr: SysProcAttr,
+		Env:         env,
+	}
+	cmd, err := tiupexec.PrepareCommand(params)
 	if err != nil {
 		return nil, err
 	}

--- a/components/playground/instance/process.go
+++ b/components/playground/instance/process.go
@@ -91,7 +91,7 @@ func NewComponentProcess(ctx context.Context, dir, binPath, component string, ve
 	}
 
 	env := environment.GlobalEnv()
-	cmd, err := tiupexec.PrepareCommand(ctx, component, version, binPath, "", dir, dir, arg, env)
+	cmd, err := tiupexec.PrepareCommand(ctx, component, version, binPath, "", dir, dir, arg, SysProcAttr, env)
 	if err != nil {
 		return nil, err
 	}

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -168,11 +168,6 @@ Examples:
 				}
 			}()
 
-			// TODO: we can set Pdeathsig of Cmd.SysProcAttr(linux only) in all the Cmd we started to kill
-			// all the process we start instead of let the orphaned child process adopted by init,
-			// this can make sure we kill all process event if
-			// playground is killed -9.
-			// ref: https://medium.com/@ganeshmaharaj/clean-exit-of-golangs-exec-command-897832ac3fa5
 			bootErr := p.bootCluster(ctx, env, opt)
 			if bootErr != nil {
 				// always kill all process started and wait before quit.

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -139,7 +139,17 @@ scrape_configs:
 	}
 
 	env := environment.GlobalEnv()
-	cmd, err := tiupexec.PrepareCommand(ctx, "prometheus", v0manifest.Version(version), "", "", dir, dir, args, instance.SysProcAttr, env)
+	params := &tiupexec.PrepareCommandParams{
+		Ctx:         ctx,
+		Component:   "prometheus",
+		Version:     v0manifest.Version(version),
+		InstanceDir: dir,
+		WD:          dir,
+		Args:        args,
+		SysProcAttr: instance.SysProcAttr,
+		Env:         env,
+	}
+	cmd, err := tiupexec.PrepareCommand(params)
 	if err != nil {
 		return nil, err
 	}

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tiup/components/playground/instance"
 	"github.com/pingcap/tiup/pkg/environment"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
@@ -138,7 +139,7 @@ scrape_configs:
 	}
 
 	env := environment.GlobalEnv()
-	cmd, err := tiupexec.PrepareCommand(ctx, "prometheus", v0manifest.Version(version), "", "", dir, dir, args, env)
+	cmd, err := tiupexec.PrepareCommand(ctx, "prometheus", v0manifest.Version(version), "", "", dir, dir, args, instance.SysProcAttr, env)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -137,6 +137,7 @@ func PrepareCommand(
 	version v0manifest.Version,
 	binPath, tag, instanceDir string, wd string,
 	args []string,
+	sysProcAttr *syscall.SysProcAttr,
 	env *environment.Environment,
 	checkUpdate ...bool,
 ) (*exec.Cmd, error) {
@@ -226,6 +227,7 @@ func PrepareCommand(
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	c.Dir = wd
+	c.SysProcAttr = sysProcAttr
 
 	return c, nil
 }
@@ -240,7 +242,7 @@ func launchComponent(ctx context.Context, component string, version v0manifest.V
 		instanceDir = env.LocalPath(localdata.DataParentDir, tag)
 	}
 
-	c, err := PrepareCommand(ctx, component, version, binPath, tag, instanceDir, "" /*wd*/, args, env, true)
+	c, err := PrepareCommand(ctx, component, version, binPath, tag, instanceDir, "" /*wd*/, args, nil, env, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #720 
Set Pdeathsig to kill subprocess if playground dead
### What is changed and how it works?
After this pr, if playground dead and some subprocess still running,
the subprocess will be killed by OS instead of becoming an orphaned child
adopted by init. This feature is linux only.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
before this pr:
<img width="1582" alt="Screen Shot 2020-08-31 at 2 57 45 PM" src="https://user-images.githubusercontent.com/1681864/91694467-27e70380-eb9f-11ea-82fb-e7e97ee60aee.png">
after this pr:
<img width="1915" alt=" " src="https://user-images.githubusercontent.com/1681864/91694634-798f8e00-eb9f-11ea-9761-7c03cd4e941a.png">





Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Set Pdeathsig to kill subprocess if playground dead
```