### PR TITLE
server/handler: MaxFileSize -> MaxMemory

### DIFF
--- a/server/handler/tarball.go
+++ b/server/handler/tarball.go
@@ -22,8 +22,8 @@ import (
 	"github.com/pingcap/tiup/server/session"
 )
 
-// MaxFileSize is the max size content can be uploaded
-const MaxFileSize = 32 * 1024 * 1024
+// MaxMemory is the a total of max bytes of its file parts stored in memory
+const MaxMemory = 32 * 1024 * 1024
 
 // UploadTarbal handle tarball upload
 func UploadTarbal(sm session.Manager) http.Handler {
@@ -59,7 +59,7 @@ func (h *tarballUploader) upload(r *http.Request) (*simpleResponse, statusError)
 
 	txn := h.sm.Load(sid)
 
-	if err := r.ParseMultipartForm(MaxFileSize); err != nil {
+	if err := r.ParseMultipartForm(MaxMemory); err != nil {
 		// TODO: log error here
 		return nil, ErrorInvalidTarball
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This variable name is different from its real context and is misleading, the doc of  [`func (r *Request) ParseMultipartForm(maxMemory int64) error`]( https://github.com/golang/go/blob/master/src/net/http/request.go#L1271-L1277) as below:

> // ParseMultipartForm parses a request body as multipart/form-data.
// The whole request body is parsed and up to a total of maxMemory bytes of
// its file parts are stored in memory, with the remainder stored on
// disk in temporary files.
// ParseMultipartForm calls ParseForm if necessary.
// After one call to ParseMultipartForm, subsequent calls have no effect.


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```