### PR TITLE
Feature/download in stream mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ bin/
 /tests/tiup_mirrors/
 /logs
 docker/secret/
+*__failpoint_binding__.go
+*__failpoint_stash__

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ tools/bin/failpoint-ctl: go.mod
 	$(GO) build -o $@ github.com/pingcap/failpoint/failpoint-ctl
 
 pkger:
-	 $(GO) run tools/pkger/main.go -s templates -d pkg/cluster/embed
+	$(GO) run tools/pkger/main.go -s templates -d pkg/cluster/embed
 
 fmt:
 	@echo "gofmt (simplify)"
@@ -121,4 +121,3 @@ tools/bin/revive: tools/check/go.mod
 
 tools/bin/golangci-lint:
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.27.0
-

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -43,6 +43,7 @@ type testCmdSuite struct {
 func (s *testCmdSuite) SetUpSuite(c *C) {
 	s.testDir = filepath.Join(currentDir(), "testdata")
 	s.mirror = repository.NewMirror(s.testDir, repository.MirrorOptions{})
+	_ = s.mirror.Open()
 }
 
 /*

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -12,6 +12,7 @@ FROM golang:1.14
      apt-get install -qqy \
          dos2unix \
          default-mysql-client \
+         psmisc \
          vim # not required by tiup-cluster itself, just for ease of use
 
 

--- a/pkg/cluster/clusterutil/cluster.go
+++ b/pkg/cluster/clusterutil/cluster.go
@@ -14,7 +14,6 @@
 package clusterutil
 
 import (
-	"io"
 	"os"
 
 	"github.com/pingcap/tiup/pkg/environment"
@@ -59,19 +58,7 @@ func (r *repositoryT) DownloadComponent(comp, version, target string) error {
 		return err
 	}
 
-	reader, err := r.repo.FetchComponent(versionItem)
-	if err != nil {
-		return err
-	}
-
-	file, err := os.Create(target)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = io.Copy(file, reader)
-	return err
+	return r.repo.DownloadComponent(versionItem, target)
 }
 
 func (r *repositoryT) VerifyComponent(comp, version, target string) error {

--- a/pkg/cluster/clusterutil/cluster.go
+++ b/pkg/cluster/clusterutil/cluster.go
@@ -40,6 +40,9 @@ func NewRepository(os, arch string) (Repository, error) {
 	mirror := repository.NewMirror(environment.Mirror(), repository.MirrorOptions{
 		Progress: repository.DisableProgress{},
 	})
+	if err := mirror.Open(); err != nil {
+		return nil, err
+	}
 	local, err := v1manifest.NewManifests(profile)
 	if err != nil {
 		return nil, err

--- a/pkg/environment/env.go
+++ b/pkg/environment/env.go
@@ -55,7 +55,7 @@ func Mirror() string {
 	m := os.Getenv(repository.EnvMirrors)
 	if m != "" {
 		if cfg.Mirror != m {
-			fmt.Printf(`WARNING: both mirror config(%s) 
+			fmt.Printf(`WARNING: both mirror config(%s)
 and TIUP_MIRRORS(%s) have been set.
 Setting mirror to TIUP_MIRRORS(%s)
 `, cfg.Mirror, m, m)
@@ -94,6 +94,9 @@ func InitEnv(options repository.Options) (*Environment, error) {
 	// Replace the mirror if some sub-commands use different mirror address
 	mirrorAddr := Mirror()
 	mirror := repository.NewMirror(mirrorAddr, repository.MirrorOptions{})
+	if err := mirror.Open(); err != nil {
+		return nil, err
+	}
 
 	var repo *repository.Repository
 	var v1repo *repository.V1Repository

--- a/pkg/localdata/constant.go
+++ b/pkg/localdata/constant.go
@@ -78,6 +78,9 @@ const (
 	// EnvNameSCPPath is the variable name by which user can specific the executable scp binary path
 	EnvNameSCPPath = "TIUP_SCP_PATH"
 
+	// EnvNameKeepSourceTarget is the variable name by which user can keep the source target or not
+	EnvNameKeepSourceTarget = "TIUP_KEEP_SOURCE_TARGET"
+
 	// MetaFilename represents the process meta file name
 	MetaFilename = "tiup_process_meta"
 )

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -253,6 +253,10 @@ func (l *httpMirror) Download(resource, targetDir string) error {
 		return errors.Trace(err)
 	}
 	defer r.Close()
+
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return errors.Trace(err)
+	}
 	return utils.Move(tmpFilePath, dstFilePath)
 }
 

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -291,7 +291,23 @@ func (l *MockMirror) Open() error {
 
 // Download implements Mirror.
 func (l *MockMirror) Download(resource, targetDir string) error {
-	return errors.New("MockMirror::Download not implemented")
+	content, ok := l.Resources[resource]
+	if !ok {
+		return errors.Annotatef(ErrNotFound, "resource %s", resource)
+	}
+
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return err
+	}
+	target := filepath.Join(targetDir, resource)
+
+	file, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	file.Write([]byte(content))
+	return nil
 }
 
 // Fetch implements Mirror.

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -306,8 +306,8 @@ func (l *MockMirror) Download(resource, targetDir string) error {
 		return err
 	}
 	defer file.Close()
-	file.Write([]byte(content))
-	return nil
+	_, err = file.Write([]byte(content))
+	return err
 }
 
 // Fetch implements Mirror.

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -505,6 +506,14 @@ func (r *V1Repository) DownloadComponent(item *v1manifest.VersionItem, target st
 	err := r.mirror.Download(item.URL, targetDir)
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	// the downloaded file is named by item.URL, which maybe differ to target name
+	if downloaded := path.Join(targetDir, item.URL); downloaded != target {
+		err := os.Rename(downloaded, target)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	reader, err := os.Open(target)

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -20,6 +20,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -484,6 +485,24 @@ func (r *V1Repository) FetchComponent(item *v1manifest.VersionItem) (io.Reader, 
 	defer reader.Close()
 
 	return checkHash(reader, item.Hashes[v1manifest.SHA256])
+}
+
+// DoDownloadComponent downloads the component specified by item into local file
+func (r *V1Repository) DownloadComponent(item *v1manifest.VersionItem, target string) error {
+	targetDir := filepath.Dir(target)
+	err := r.mirror.Download(item.URL, targetDir)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	reader, err := os.Open(target)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	_, err = checkHash(reader, item.Hashes[v1manifest.SHA256])
+	return err
 }
 
 // FetchTimestamp downloads the timestamp file, validates it, and checks if the snapshot hash in it

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -498,7 +498,7 @@ func (r *V1Repository) FetchComponent(item *v1manifest.VersionItem) (io.Reader, 
 	return checkHash(reader, item.Hashes[v1manifest.SHA256])
 }
 
-// DoDownloadComponent downloads the component specified by item into local file
+// DownloadComponent downloads the component specified by item into local file
 func (r *V1Repository) DownloadComponent(item *v1manifest.VersionItem, target string) error {
 	targetDir := filepath.Dir(target)
 	err := r.mirror.Download(item.URL, targetDir)

--- a/pkg/repository/v1manifest/local_manifests.go
+++ b/pkg/repository/v1manifest/local_manifests.go
@@ -49,6 +49,9 @@ type LocalManifests interface {
 	// ManifestVersion opens filename, if it exists and is a manifest, returns its manifest version number. Otherwise
 	// returns 0.
 	ManifestVersion(filename string) uint
+
+	// TargetRootDir returns the root directory of target
+	TargetRootDir() string
 }
 
 // FsManifests represents a collection of v1 manifests on disk.
@@ -230,11 +233,6 @@ func (ms *FsManifests) ComponentInstalled(component, version string) (bool, erro
 
 // InstallComponent implements LocalManifests.
 func (ms *FsManifests) InstallComponent(reader io.Reader, targetDir, component, version, filename string, noExpand bool) error {
-	// TODO factor path construction to profile (also used by v0 repo).
-	if targetDir == "" {
-		targetDir = ms.profile.Path(localdata.ComponentParentDir, component, version)
-	}
-
 	if !noExpand {
 		return utils.Untar(reader, targetDir)
 	}
@@ -279,6 +277,11 @@ func (ms *FsManifests) ManifestVersion(filename string) uint {
 	}
 
 	return base.Version
+}
+
+// TargetRootDir implements LocalManifests.
+func (ms *FsManifests) TargetRootDir() string {
+	return ms.profile.Root()
 }
 
 // MockManifests is a LocalManifests implementation for testing.
@@ -390,6 +393,11 @@ func (ms *MockManifests) InstallComponent(reader io.Reader, targetDir string, co
 // KeyStore implements LocalManifests.
 func (ms *MockManifests) KeyStore() *KeyStore {
 	return ms.Ks
+}
+
+// TargetRootDir implements LocalManifests.
+func (ms *MockManifests) TargetRootDir() string {
+	return ""
 }
 
 // ManifestVersion implements LocalManifests.


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

#728 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

**The original tar.gz file is saved, not deleted, delete it or not is a question. Currently the disk layout as below:**

eg: *tispark*

```bash
(base) root@rabbit:tiup <feature/download-in-stream-mode(v1.1.0-18-gfe49c91) ✖️  ># tree ~/.tiup/components/tispark/
/home/.tiup/components/tispark/
└── v2.3.1
    ├── tispark-assembly-2.3.1.jar
    └── tispark-v2.3.1-any-any.tar.gz ## not deleted
```



Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```