### PR TITLE
cluster/command: missing short help of clean/destory

### DIFF
--- a/components/cluster/command/clean.go
+++ b/components/cluster/command/clean.go
@@ -23,7 +23,8 @@ func newCleanCmd() *cobra.Command {
 	cleanALl := false
 
 	cmd := &cobra.Command{
-		Use: "clean <cluster-name>",
+		Use:   "clean <cluster-name>",
+		Short: "Cleanup a specified cluster",
 		Long: `Cleanup a specified cluster without destroying it (experimental).
 You can retain some nodes and roles data when cleanup the cluster, eg:
     $ tiup cluster clean <cluster-name> --all

--- a/components/cluster/command/destroy.go
+++ b/components/cluster/command/destroy.go
@@ -24,10 +24,11 @@ import (
 func newDestroyCmd() *cobra.Command {
 	destoyOpt := operator.Options{}
 	cmd := &cobra.Command{
-		Use: "destroy <cluster-name>",
+		Use:   "destroy <cluster-name>",
+		Short: "Destroy a specified cluster",
 		Long: `Destroy a specified cluster, which will clean the deployment binaries and data.
 You can retain some nodes and roles data when destroy cluster, eg:
-  
+
   $ tiup cluster destroy <cluster-name> --retain-role-data prometheus
   $ tiup cluster destroy <cluster-name> --retain-node-data 172.16.13.11:9000
   $ tiup cluster destroy <cluster-name> --retain-node-data 172.16.13.12`,


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```