### PR TITLE
Fix dependences version binding when cloning mirror

### DIFF
--- a/pkg/cluster/spec/bindversion.go
+++ b/pkg/cluster/spec/bindversion.go
@@ -31,7 +31,7 @@ func TiDBComponentVersion(comp, version string) string {
 		return "v0.7.0"
 	case ComponentCheckCollector:
 		return "v0.3.1"
-	case ComponentTiSpark:
+	case ComponentTiSpark: // Note: change also: pkg/repository/clone_mirror.go#combineVersions
 		return "v2.3.1"
 	case ComponentSpark:
 		return "v2.4.3"

--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -405,6 +405,10 @@ func combineVersions(versions *[]string, manifest *v1manifest.Component, oss, ar
 		return set.NewStringSet("v0.17.0")
 	case "pushgateway":
 		return set.NewStringSet("v0.7.0")
+	case "tispark":
+		return set.NewStringSet("v2.3.1")
+	case "spark":
+		return set.NewStringSet("v2.4.3")
 	}
 
 	result := set.NewStringSet()


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, if the versions of the non-core components not specified, the latest version will be chosen. The behavior will abort the `tiup cluster deploy` because it binds version to a specific version to `tispark/spark`.

This PR fixes dependences version binding when cloning mirrors.

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix dependences version binding when cloning mirror
```