### PR TITLE
fix(docker): ompatible with macOS's echo

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -9,15 +9,15 @@ set -o nounset
 # set -o xtrace
 
 ERROR() {
-    /bin/echo -e "\e[101m\e[97m[ERROR]\e[49m\e[39m" "$@"
+    echo -e "\e[101m\e[97m[ERROR]\e[49m\e[39m" "$@"
 }
 
 WARNING() {
-    /bin/echo -e "\e[101m\e[97m[WARNING]\e[49m\e[39m" "$@"
+    echo -e "\e[101m\e[97m[WARNING]\e[49m\e[39m" "$@"
 }
 
 INFO() {
-    /bin/echo -e "\e[104m\e[97m[INFO]\e[49m\e[39m" "$@"
+    echo -e "\e[104m\e[97m[INFO]\e[49m\e[39m" "$@"
 }
 
 exists() {
@@ -123,14 +123,14 @@ if [ -z "${DEV}" ]; then
     # Dockerfile does not allow `ADD ..`. So we need to copy it here in setup.
     INFO "Copying .. to control/tiup-cluster"
     (
-		# TODO support exclude-ignore, check version of tar support this.
-		# https://www.gnu.org/software/tar/manual/html_section/tar_48.html#IDX408
+        # TODO support exclude-ignore, check version of tar support this.
+        # https://www.gnu.org/software/tar/manual/html_section/tar_48.html#IDX408
         # (cd ..; tar --exclude=./docker --exclude=./.git --exclude-ignore=.gitignore -cf - .)  | tar Cxf ./control/tiup-cluster -
         (cd ..; tar --exclude=./docker --exclude=./.git -cf - .)  | tar Cxf ./control/tiup-cluster -
     )
 else
-	INFO "Build tiup-cluster in $TIUP_CLUSTER_ROOT"
-	(cd $TIUP_CLUSTER_ROOT;make failpoint-enable;GOOS=linux GOARCH=amd64 make cluster dm;make failpoint-disable)
+    INFO "Build tiup-cluster in $TIUP_CLUSTER_ROOT"
+    (cd $TIUP_CLUSTER_ROOT;make failpoint-enable;GOOS=linux GOARCH=amd64 make cluster dm;make failpoint-disable)
 fi
 
 if [ "${INIT_ONLY}" -eq 1 ]; then


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The `/bin/echo` in macOS defaults to BSD's, and which can't print out a message with the colorful output:

![image](https://user-images.githubusercontent.com/29431502/92007046-05f4a900-ed78-11ea-8a6a-b913ea314928.png)


_ps_: If you want to use colorful echo output in macOS, you can install `coreutils` and put the binutils  first in PATH

```bash
brew install coreutils
export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
```


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```