### PR TITLE
Skip atuo-start cluster before scale-out action

### DIFF
--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -2138,11 +2138,7 @@ func buildScaleOutTask(
 		afterDeploy(builder, newPart)
 	}
 
-	// TODO: find another way to make sure current cluster started
 	builder.
-		Func("StartCluster", func(ctx *task.Context) error {
-			return operator.Start(ctx, metadata.GetTopology(), operator.Options{OptTimeout: optTimeout}, tlsCfg)
-		}).
 		ClusterSSH(newPart, base.User, sshTimeout, sshType, topo.BaseTopo().GlobalOptions.SSHType).
 		Func("Save meta", func(_ *task.Context) error {
 			metadata.SetTopology(mergedTopo)


### PR DESCRIPTION
Fix https://github.com/pingcap/tiup/issues/823

Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tiup/issues/823

### What is changed and how it works?
Skip auto-start because before any really action, tiup need to check the labels set in PD(https://github.com/pingcap/tiup/blob/b4c0a9f59e9ffb1e5e7c20e2515a84fb8844053a/pkg/cluster/manager.go#L602), which implies that the PDs must be started.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)



Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```