### PR TITLE
Fix/tests wrong path

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -1,55 +1,55 @@
 name: install
 
 on:
-    pull_request:
-        branches:
-            - master
-            - release-*
+  pull_request:
+    branches:
+      - master
+      - release-*
 
 jobs:
-    install:
-        name: Install
-        runs-on: ubuntu-latest
-        env:
-            working-directory: ${{ github.workspace   }}/go/src/github.com/${{ github.repository   }}
-        steps:
-            - name: Check out code into the Go module directory
-              uses: actions/checkout@v2
-              with:
-                ref: ${{ github.event.pull_request.head.sha  }}
-                path: go/src/github.com/${{ github.repository  }}
-            - name: Install And Check
-              working-directory: ${{env.working-directory}}
-              run: |
-                sh install.sh
-                source ~/.profile
-                which tiup || (echo "no tiup found" && exit 1)
-                ! tiup update --self | grep -i "WARN: adding root certificate"
-    local_install:
-        name: Local Install
-        runs-on: ubuntu-latest
-        env:
-            working-directory: ${{ github.workspace   }}/go/src/github.com/${{ github.repository   }}
-        steps:
-            - name: Check out code into the Go module directory
-              uses: actions/checkout@v2
-              with:
-                ref: ${{ github.event.pull_request.head.sha  }}
-                path: go/src/github.com/${{ github.repository  }}
-            - name: Build TiUP
-              working-directory: ${{env.working-directory}}
-              run: make build
-            - name: Setup TiUP
-              run: |
-                mkdir -p ~/.tiup/bin
-                curl https://tiup-mirrors.pingcap.com/root.json -o ~/.tiup/bin/root.json
-            - name: Clone Mirror
-              working-directory: ${{env.working-directory}}
-              run: ./bin/tiup mirror clone test-mirror
-            - name: Local Install And Check
-              working-directory: ${{env.working-directory}}/test-mirror
-              run: |
-                sh local_install.sh
-                source ~/.profile
-                which tiup || (echo "no tiup found" && exit 1)
-                ! tiup update --self | grep -i "WARN: adding root certificate"
+  install:
+    name: Install
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
+      - name: Install And Check
+        working-directory: ${{ env.working-directory }}
+        run: |
+          sh install.sh
+          source ~/.profile
+          which tiup || (echo "no tiup found" && exit 1)
+          ! tiup update --self | grep -i "WARN: adding root certificate"
+  local_install:
+    name: Local Install
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
+      - name: Build TiUP
+        working-directory: ${{ env.working-directory }}
+        run: make build
+      - name: Setup TiUP
+        run: |
+          mkdir -p ~/.tiup/bin
+          curl https://tiup-mirrors.pingcap.com/root.json -o ~/.tiup/bin/root.json
+      - name: Clone Mirror
+        working-directory: ${{ env.working-directory }}
+        run: ./bin/tiup mirror clone test-mirror
+      - name: Local Install And Check
+        working-directory: ${{ env.working-directory }}/test-mirror
+        run: |
+          sh local_install.sh
+          source ~/.profile
+          which tiup || (echo "no tiup found" && exit 1)
+          ! tiup update --self | grep -i "WARN: adding root certificate"

--- a/.github/workflows/integrate-cluster-cmd.yaml
+++ b/.github/workflows/integrate-cluster-cmd.yaml
@@ -1,5 +1,4 @@
 ---
-
 name: integrate-cluster-cmd
 
 on:
@@ -35,19 +34,19 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha  }}
-          path: go/src/github.com/${{ github.repository  }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
       - name: Build build_integration_test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           export GOPATH=${GITHUB_WORKSPACE}/go
           export PATH=$PATH:$GOPATH/bin
           make build_integration_test
 
       - name: Build the docker-compose stack
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         # with --dev the first run will fail for unknow reason, just retry it and will success now..
-        run: TIUP_CLUSTER_ROOT=${{env.working-directory}} ./docker/up.sh --daemon --dev || TIUP_CLUSTER_ROOT=${{env.working-directory}} ./docker/up.sh --daemon --dev
+        run: TIUP_CLUSTER_ROOT=${{ env.working-directory }} ./docker/up.sh --daemon --dev || TIUP_CLUSTER_ROOT=${{ env.working-directory }} ./docker/up.sh --daemon --dev
 
       - name: Check running containers
         run: |
@@ -57,20 +56,20 @@ jobs:
 
       - name: Run test suite
         id: test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           # should not use -it
           # ref: https://stackoverflow.com/questions/43099116/error-the-input-device-is-not-a-tty
-          docker exec  tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/run.sh ${{matrix.cases}}
+          docker exec tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/run.sh ${{matrix.cases}}
 
       - name: Collect component log
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         # if: steps.test.outputs.exit_code != 0
         if: always()
         run: |
-          docker exec  tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/script/pull_log.sh /tiup-cluster/logs
-          ls ${{env.working-directory}}
-          tar czvf ${{env.working-directory}}/logs.tar.gz ${{env.working-directory}}/logs/
+          docker exec tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/script/pull_log.sh /tiup-cluster/logs
+          ls ${{ env.working-directory }}
+          tar czvf ${{ env.working-directory }}/logs.tar.gz ${{ env.working-directory }}/logs/
 
       - name: Upload component log
         # if: steps.test.outputs.exit_code != 0
@@ -78,10 +77,10 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: component_logs
-          path: ${{env.working-directory}}/logs.tar.gz
+          path: ${{ env.working-directory }}/logs.tar.gz
 
       - name: Output cluster debug log
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         if: always()
         run: |
           pwd
@@ -91,6 +90,6 @@ jobs:
           "cat ./tests/*.log" || true
 
       - name: Upload coverage to Codecov
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,cluster -s ${{env.working-directory}}/tests/tiup-cluster/cover -f '*.out'
+          curl -s https://codecov.io/bash | bash -s - -F integrate,cluster -s ${{ env.working-directory }}/tests/tiup-cluster/cover -f '*.out'

--- a/.github/workflows/integrate-cluster-scale.yaml
+++ b/.github/workflows/integrate-cluster-scale.yaml
@@ -1,5 +1,4 @@
 ---
-
 name: integrate-cluster-scale
 
 on:
@@ -35,19 +34,19 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha  }}
-          path: go/src/github.com/${{ github.repository  }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
       - name: Build build_integration_test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           export GOPATH=${GITHUB_WORKSPACE}/go
           export PATH=$PATH:$GOPATH/bin
           make build_integration_test
 
       - name: Build the docker-compose stack
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         # with --dev the first run will fail for unknow reason, just retry it and will success now..
-        run: TIUP_CLUSTER_ROOT=${{env.working-directory}} ./docker/up.sh --daemon --dev || TIUP_CLUSTER_ROOT=${{env.working-directory}} ./docker/up.sh --daemon --dev
+        run: TIUP_CLUSTER_ROOT=${{ env.working-directory }} ./docker/up.sh --daemon --dev || TIUP_CLUSTER_ROOT=${{ env.working-directory }} ./docker/up.sh --daemon --dev
 
       - name: Check running containers
         run: |
@@ -57,20 +56,20 @@ jobs:
 
       - name: Run test suite
         id: test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           # should not use -it
           # ref: https://stackoverflow.com/questions/43099116/error-the-input-device-is-not-a-tty
-          docker exec  tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/run.sh ${{matrix.cases}}
+          docker exec tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/run.sh ${{matrix.cases}}
 
       - name: Collect component log
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         # if: steps.test.outputs.exit_code != 0
         if: always()
         run: |
-          docker exec  tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/script/pull_log.sh /tiup-cluster/logs
-          ls ${{env.working-directory}}
-          tar czvf ${{env.working-directory}}/logs.tar.gz ${{env.working-directory}}/logs/
+          docker exec tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/script/pull_log.sh /tiup-cluster/logs
+          ls ${{ env.working-directory }}
+          tar czvf ${{ env.working-directory }}/logs.tar.gz ${{ env.working-directory }}/logs/
 
       - name: Upload component log
         # if: steps.test.outputs.exit_code != 0
@@ -78,10 +77,10 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: component_logs
-          path: ${{env.working-directory}}/logs.tar.gz
+          path: ${{ env.working-directory }}/logs.tar.gz
 
       - name: Output cluster debug log
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         if: always()
         run: |
           pwd
@@ -91,6 +90,6 @@ jobs:
           "cat ./tests/*.log" || true
 
       - name: Upload coverage to Codecov
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,cluster -s ${{env.working-directory}}/tests/tiup-cluster/cover -f '*.out'
+          curl -s https://codecov.io/bash | bash -s - -F integrate,cluster -s ${{ env.working-directory }}/tests/tiup-cluster/cover -f '*.out'

--- a/.github/workflows/integrate-dm.yaml
+++ b/.github/workflows/integrate-dm.yaml
@@ -1,5 +1,4 @@
 ---
-
 name: integrate-dm
 
 on:
@@ -35,11 +34,11 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha  }}
-          path: go/src/github.com/${{ github.repository  }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
 
       - name: Build build_integration_test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           export GOPATH=${GITHUB_WORKSPACE}/go
           export PATH=$PATH:$GOPATH/bin
@@ -47,11 +46,11 @@ jobs:
           make tiup
 
       - name: Build the docker-compose stack
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         # with --dev the first run will fail for unknow reason, just retry it and will success now..
         run: |
-          cd ${{env.working-directory}}/docker
-          TIUP_CLUSTER_ROOT=${{env.working-directory}} ./up.sh --daemon --dev --compose ./docker-compose.dm.yml || TIUP_CLUSTER_ROOT=${{env.working-directory}} ./up.sh --daemon --dev --compose ./docker-compose.dm.yml
+          cd ${{ env.working-directory }}/docker
+          TIUP_CLUSTER_ROOT=${{ env.working-directory }} ./up.sh --daemon --dev --compose ./docker-compose.dm.yml || TIUP_CLUSTER_ROOT=${{ env.working-directory }} ./up.sh --daemon --dev --compose ./docker-compose.dm.yml
 
       - name: Check running containers
         run: |
@@ -61,13 +60,13 @@ jobs:
 
       - name: Run test suite
         id: test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           # should not use -it
           # ref: https://stackoverflow.com/questions/43099116/error-the-input-device-is-not-a-tty
-          docker exec  tiup-cluster-control bash /tiup-cluster/tests/tiup-dm/run.sh ${{matrix.cases}}
+          docker exec tiup-cluster-control bash /tiup-cluster/tests/tiup-dm/run.sh ${{matrix.cases}}
 
       - name: Upload coverage to Codecov
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,dm -s ${{env.working-directory}}/tests/tiup-dm/cover -f '*.out'
+          curl -s https://codecov.io/bash | bash -s - -F integrate,dm -s ${{ env.working-directory }}/tests/tiup-dm/cover -f '*.out'

--- a/.github/workflows/integrate-playground.yaml
+++ b/.github/workflows/integrate-playground.yaml
@@ -1,5 +1,4 @@
 ---
-
 name: integrate-playground
 
 on:
@@ -33,10 +32,10 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha  }}
-          path: go/src/github.com/${{ github.repository  }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
       - name: Build build_tiup_playground_test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           export GOPATH=${GITHUB_WORKSPACE}/go
           export PATH=$PATH:$GOPATH/bin
@@ -44,17 +43,17 @@ jobs:
 
       - name: Run test suite
         id: test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
-          export PATH=$PATH:${{env.working-directory}}/bin/
-          bash ${{env.working-directory}}/tests/tiup-playground/${{matrix.cases}}.sh
+          export PATH=$PATH:${{ env.working-directory }}/bin/
+          bash ${{ env.working-directory }}/tests/tiup-playground/${{matrix.cases}}.sh
 
       - name: Collect component log
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         # if: steps.test.outputs.exit_code != 0
         if: always()
         run: |
-          find ${{env.working-directory}}/tests/tiup-playground/_tmp/home/data -type f | grep -E '*/ti.*/ti.*.log$' | xargs tar czvf ${{env.working-directory}}/playground.logs.tar.gz
+          find ${{ env.working-directory }}/tests/tiup-playground/_tmp/home/data -type f | grep -E '*/ti.*/ti.*.log$' | xargs tar czvf ${{ env.working-directory }}/playground.logs.tar.gz
 
       - name: Upload component log
         # if: steps.test.outputs.exit_code != 0
@@ -62,9 +61,9 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: playground_logs
-          path: ${{env.working-directory}}/playground.logs.tar.gz
+          path: ${{ env.working-directory }}/playground.logs.tar.gz
 
       - name: Upload coverage to Codecov
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,playground -s ${{env.working-directory}}/tests/tiup-playground/cover -f '*.out'
+          curl -s https://codecov.io/bash | bash -s - -F integrate,playground -s ${{ env.working-directory }}/tests/tiup-playground/cover -f '*.out'

--- a/.github/workflows/integrate-tiup.yaml
+++ b/.github/workflows/integrate-tiup.yaml
@@ -1,5 +1,4 @@
 ---
-
 name: integrate-tiup
 
 on:
@@ -33,11 +32,11 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha  }}
-          path: go/src/github.com/${{ github.repository  }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
 
       - name: Build build_tiup_test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           export GOPATH=${GITHUB_WORKSPACE}/go
           export PATH=$PATH:$GOPATH/bin
@@ -45,16 +44,16 @@ jobs:
 
       - name: Run test suite
         id: test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
-          export PATH=$PATH:${{env.working-directory}}/bin/
+          export PATH=$PATH:${{ env.working-directory }}/bin/
           echo $PATH
-          bash ${{env.working-directory}}/tests/tiup/${{matrix.cases}}.sh
-      
+          bash ${{ env.working-directory }}/tests/tiup/${{matrix.cases}}.sh
+
       - name: Upload coverage to Codecov
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,tiup -s ${{env.working-directory}}/tests/tiup/cover -f '*.out'
+          curl -s https://codecov.io/bash | bash -s - -F integrate,tiup -s ${{ env.working-directory }}/tests/tiup/cover -f '*.out'
 
   unit-test:
     runs-on: ubuntu-latest
@@ -64,8 +63,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha  }}
-          path: go/src/github.com/${{ github.repository  }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
 
       - name: Set up Go 1.14
         uses: actions/setup-go@v2
@@ -74,7 +73,7 @@ jobs:
         id: go
 
       - name: make unit-test
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           export GOPATH=${GITHUB_WORKSPACE}/go
           export PATH=$PATH:$GOPATH/bin
@@ -82,6 +81,6 @@ jobs:
           make test
 
       - name: Upload coverage to Codecov
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
         run: |
           curl -s https://codecov.io/bash | bash -s - -F unittest -s cover -f '*.out'

--- a/.github/workflows/reprotest.yaml
+++ b/.github/workflows/reprotest.yaml
@@ -28,16 +28,15 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
 
-    - name: Install reprotest
-      run: sudo apt-get update && sudo apt-get -qy install reprotest
+      - name: Install reprotest
+        run: sudo apt-get update && sudo apt-get -qy install reprotest
 
-    - name: Check for reproducible build
-      run: sudo reprotest "make clean && BUILD_FLAG='-trimpath -buildmode=pie' make build" bin
-
+      - name: Check for reproducible build
+        run: sudo reprotest "make clean && BUILD_FLAG='-trimpath -buildmode=pie' make build" bin

--- a/docker/control/bashrc
+++ b/docker/control/bashrc
@@ -5,7 +5,7 @@ export PATH=$PATH:/usr/local/go/bin
 export PATH=$PATH:/tiup-cluster/bin
 
 if [ -d "/mirrors" ]; then
-	export TIUP_MIRRORS=/mirrors
+    export TIUP_MIRRORS=/mirrors
 fi
 
 # You may uncomment the following lines if you want `ls' to be colorized:
@@ -16,7 +16,7 @@ alias ll='ls $LS_OPTIONS -l'
 alias l='ls $LS_OPTIONS -lA'
 
 mkdir -p ~/.tiup/bin
-file ~/.tiup/bin/root.json || curl "https://tiup-mirrors.pingcap.com/root.json" > ~/.tiup/bin/root.json
+[[ -f ~/.tiup/bin/root.json ]] || curl "https://tiup-mirrors.pingcap.com/root.json" > ~/.tiup/bin/root.json
 
 cat <<EOF
 Welcome to tiup-cluster on Docker
@@ -26,10 +26,10 @@ This container runs the tiup-cluster tests in sub-containers.
 
 You are currently in the base dir of the git repo for tiup-cluster.
 
-Run `tiup-cluster` to play with tiup-cluster.
+Run \`tiup-cluster\` to play with tiup-cluster.
 
 To run the test:
-   ./tests/run.sh
+   ./tests/tiup-cluster/run.sh
    ...
 EOF
 

--- a/tests/tiup-cluster/run.sh
+++ b/tests/tiup-cluster/run.sh
@@ -25,8 +25,8 @@ function tiup-cluster() {
     # echo "in function"
     if [ -f "./bin/tiup-cluster.test" ]; then
         ./bin/tiup-cluster.test -test.coverprofile=./cover/cov.itest-$(date +'%s')-$RANDOM.out __DEVEL--i-heard-you-like-tests "$@"
-        else
-        ../bin/tiup-cluster "$@"
+    else
+        ../../bin/tiup-cluster "$@"
     fi
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

1. [tests/tiup-cluster/run.sh](tests/tiup-cluster/run.sh) wrong tiup-cluster path;
2. command `file` not exist in the default golang:1.14 base image, use `-f` instead;
2. indent _github/workflows/*.yaml_ with 2 spaces


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```