### PR TITLE
Skip download nightly package when it exists

### DIFF
--- a/pkg/cluster/operation/download.go
+++ b/pkg/cluster/operation/download.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/utils"
-	tiupver "github.com/pingcap/tiup/pkg/version"
 )
 
 // Download the specific version of a component from
@@ -55,7 +54,7 @@ func Download(component, nodeOS, arch string, version string) error {
 	}
 
 	// Download from repository if not exists
-	if version == tiupver.NightlyVersion || utils.IsNotExist(srcPath) {
+	if utils.IsNotExist(srcPath) {
 		if err := repo.DownloadComponent(component, version, srcPath); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix https://github.com/pingcap/tiup/issues/565

Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tiup/issues/565

### What is changed and how it works?
Stop ignoring nightly when check if we should download. This is ok because the `VerifyComponent` step will remove old nightly version.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```