### PR TITLE
Fix the issue that tiflash's data is not clean up when tombstone

### DIFF
--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -261,6 +261,7 @@ func DestroyClusterTombstone(
 		}
 
 		instances := (&spec.TiFlashComponent{Specification: cluster}).Instances()
+		id = s.Host + ":" + strconv.Itoa(s.GetMainPort())
 		instances = filterID(instances, id)
 
 		err = StopComponent(getter, instances, options.OptTimeout)

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -108,7 +108,7 @@ func (c *TiFlashComponent) Instances() []Instance {
 			InstanceSpec: s,
 			Name:         c.Name(),
 			Host:         s.Host,
-			Port:         s.TCPPort,
+			Port:         s.GetMainPort(),
 			SSHP:         s.SSHPort,
 
 			Ports: []int{


### PR DESCRIPTION


<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the issue that tiflash's data is not clean up when tombstone

when tombstone
before this pr:
<img width="981" alt="Screen Shot 2020-09-09 at 4 12 21 PM" src="https://user-images.githubusercontent.com/1681864/92580763-64161480-f2c1-11ea-84af-a3159441e2b4.png">
after this pr:
<img width="1079" alt="Screen Shot 2020-09-09 at 5 24 31 PM" src="https://user-images.githubusercontent.com/1681864/92580786-6b3d2280-f2c1-11ea-99f8-0f4fc2fe986d.png">


### What is changed and how it works?
We use ServicePort in DestroyClusterTombstone to construct id and filter by id,
but the id of instances of the cluster is construct using Port(TCPPort for
	tiflash),
so it will not get the instance and clean its data in DestroyClusterTombstone.

Note the GetMainPort() is TCPPort now, change the code to both
using GetMainPort() to avoid inconsistent.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)

deploy -> scale-in -> check work as expect


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the issue that tiflash's data is not clean up when tombstone
```