### PR TITLE
update tispark example parameter spark.tispark.grpc.framesize value

### DIFF
--- a/examples/topology.example.yaml
+++ b/examples/topology.example.yaml
@@ -221,7 +221,7 @@ tispark_masters:
     #spark_config:
     #  spark.driver.memory: "2g"
     #  spark.eventLog.enabled: "False"
-    #  spark.tispark.grpc.framesize: 268435456
+    #  spark.tispark.grpc.framesize: 2147483647
     #  spark.tispark.grpc.timeout_in_sec: 100
     #  spark.tispark.meta.reload_period_in_sec: 60
     #  spark.tispark.request.command.priority: "Low"


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
the example value of parameter `spark.tispark.grpc.framesize` is too small
see https://github.com/pingcap/tispark/pull/1597

### What is changed and how it works?
let `spark.tispark.grpc.framesize` = 2147483647

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```