### PR TITLE
cliutil: set cmdLine if registered

### DIFF
--- a/components/cluster/main.go
+++ b/components/cluster/main.go
@@ -13,8 +13,12 @@
 
 package main
 
-import "github.com/pingcap/tiup/components/cluster/command"
+import (
+	"github.com/pingcap/tiup/components/cluster/command"
+	"github.com/pingcap/tiup/pkg/cliutil"
+)
 
 func main() {
+	cliutil.RegisterArg0("tiup cluster")
 	command.Execute()
 }

--- a/pkg/cliutil/cliutil.go
+++ b/pkg/cliutil/cliutil.go
@@ -124,7 +124,7 @@ func SuggestionFromFormat(format string, a ...interface{}) (errorx.Property, str
 // BeautifyCobraUsageAndHelp beautifies cobra usages and help.
 func BeautifyCobraUsageAndHelp(rootCmd *cobra.Command) {
 	s := `Usage:{{if .Runnable}}
-  {{ColorCommand}}{{.UseLine}}{{ColorReset}}{{end}}{{if .HasAvailableSubCommands}}
+  {{ColorCommand}}{{tiupCmdLine .UseLine}}{{ColorReset}}{{end}}{{if .HasAvailableSubCommands}}
   {{ColorCommand}}{{tiupCmdPath .Use}} [command]{{ColorReset}}{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
@@ -147,9 +147,19 @@ Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 
 Use "{{ColorCommand}}{{tiupCmdPath .Use}} help [command]{{ColorReset}}" for more information about a command.{{end}}
 `
+	cobra.AddTemplateFunc("tiupCmdLine", cmdLine)
 	cobra.AddTemplateFunc("tiupCmdPath", cmdPath)
 
 	rootCmd.SetUsageTemplate(s)
+}
+
+// cmdLine is a customized cobra.Command.UseLine()
+func cmdLine(useline string) string {
+	i := strings.Index(useline, " ")
+	if i > 0 {
+		return OsArgs0() + useline[i:]
+	}
+	return useline
 }
 
 // cmdPath is a customized cobra.Command.CommandPath()


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


fix #753 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

**Manual test**

```bash
(base) root@rabbit:tiup <fix/cluster-help-inconsistent(v1.1.0-15-gf645c99)>$ ./bin/tiup cluster check -h
Perform preflight checks for the cluster. By default, it checks deploy servers
before a cluster is deployed, the input is the topology.yaml for the cluster.
If '--cluster' is set, it will perform checks for an existing cluster, the input
is the cluster name. Some checks are ignore in this mode, such as port and dir
conflict checks with other clusters

Usage:
  tiup cluster check <topology.yml | cluster-name> [flags]

Flags:
      --apply                  Try to fix failed checks
      --cluster                Check existing cluster, the input is a cluster name.
      --enable-cpu             Enable CPU thread count check
      --enable-disk            Enable disk IO (fio) check
      --enable-mem             Enable memory size check
  -h, --help                   help for check
  -i, --identity_file string   The path of the SSH identity file. If specified, public key authentication will be used. (default "/home/.ssh/id_rsa")
  -p, --password               Use password of target hosts. If specified, password authentication will be used.
  -u, --user string            The user name to login via SSH. The user must has root (or sudo) privilege. (default "root")

Global Flags:
      --native-ssh         Use the native SSH client installed on local system instead of the build-in one (experimental).
      --ssh-timeout int    Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection. (default 5)
      --wait-timeout int   Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit. (default 120)
  -y, --yes                Skip all confirmations and assumes 'yes'
```

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```