### PR TITLE
Force relaod, scale-in and destroy

### DIFF
--- a/components/cluster/command/check.go
+++ b/components/cluster/command/check.go
@@ -301,10 +301,10 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, op
 	})
 
 	t := task.NewBuilder().
-		ParallelStep("+ Download necessary tools", downloadTasks...).
-		ParallelStep("+ Collect basic system information", collectTasks...).
-		ParallelStep("+ Check system requirements", checkSysTasks...).
-		ParallelStep("+ Cleanup check files", cleanTasks...).
+		ParallelStep("+ Download necessary tools", false, downloadTasks...).
+		ParallelStep("+ Collect basic system information", false, collectTasks...).
+		ParallelStep("+ Check system requirements", false, checkSysTasks...).
+		ParallelStep("+ Cleanup check files", false, cleanTasks...).
 		Build()
 
 	ctx := task.NewContext()
@@ -349,7 +349,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, op
 
 	if opt.applyFix {
 		tc := task.NewBuilder().
-			ParallelStep("+ Try to apply changes to fix failed checks", applyFixTasks...).
+			ParallelStep("+ Try to apply changes to fix failed checks", false, applyFixTasks...).
 			Build()
 		if err := tc.Execute(ctx); err != nil {
 			if errorx.Cast(err) != nil {

--- a/components/cluster/command/deploy.go
+++ b/components/cluster/command/deploy.go
@@ -111,12 +111,12 @@ func postDeployHook(builder *task.Builder, topo spec.Topology) {
 	}).BuildAsStep("Check status").SetHidden(true)
 
 	if report.Enable() {
-		builder.ParallelStep("+ Check status", nodeInfoTask)
+		builder.ParallelStep("+ Check status", false, nodeInfoTask)
 	}
 
 	enableTask := task.NewBuilder().Func("Enable cluster", func(ctx *task.Context) error {
 		return operator.Enable(ctx, topo, operator.Options{}, true)
 	}).BuildAsStep("Enable cluster").SetHidden(true)
 
-	builder.ParallelStep("+ Enable cluster", enableTask)
+	builder.ParallelStep("+ Enable cluster", false, enableTask)
 }

--- a/components/cluster/command/destroy.go
+++ b/components/cluster/command/destroy.go
@@ -56,6 +56,7 @@ You can retain some nodes and roles data when destroy cluster, eg:
 
 	cmd.Flags().StringArrayVar(&destoyOpt.RetainDataNodes, "retain-node-data", nil, "Specify the nodes or hosts whose data will be retained")
 	cmd.Flags().StringArrayVar(&destoyOpt.RetainDataRoles, "retain-role-data", nil, "Specify the roles whose data will be retained")
+	cmd.Flags().BoolVar(&destoyOpt.Force, "force", false, "Force will ignore any error while destroy the cluster")
 
 	return cmd
 }

--- a/components/cluster/command/destroy.go
+++ b/components/cluster/command/destroy.go
@@ -56,7 +56,7 @@ You can retain some nodes and roles data when destroy cluster, eg:
 
 	cmd.Flags().StringArrayVar(&destoyOpt.RetainDataNodes, "retain-node-data", nil, "Specify the nodes or hosts whose data will be retained")
 	cmd.Flags().StringArrayVar(&destoyOpt.RetainDataRoles, "retain-role-data", nil, "Specify the roles whose data will be retained")
-	cmd.Flags().BoolVar(&destoyOpt.Force, "force", false, "Force will ignore any error while destroy the cluster")
+	cmd.Flags().BoolVar(&destoyOpt.Force, "force", false, "Force will ignore remote error while destroy the cluster")
 
 	return cmd
 }

--- a/components/cluster/command/reload.go
+++ b/components/cluster/command/reload.go
@@ -40,7 +40,7 @@ func newReloadCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force reload without transferring PD leader")
+	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force reload without transferring PD leader and ignore any error")
 	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only start specified nodes")
 	cmd.Flags().Int64Var(&gOpt.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")

--- a/components/cluster/command/reload.go
+++ b/components/cluster/command/reload.go
@@ -40,7 +40,7 @@ func newReloadCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force reload without transferring PD leader and ignore any error")
+	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force reload without transferring PD leader and ignore remote error")
 	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only start specified nodes")
 	cmd.Flags().Int64Var(&gOpt.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")

--- a/components/cluster/command/scale_out.go
+++ b/components/cluster/command/scale_out.go
@@ -104,6 +104,6 @@ func postScaleOutHook(builder *task.Builder, newPart spec.Topology) {
 	}).BuildAsStep("Check status").SetHidden(true)
 
 	if report.Enable() {
-		builder.Parallel(convertStepDisplaysToTasks([]*task.StepDisplay{nodeInfoTask})...)
+		builder.Parallel(false, convertStepDisplaysToTasks([]*task.StepDisplay{nodeInfoTask})...)
 	}
 }

--- a/pkg/cluster/ansible/config.go
+++ b/pkg/cluster/ansible/config.go
@@ -87,7 +87,7 @@ func ImportConfig(name string, clsMeta *spec.ClusterMeta, sshTimeout int64, sshT
 		}
 	}
 	t := task.NewBuilder().
-		Parallel(copyFileTasks...).
+		Parallel(false, copyFileTasks...).
 		Build()
 
 	if err := t.Execute(task.NewContext()); err != nil {

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -904,7 +904,7 @@ func (m *Manager) Upgrade(clusterName string, clusterVersion string, opt operato
 			m.specManager.Path(clusterName, "ssh", "id_rsa.pub")).
 		ClusterSSH(topo, base.User, opt.SSHTimeout, opt.SSHType, topo.BaseTopo().GlobalOptions.SSHType).
 		Parallel(false, downloadCompTasks...).
-		Parallel(false, copyCompTasks...).
+		Parallel(opt.Force, copyCompTasks...).
 		Func("UpgradeCluster", func(ctx *task.Context) error {
 			return operator.Upgrade(ctx, topo, opt, tlsCfg)
 		}).

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -118,14 +118,14 @@ func Stop(
 	for _, com := range components {
 		insts := FilterInstance(com.Instances(), nodeFilter)
 		err := StopComponent(getter, insts, options.OptTimeout)
-		if err != nil {
+		if err != nil && !options.Force {
 			return errors.Annotatef(err, "failed to stop %s", com.Name())
 		}
 		for _, inst := range insts {
 			instCount[inst.GetHost()]--
 			if instCount[inst.GetHost()] == 0 {
 				if cluster.GetMonitoredOptions() != nil {
-					if err := StopMonitored(getter, inst, cluster.GetMonitoredOptions(), options.OptTimeout); err != nil {
+					if err := StopMonitored(getter, inst, cluster.GetMonitoredOptions(), options.OptTimeout); err != nil && !options.Force {
 						return err
 					}
 				}

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -67,14 +67,14 @@ func Destroy(
 	for _, com := range coms {
 		insts := com.Instances()
 		err := DestroyComponent(getter, insts, cluster, options)
-		if err != nil {
+		if err != nil && !options.Force {
 			return errors.Annotatef(err, "failed to destroy %s", com.Name())
 		}
 		for _, inst := range insts {
 			instCount[inst.GetHost()]--
 			if instCount[inst.GetHost()] == 0 {
 				if cluster.GetMonitoredOptions() != nil {
-					if err := DestroyMonitored(getter, inst, cluster.GetMonitoredOptions(), options.OptTimeout); err != nil {
+					if err := DestroyMonitored(getter, inst, cluster.GetMonitoredOptions(), options.OptTimeout); err != nil && !options.Force {
 						return err
 					}
 				}

--- a/pkg/cluster/operation/upgrade.go
+++ b/pkg/cluster/operation/upgrade.go
@@ -55,18 +55,18 @@ func Upgrade(
 
 			if isRollingInstance {
 				err := rollingInstance.PreRestart(topo, int(options.APITimeout), tlsCfg)
-				if err != nil {
+				if err != nil && !options.Force {
 					return errors.AddStack(err)
 				}
 			}
 
-			if err := restartInstance(getter, instance, options.OptTimeout); err != nil {
+			if err := restartInstance(getter, instance, options.OptTimeout); err != nil && !options.Force {
 				return errors.AddStack(err)
 			}
 
 			if isRollingInstance {
 				err := rollingInstance.PostRestart(topo, tlsCfg)
-				if err != nil {
+				if err != nil && !options.Force {
 					return errors.AddStack(err)
 				}
 			}

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -395,9 +395,9 @@ func (b *Builder) TLSCert(inst spec.Instance, ca *crypto.CertificateAuthority, p
 }
 
 // Parallel appends a parallel task to the current task collection
-func (b *Builder) Parallel(tasks ...Task) *Builder {
+func (b *Builder) Parallel(ignoreError bool, tasks ...Task) *Builder {
 	if len(tasks) > 0 {
-		b.tasks = append(b.tasks, &Parallel{inner: tasks})
+		b.tasks = append(b.tasks, &Parallel{ignoreError: ignoreError, inner: tasks})
 	}
 	return b
 }
@@ -427,8 +427,8 @@ func (b *Builder) Step(prefix string, inner Task) *Builder {
 
 // ParallelStep appends a new ParallelStepDisplay task, which will print multi line progress in parallel
 // for inner tasks. Inner tasks must be a StepDisplay task.
-func (b *Builder) ParallelStep(prefix string, tasks ...*StepDisplay) *Builder {
-	b.tasks = append(b.tasks, newParallelStepDisplay(prefix, tasks...))
+func (b *Builder) ParallelStep(prefix string, ignoreError bool, tasks ...*StepDisplay) *Builder {
+	b.tasks = append(b.tasks, newParallelStepDisplay(prefix, ignoreError, tasks...))
 	return b
 }
 

--- a/pkg/cluster/task/step.go
+++ b/pkg/cluster/task/step.go
@@ -140,7 +140,7 @@ type ParallelStepDisplay struct {
 	progressBar *progress.MultiBar
 }
 
-func newParallelStepDisplay(prefix string, sdTasks ...*StepDisplay) *ParallelStepDisplay {
+func newParallelStepDisplay(prefix string, ignoreError bool, sdTasks ...*StepDisplay) *ParallelStepDisplay {
 	bar := progress.NewMultiBar(prefix)
 	tasks := make([]Task, 0, len(sdTasks))
 	for _, t := range sdTasks {
@@ -150,7 +150,7 @@ func newParallelStepDisplay(prefix string, sdTasks ...*StepDisplay) *ParallelSte
 		tasks = append(tasks, t)
 	}
 	return &ParallelStepDisplay{
-		inner:       &Parallel{inner: tasks},
+		inner:       &Parallel{inner: tasks, ignoreError: ignoreError},
 		prefix:      prefix,
 		progressBar: bar,
 	}


### PR DESCRIPTION
Fix https://github.com/pingcap/tiup/issues/750

Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tiup/issues/750

### What is changed and how it works?
Ignore remote error while `scale-in`, `reload`, `upgrade` and `destroy` cluster

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Assume we have a broken cluster (host lost):
<img width="845" alt="屏幕快照 2020-09-23 下午8 56 53" src="https://user-images.githubusercontent.com/8718109/94015428-6d35d400-fddf-11ea-8e87-a1a9e5d0758f.png">

#### Upgrade cluster without `--force`:
<img width="1507" alt="屏幕快照 2020-09-23 下午8 58 58" src="https://user-images.githubusercontent.com/8718109/94017083-8fc8ec80-fde1-11ea-920c-fc3905eb3e25.png">

#### Upgrade cluster with `--force`:
<img width="738" alt="屏幕快照 2020-09-23 下午9 34 16" src="https://user-images.githubusercontent.com/8718109/94019607-8ee58a00-fde4-11ea-8935-154df42226d5.png">

#### Reload cluster without `--force`
<img width="1502" alt="屏幕快照 2020-09-23 下午9 36 23" src="https://user-images.githubusercontent.com/8718109/94019872-db30ca00-fde4-11ea-8b5a-7af12bc0379f.png">

#### Reload cluster with `--force`
<img width="710" alt="屏幕快照 2020-09-23 下午9 51 35" src="https://user-images.githubusercontent.com/8718109/94021786-fc92b580-fde6-11ea-8db1-316258f7b21d.png">

#### Scale in cluster without `--force`:
<img width="1481" alt="屏幕快照 2020-09-23 下午10 04 26" src="https://user-images.githubusercontent.com/8718109/94023467-d0783400-fde8-11ea-9f4c-6eeec0140f7a.png">


#### Scale in cluster with `--force`:
<img width="903" alt="屏幕快照 2020-09-23 下午10 04 07" src="https://user-images.githubusercontent.com/8718109/94023433-c5bd9f00-fde8-11ea-9755-6209ccf55344.png">


#### Destroy cluster without `--force`:
<img width="1516" alt="屏幕快照 2020-09-23 下午9 58 47" src="https://user-images.githubusercontent.com/8718109/94022753-010b9e00-fde8-11ea-8e9f-8647064a1e61.png">

#### Destroy cluster with `--force`:
<img width="954" alt="屏幕快照 2020-09-23 下午9 59 36" src="https://user-images.githubusercontent.com/8718109/94022836-1680c800-fde8-11ea-81d6-6ccc357bb862.png">


Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```