### PR TITLE
Fix copy file without mode

### DIFF
--- a/components/cluster/command/import.go
+++ b/components/cluster/command/import.go
@@ -116,10 +116,10 @@ func newImportCmd() *cobra.Command {
 			srcKeyPathPub := srcKeyPathPriv + ".pub"
 			dstKeyPathPriv := spec.ClusterPath(clsName, "ssh", "id_rsa")
 			dstKeyPathPub := dstKeyPathPriv + ".pub"
-			if err = tiuputils.CopyFile(srcKeyPathPriv, dstKeyPathPriv); err != nil {
+			if err = tiuputils.Copy(srcKeyPathPriv, dstKeyPathPriv); err != nil {
 				return err
 			}
-			if err = tiuputils.CopyFile(srcKeyPathPub, dstKeyPathPub); err != nil {
+			if err = tiuputils.Copy(srcKeyPathPub, dstKeyPathPub); err != nil {
 				return err
 			}
 

--- a/components/err/error.go
+++ b/components/err/error.go
@@ -55,7 +55,7 @@ func main() {
 
 type errorSpec struct {
 	Code        string   `toml:"code" json:"code"`
-	Error     string   `toml:"error" json:"error"`
+	Error       string   `toml:"error" json:"error"`
 	Description string   `toml:"description" json:"description"`
 	Tags        []string `toml:"tags" json:"tags"`
 	Workaround  string   `toml:"workaround" json:"workaround"`

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -1801,7 +1801,7 @@ func overwritePatch(specManager *spec.SpecManager, clusterName, comp, packagePat
 
 	tg := specManager.Path(clusterName, spec.PatchDirName, comp+"-"+checksum[:7]+".tar.gz")
 	if !utils.IsExist(tg) {
-		if err := utils.CopyFile(packagePath, tg); err != nil {
+		if err := utils.Copy(packagePath, tg); err != nil {
 			return err
 		}
 	}

--- a/pkg/localdata/profile.go
+++ b/pkg/localdata/profile.go
@@ -386,7 +386,7 @@ func (p *Profile) ResetMirror(addr, root string) error {
 			fmt.Printf("WARN: adding root certificate via internet: %s\n", root)
 			fmt.Printf("You can revoke this by remove %s\n", localRoot)
 		}
-		_ = utils.CopyFile(p.Path("bin", "root.json"), localRoot)
+		_ = utils.Copy(p.Path("bin", "root.json"), localRoot)
 	}
 
 	if err := os.RemoveAll(p.Path(ManifestParentDir)); err != nil {

--- a/pkg/utils/ioutil.go
+++ b/pkg/utils/ioutil.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"crypto/sha1"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -149,7 +148,13 @@ func Copy(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	return out.Close()
+
+	err = out.Close()
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, fi.Mode())
 }
 
 // Move moves a file from src to dst, this is done by copying the file and then
@@ -168,29 +173,6 @@ func CreateDir(path string) error {
 		if os.IsNotExist(err) {
 			return os.MkdirAll(path, 0755)
 		}
-		return err
-	}
-	return nil
-}
-
-// CopyFile copies a file from src to dst
-func CopyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	if IsExist(dst) {
-		return fmt.Errorf("destination path %s already exist", dst)
-	}
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	if _, err = io.Copy(out, in); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/utils/ioutil_test.go
+++ b/pkg/utils/ioutil_test.go
@@ -68,3 +68,21 @@ func (s *TestIOUtilSuite) TestUntar(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(IsExist(path.Join(currentDir(), "testdata", "parent", "child", "content")), IsTrue)
 }
+
+func (s *TestIOUtilSuite) TestCopy(c *C) {
+	c.Assert(Copy(path.Join(currentDir(), "testdata", "test.tar.gz"), "/tmp/not-exists/test.tar.gz"), NotNil)
+	c.Assert(Copy(path.Join(currentDir(), "testdata", "test.tar.gz"), "/tmp/test.tar.gz"), IsNil)
+	fi, err := os.Stat(path.Join(currentDir(), "testdata", "test.tar.gz"))
+	c.Assert(err, IsNil)
+	fii, err := os.Stat("/tmp/test.tar.gz")
+	c.Assert(err, IsNil)
+	c.Assert(fi.Mode(), Equals, fii.Mode())
+
+	c.Assert(os.Chmod("/tmp/test.tar.gz", 0777), IsNil)
+	c.Assert(Copy(path.Join(currentDir(), "testdata", "test.tar.gz"), "/tmp/test.tar.gz"), IsNil)
+	fi, err = os.Stat(path.Join(currentDir(), "testdata", "test.tar.gz"))
+	c.Assert(err, IsNil)
+	fii, err = os.Stat("/tmp/test.tar.gz")
+	c.Assert(err, IsNil)
+	c.Assert(fi.Mode(), Equals, fii.Mode())
+}


### PR DESCRIPTION
Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
We copy file with tiuputils.CopyFile, which is dup with tiuputils.Copy and both of them forget to change the mode of created file.

### What is changed and how it works?
call os.Chmod after create target.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```