### PR TITLE
dm: forget to set sshType,sshTimeout

### DIFF
--- a/components/dm/ansible/import.go
+++ b/components/dm/ansible/import.go
@@ -140,6 +140,8 @@ func NewImporter(ansibleDir, inventoryFileName string, sshType executor.SSHType,
 		dir:               dir,
 		inventoryFileName: inventoryFileName,
 		sources:           make(map[string]*SourceConfig),
+		sshType:           sshType,
+		sshTimeout:        sshTimeout,
 	}, nil
 }
 

--- a/components/dm/command/deploy.go
+++ b/components/dm/command/deploy.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-func newDeploy() *cobra.Command {
+func newDeployCmd() *cobra.Command {
 	opt := cluster.DeployOptions{
 		IdentityFile: path.Join(utils.UserHome(), ".ssh", "id_rsa"),
 	}

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -114,7 +114,7 @@ func init() {
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")
 
 	rootCmd.AddCommand(
-		newDeploy(),
+		newDeployCmd(),
 		newStartCmd(),
 		newStopCmd(),
 		newRestartCmd(),


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

maybe fix #781.

IMO, we should set the type of timeout from `int64` to `uint64`, and bind with `Uint64Var`  https://github.com/pingcap/tiup/blob/65fdf56b28440506356942167b007315802a7e52/pkg/cluster/operation/operation.go#L29-L31

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```