### PR TITLE
Fix/datarace when concurrent save the same file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOARCH  := $(if $(GOARCH),$(GOARCH),amd64)
 GOENV   := GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
 GO      := $(GOENV) go
 GOBUILD := $(GO) build $(BUILD_FLAG)
-GOTEST  := GO111MODULE=on CGO_ENABLED=1 $(GO) test -p 3
+GOTEST  := GO111MODULE=on CGO_ENABLED=1 go test -p 3
 SHELL   := /usr/bin/env bash
 
 COMMIT    := $(shell git describe --no-match --always --dirty)
@@ -92,6 +92,10 @@ run-tests: unit-test
 unit-test:
 	mkdir -p cover
 	TIUP_HOME=$(shell pwd)/tests/tiup $(GOTEST) ./... -covermode=count -coverprofile cover/cov.unit-test.out
+
+race: failpoint-enable
+	TIUP_HOME=$(shell pwd)/tests/tiup $(GOTEST) -race ./...  || { $(FAILPOINT_DISABLE); exit 1; }
+	@$(FAILPOINT_DISABLE)
 
 failpoint-enable: tools/bin/failpoint-ctl
 	@$(FAILPOINT_ENABLE)

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -384,7 +384,7 @@ func (b *Builder) DeploySpark(inst spec.Instance, sparkVersion, srcPath, deployD
 	)
 }
 
-// TLSCert geenrates certificate for instance and transfer it to the server
+// TLSCert generates certificate for instance and transfers it to the server
 func (b *Builder) TLSCert(inst spec.Instance, ca *crypto.CertificateAuthority, paths meta.DirPaths) *Builder {
 	b.tasks = append(b.tasks, &TLSCert{
 		ca:    ca,

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -11,7 +11,10 @@ import (
 	"github.com/pingcap/errors"
 )
 
-var fileLocks = make(map[string]*sync.Mutex)
+var (
+	fileLocks = make(map[string]*sync.Mutex)
+	filesLock = sync.Mutex{}
+)
 
 // SaveFileWithBackup will backup the file before save it.
 // e.g., backup meta.yaml as meta-2006-01-02T15:04:05Z07:00.yaml
@@ -28,6 +31,8 @@ func SaveFileWithBackup(path string, data []byte, backupDir string) error {
 		return errors.Errorf("%s is directory", path)
 	}
 
+	filesLock.Lock()
+	defer filesLock.Unlock()
 	if _, ok := fileLocks[path]; !ok {
 		fileLocks[path] = &sync.Mutex{}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In some cases, saving the same file may cause an error due to a race condition, eg in the cluster deploy with TLS supported scenario,  the _ca.crt_ file was saved multi times in parallel, in my local env, this leads to the _ca.crt_ file to be left empty.

```bash
root@control:~/.tiup/storage/cluster/clusters/test_scale_core_30845# ll config-cache/ca*
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:07.798975201Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:08.057441637Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:08.070494012Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:08.448460096Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:08.550741396Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:08.719875556Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:09.14992231Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:09.312662983Z.crt
-rw-r--r-- 1 root root    0 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:09.315387179Z.crt
-rw-r--r-- 1 root root    0 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:09.401021401Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:09.505369444Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:09.614051511Z.crt
-rw-r--r-- 1 root root    0 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:09.671778643Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:10.837351042Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:10.924662339Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:11.240826755Z.crt
-rw-r--r-- 1 root root    0 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:11.414010019Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca-2020-10-10T13:54:11.921334897Z.crt
-rw-r--r-- 1 root root 1123 Oct 10 13:54 config-cache/ca.crt
```


### What is changed and how it works?

introduce a simple lock to ensure the file was written in sequence.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```