### PR TITLE
Update the output of errdoc component

### DIFF
--- a/components/errdoc/main.go
+++ b/components/errdoc/main.go
@@ -14,7 +14,6 @@
 package main
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -37,7 +36,7 @@ func init() {
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:          "tiup err",
+		Use:          "tiup errdoc",
 		Short:        "Show detailed error message via error code or keyword",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -66,9 +65,9 @@ func searchError(args []string) error {
 
 	for i, match := range result.Hits {
 		spec := errStore[match.ID]
-		fmt.Println(spec)
+		fmt.Print(spec)
 		if i != len(result.Hits)-1 {
-			fmt.Println(string(bytes.Repeat([]byte("-"), 80)))
+			fmt.Println()
 		}
 	}
 
@@ -78,7 +77,7 @@ func searchError(args []string) error {
 func loadIndex() (bleve.Index, map[string]*spec.ErrorSpec, error) {
 	dir := os.Getenv(localdata.EnvNameComponentInstallDir)
 	if dir == "" {
-		return nil, nil, errors.New("component `doc` doesn't running in TiUP mode")
+		return nil, nil, errors.New("component `errdoc` doesn't running in TiUP mode")
 	}
 
 	type tomlFile map[string]*spec.ErrorSpec

--- a/components/errdoc/spec/spec.go
+++ b/components/errdoc/spec/spec.go
@@ -44,10 +44,18 @@ func (f ErrorSpec) String() string {
 		header = fmt.Sprintf("# Error: **%s**", f.Code)
 	}
 
-	return newCompiler().Compile(fmt.Sprintf(`%s
-%s
-## Description
-%s
-## Workaround
-%s`, header, f.Error, f.Description, f.Workaround))
+	tmpl := header + "\n" + f.Error
+
+	description := f.Description
+	if description != "" {
+		tmpl += `## Description
+		` + description
+	}
+	workaround := f.Workaround
+	if workaround != "" {
+		tmpl += `## Workaround
+		` + workaround
+	}
+
+	return newCompiler().Compile(tmpl)
 }


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR refine the output of errdoc search results and make it more pretty.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```
# Error: autoid:1467

  Failed to read auto-increment value from storage engine


# Error: ddl:3109

  Generated column '%s' cannot refer to auto-increment column.


# Error: ddl:3754

  Expression index '%s' cannot refer to an auto-increment column
```

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Update the search result output of errdoc component
```