### PR TITLE
Introduce a more graceful way to check labels

### DIFF
--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -4,6 +4,8 @@
 
 For detailed documentation, see the manual which starts with an [overview](overview.md).
 
+To get started with TiDB using TiUP, see the [TiDB quick start guide](https://docs.pingcap.com/tidb/stable/quick-start-with-tidb). To deploy TiDB using TiUP in a production-like environment, see the [TiDB deploymeny guide](https://docs.pingcap.com/tidb/stable/production-deployment-using-tiup).
+
 ## Installation
 
 ```sh
@@ -40,8 +42,7 @@ tiup update --all
 After installing `tiup`, you can use it to install binaries of TiDB components and create clusters.
 
 ```
-Use "tiup [command] --help" for more information about a command.Use "tiup [command] --help" for more information about a command.
-s a command-line component management tool that can help to download and install
+TiUP is a command-line component management tool that can help to download and install
 TiDB platform components to the local system. You can run a specific version of a component via
 "tiup <component>[:version]". If no version number is specified, the latest version installed
 locally will be used. If the specified component does not have any version installed locally,
@@ -58,36 +59,23 @@ Available Commands:
   update      Update tiup components to the latest version
   status      List the status of instantiated components
   clean       Clean the data of instantiated components
+  mirror      Manage a repository mirror for TiUP components
+  telemetry   Controls things about telemetry
+  completion  Output shell completion code for the specified shell (bash or zsh)
+  env         Show the list of system environment variable that related to TiUP
   help        Help about any command or component
 
-Available Components:
-  tidb                TiDB is an open source distributed HTAP database compatible with the MySQL protocol
-  tikv                Distributed transactional key-value database, originally created to complement TiDB
-  pd                  PD is the abbreviation for Placement Driver. It is used to manage and schedule the TiKV cluster
-  playground          Bootstrap a local TiDB cluster
-  client              A simple mysql client to connect TiDB
-  prometheus          The Prometheus monitoring system and time series database.
-  tpc                 A toolbox to benchmark workloads in TPC
-  package             A toolbox to package tiup component
-  tiops               Bootstrap a remote TiDB cluster
-  grafana             Grafana is the open source analytics & monitoring solution for every database
-  alertmanager        Prometheus Alertmanager
-  blackbox_exporter   Blackbox prober exporter
-  node_exporter       Blackbox prober exporter
-  pushgateway         Blackbox prober exporter
-  tiflash             
-  drainer             The drainer componet of TiDB binlog service
-  pump                The pump componet of TiDB binlog service
-  cluster             Deploy a TiDB cluster for production
+Components Manifest:
+  use "tiup list" to fetch the latest components manifest
 
 Flags:
   -B, --binary <component>[:version]   Print binary path of a specific version of a component <component>[:version]
                                        and the latest version installed will be selected if no version specified
       --binpath string                 Specify the binary path of component instance
-  -h, --help                           help for tiup
+      --help                           Help for this command
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
   -T, --tag string                     Specify a tag for component instance
-      --version                        version for tiup
+  -v, --version                        Print the version of tiup
 
 Component instances with the same "tag" will share a data directory ($TIUP_HOME/data/$tag):
   $ tiup --tag mycluster playground
@@ -105,4 +93,40 @@ Examples:
   $ tiup clean --all                   # Clean the data of all running/terminated instances
 
 Use "tiup [command] --help" for more information about a command.
+```
+
+The components available are
+
+```
+Name               Owner    Description
+----               -----    -----------
+alertmanager       pingcap  Prometheus alertmanager
+bench              pingcap  Benchmark database with different workloads
+blackbox_exporter  pingcap  Blackbox prober exporter
+br                 pingcap  TiDB/TiKV cluster backup restore tool
+cdc                pingcap  CDC is a change data capture tool for TiDB
+client             pingcap  A simple mysql client to connect TiDB
+cluster            pingcap  Deploy a TiDB cluster for production
+ctl                pingcap  TiDB controller suite
+dm                 pingcap  Data Migration Platform manager
+dm-master          pingcap  dm-master component of Data Migration Platform
+dm-worker          pingcap  dm-worker component of Data Migration Platform
+dmctl              pingcap  dmctl component of Data Migration Platform
+drainer            pingcap  The drainer componet of TiDB binlog service
+dumpling           pingcap  Dumpling is a CLI tool that helps you dump MySQL/TiDB data
+grafana            pingcap  Grafana is the open source analytics & monitoring solution for every database
+insight            pingcap  TiDB-Insight collector
+node_exporter      pingcap  Exporter for machine metrics
+package            pingcap  A toolbox to package tiup component
+pd                 pingcap  PD is the abbreviation for Placement Driver. It is used to manage and schedule the TiKV cluster
+pd-recover         pingcap  PD Recover is a disaster recovery tool of PD, used to recover the PD cluster which cannot start or provide services normally
+playground         pingcap  Bootstrap a local TiDB cluster
+prometheus         pingcap  The Prometheus monitoring system and time series database
+pump               pingcap  The pump componet of TiDB binlog service
+pushgateway        pingcap  Push acceptor for ephemeral and batch jobs
+tidb               pingcap  TiDB is an open source distributed HTAP database compatible with the MySQL protocol
+tidb-lightning     pingcap  TiDB Lightning is a tool used for fast full import of large amounts of data into a TiDB cluster
+tiflash            pingcap  The TiFlash Columnar Storage Engine
+tikv               pingcap  Distributed transactional key-value database, originally created to complement TiDB
+tiup               pingcap  TiUP is a command-line component management tool that can help to download and install TiDB platform components to the local system
 ```

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -677,6 +677,39 @@ func (pc *PDClient) GetLocationLabels() ([]string, error) {
 	return rc.LocationLabels, nil
 }
 
+// StoreList implements StoreLabelProvider
+func (pc *PDClient) StoreList() ([]string, error) {
+	r, err := pc.GetStores()
+	if err != nil {
+		return nil, err
+	}
+	addrs := []string{}
+	for _, s := range r.Stores {
+		addrs = append(addrs, s.Store.GetAddress())
+	}
+	return addrs, nil
+}
+
+// GetStoreLabels implements StoreLabelProvider
+func (pc *PDClient) GetStoreLabels(address string) (map[string]string, error) {
+	r, err := pc.GetStores()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range r.Stores {
+		if address == s.Store.GetAddress() {
+			lbs := s.Store.GetLabels()
+			labels := map[string]string{}
+			for _, lb := range lbs {
+				labels[lb.GetKey()] = lb.GetValue()
+			}
+			return labels, nil
+		}
+	}
+	return nil, errors.Errorf("store %s not found", address)
+}
+
 // UpdateScheduleConfig updates the PD schedule config
 func (pc *PDClient) UpdateScheduleConfig(body io.Reader) error {
 	return pc.updateConfig(body, pdConfigSchedule)

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -244,8 +244,8 @@ func (s *Specification) StoreList() ([]string, error) {
 	for _, kv := range kvs {
 		if kv.IsImported() {
 			// FIXME: this function implements StoreLabelProvider, which is used to
-			//        deletec if there is label config missing. However, we do that
-			//        based on the meta.yaml, whose server.labels field will be empty
+			//        detect if the label config is missing. However, we do that
+			//        base on the meta.yaml, whose server.labels field is empty
 			//        for imported TiKV servers, to workaround that, we just skip the
 			//        imported TiKV servers at this time.
 			continue

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -620,9 +620,9 @@ tikv_servers:
     status_port: 20180
 `), &topo)
 	c.Assert(err, IsNil)
-	err = CheckTiKVLocationLabels(nil, topo.TiKVServers)
+	err = CheckTiKVLocationLabels(nil, &topo)
 	c.Assert(err, IsNil)
-	err = CheckTiKVLocationLabels([]string{}, topo.TiKVServers)
+	err = CheckTiKVLocationLabels([]string{}, &topo)
 	c.Assert(err, IsNil)
 
 	// 2 tikv on the same host without label
@@ -637,7 +637,7 @@ tikv_servers:
     status_port: 20181
 `), &topo)
 	c.Assert(err, IsNil)
-	err = CheckTiKVLocationLabels(nil, topo.TiKVServers)
+	err = CheckTiKVLocationLabels(nil, &topo)
 	c.Assert(err, NotNil)
 
 	// 2 tikv on the same host with unacquainted label
@@ -656,7 +656,7 @@ tikv_servers:
       server.labels: { zone: "zone1", host: "172.16.5.140" }
 `), &topo)
 	c.Assert(err, IsNil)
-	err = CheckTiKVLocationLabels(nil, topo.TiKVServers)
+	err = CheckTiKVLocationLabels(nil, &topo)
 	c.Assert(err, NotNil)
 
 	// 2 tikv on the same host with correct label
@@ -675,7 +675,7 @@ tikv_servers:
       server.labels: { zone: "zone1", host: "172.16.5.140" }
 `), &topo)
 	c.Assert(err, IsNil)
-	err = CheckTiKVLocationLabels([]string{"zone", "host"}, topo.TiKVServers)
+	err = CheckTiKVLocationLabels([]string{"zone", "host"}, &topo)
 	c.Assert(err, IsNil)
 
 	// 2 tikv on the same host with diffrent config style
@@ -697,6 +697,6 @@ tikv_servers:
         host: "172.16.5.140"
 `), &topo)
 	c.Assert(err, IsNil)
-	err = CheckTiKVLocationLabels([]string{"zone", "host"}, topo.TiKVServers)
+	err = CheckTiKVLocationLabels([]string{"zone", "host"}, &topo)
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Fix https://github.com/pingcap/tiup/issues/838

Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
For imported clusters, it will report missing label when executing `tiup cluster display` since the server.labels is missing in meta.yaml. 
<img width="745" alt="屏幕快照 2020-10-15 下午8 49 26" src="https://user-images.githubusercontent.com/8718109/96128469-f8f6d800-0f27-11eb-996a-05e1ea72d460.png">

### What is changed and how it works?
Read labels config from PD server instead of meta.yaml.
<img width="786" alt="屏幕快照 2020-10-15 下午8 50 22" src="https://user-images.githubusercontent.com/8718109/96128559-19269700-0f28-11eb-850a-44185d338800.png">

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```