### PR TITLE
More safe way to cleanup tombstone nodes

### DIFF
--- a/components/cluster/command/prune.go
+++ b/components/cluster/command/prune.go
@@ -82,11 +82,13 @@ func destroyTombstoneIfNeed(clusterName string, metadata *spec.ClusterMeta, opt 
 		return nil
 	}
 
-	err = cliutil.PromptForConfirmOrAbortError(
-		color.HiYellowString(fmt.Sprintf("Will destroy these nodes: %v\nDo you confirm this action? [y/N]:", nodes)),
-	)
-	if err != nil {
-		return err
+	if !skipConfirm {
+		err = cliutil.PromptForConfirmOrAbortError(
+			color.HiYellowString(fmt.Sprintf("Will destroy these nodes: %v\nDo you confirm this action? [y/N]:", nodes)),
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	log.Infof("Start destroy Tombstone nodes: %v ...", nodes)

--- a/components/cluster/command/prune.go
+++ b/components/cluster/command/prune.go
@@ -1,0 +1,126 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/fatih/color"
+	perrs "github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/cliutil"
+	operator "github.com/pingcap/tiup/pkg/cluster/operation"
+	"github.com/pingcap/tiup/pkg/cluster/spec"
+	"github.com/pingcap/tiup/pkg/cluster/task"
+	"github.com/pingcap/tiup/pkg/logger/log"
+	"github.com/spf13/cobra"
+)
+
+func newPruneCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prune <cluster-name>",
+		Short: "Destroy and remove instances that is in tombstone state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmd.Help()
+			}
+
+			clusterName := args[0]
+
+			metadata, err := spec.ClusterMetadata(clusterName)
+			if err != nil {
+				return err
+			}
+
+			return destroyTombstoneIfNeed(clusterName, metadata, gOpt, skipConfirm)
+		},
+	}
+
+	return cmd
+}
+
+func confirmTombstone(tombs []spec.InstanceSpec) error {
+	printTable := [][]string{}
+	printTable = append(printTable, []string{
+		"ID", "Role", "Host", "Main Port",
+	})
+
+	for _, inst := range tombs {
+		host, _ := inst.SSH()
+		role := inst.Role()
+		port := inst.GetMainPort()
+		id := fmt.Sprintf("%s:%d", host, port)
+
+		printTable = append(printTable, []string{
+			id, role, host, strconv.Itoa(port),
+		})
+	}
+
+	fmt.Println(color.HiYellowString("These instances will be destroyed:"))
+	cliutil.PrintTable(printTable, true)
+	return cliutil.PromptForConfirmOrAbortError(color.HiYellowString("Do you confirm this action? [y/N]:"))
+}
+
+func destroyTombstoneIfNeed(clusterName string, metadata *spec.ClusterMeta, opt operator.Options, skipConfirm bool) error {
+	topo := metadata.Topology
+
+	tombs := operator.NeedCheckTomebsome(topo)
+	if len(tombs) == 0 {
+		fmt.Println("There is no instance in tombstone state")
+		return nil
+	}
+
+	if !skipConfirm {
+		if err := confirmTombstone(tombs); err != nil {
+			return err
+		}
+	}
+
+	tlsCfg, err := topo.TLSConfig(tidbSpec.Path(clusterName, spec.TLSCertKeyDir))
+	if err != nil {
+		return perrs.AddStack(err)
+	}
+
+	ctx := task.NewContext()
+	err = ctx.SetSSHKeySet(spec.ClusterPath(clusterName, "ssh", "id_rsa"),
+		spec.ClusterPath(clusterName, "ssh", "id_rsa.pub"))
+	if err != nil {
+		return perrs.AddStack(err)
+	}
+
+	err = ctx.SetClusterSSH(topo, metadata.User, gOpt.SSHTimeout, gOpt.SSHType, topo.BaseTopo().GlobalOptions.SSHType)
+	if err != nil {
+		return perrs.AddStack(err)
+	}
+
+	nodes, err := operator.DestroyTombstone(ctx, topo, true /* returnNodesOnly */, opt, tlsCfg)
+	if err != nil {
+		return perrs.AddStack(err)
+	}
+
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	log.Infof("Start destroy Tombstone nodes: %v ...", nodes)
+
+	_, err = operator.DestroyTombstone(ctx, topo, false /* returnNodesOnly */, opt, tlsCfg)
+	if err != nil {
+		return perrs.AddStack(err)
+	}
+
+	log.Infof("Destroy success")
+
+	return spec.SaveClusterMeta(clusterName, metadata)
+}

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -153,6 +153,7 @@ func init() {
 		newUpgradeCmd(),
 		newExecCmd(),
 		newDisplayCmd(),
+		newPruneCmd(),
 		newListCmd(),
 		newAuditCmd(),
 		newImportCmd(),

--- a/components/dm/command/prune.go
+++ b/components/dm/command/prune.go
@@ -1,0 +1,113 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"sync"
+	"time"
+
+	"github.com/pingcap/tiup/components/dm/spec"
+	"github.com/pingcap/tiup/pkg/cluster/api"
+	operator "github.com/pingcap/tiup/pkg/cluster/operation"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func newPruneCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prune <cluster-name>",
+		Short: "Clear etcd info ",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmd.Help()
+			}
+
+			clusterName := args[0]
+
+			metadata := new(spec.Metadata)
+			err := dmspec.Metadata(clusterName, metadata)
+			if err != nil {
+				return err
+			}
+
+			return clearOutDatedEtcdInfo(clusterName, metadata, gOpt)
+		},
+	}
+
+	return cmd
+}
+
+func clearOutDatedEtcdInfo(clusterName string, metadata *spec.Metadata, opt operator.Options) error {
+	topo := metadata.Topology
+
+	existedMasters := make(map[string]struct{})
+	existedWorkers := make(map[string]struct{})
+	mastersToDelete := make([]string, 0)
+	workersToDelete := make([]string, 0)
+
+	for _, masterSpec := range topo.Masters {
+		existedMasters[masterSpec.Name] = struct{}{}
+	}
+	for _, workerSpec := range topo.Workers {
+		existedWorkers[workerSpec.Name] = struct{}{}
+	}
+
+	dmMasterClient := api.NewDMMasterClient(topo.GetMasterList(), 10*time.Second, nil)
+	registeredMasters, registeredWorkers, err := dmMasterClient.GetRegisteredMembers()
+	if err != nil {
+		return err
+	}
+
+	for _, master := range registeredMasters {
+		if _, ok := existedMasters[master]; !ok {
+			mastersToDelete = append(mastersToDelete, master)
+		}
+	}
+	for _, worker := range registeredWorkers {
+		if _, ok := existedWorkers[worker]; !ok {
+			workersToDelete = append(workersToDelete, worker)
+		}
+	}
+
+	panic(len(registeredMasters) + len(registeredWorkers))
+	zap.L().Info("Outdated components needed to clear etcd info", zap.Strings("masters", mastersToDelete), zap.Strings("workers", workersToDelete))
+
+	errCh := make(chan error, len(existedMasters)+len(existedWorkers))
+	var wg sync.WaitGroup
+
+	for _, master := range mastersToDelete {
+		master := master
+		wg.Add(1)
+		go func() {
+			errCh <- dmMasterClient.OfflineMaster(master, nil)
+			wg.Done()
+		}()
+	}
+	for _, worker := range workersToDelete {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			errCh <- dmMasterClient.OfflineWorker(worker, nil)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	if len(errCh) == 0 {
+		return nil
+	}
+
+	// return any one error
+	return <-errCh
+}

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -124,6 +124,7 @@ func init() {
 		newExecCmd(),
 		newEditConfigCmd(),
 		newDisplayCmd(),
+		newPruneCmd(),
 		newReloadCmd(),
 		newUpgradeCmd(),
 		newPatchCmd(),

--- a/go.sum
+++ b/go.sum
@@ -639,6 +639,7 @@ github.com/pingcap/parser v0.0.0-20190506092653-e336082eb825/go.mod h1:1FNvfp9+J
 github.com/pingcap/parser v0.0.0-20200422082501-7329d80eaf2c/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/pingcap/pd v2.1.5+incompatible h1:vOLV2tSQdRjjmxaTXtJULoC94dYQOd+6fzn2yChODHc=
 github.com/pingcap/pd v2.1.5+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
+github.com/pingcap/pd/v4 v4.0.0-rc.1.0.20200422143320-428acd53eba2 h1:JTzYYukREvxVSKW/ncrzNjFitd8snoQ/Xz32pw8i+s8=
 github.com/pingcap/pd/v4 v4.0.0-rc.1.0.20200422143320-428acd53eba2/go.mod h1:s+utZtXDznOiL24VK0qGmtoHjjXNsscJx3m1n8cC56s=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -136,31 +136,29 @@ func Stop(
 }
 
 // NeedCheckTomebsome return true if we need to check and destroy some node.
-func NeedCheckTomebsome(topo *spec.Specification) []spec.InstanceSpec {
-	tombs := []spec.InstanceSpec{}
-
+func NeedCheckTomebsome(topo *spec.Specification) bool {
 	for _, s := range topo.TiKVServers {
 		if s.Offline {
-			tombs = append(tombs, s)
+			return true
 		}
 	}
 	for _, s := range topo.TiFlashServers {
 		if s.Offline {
-			tombs = append(tombs, s)
+			return true
 		}
 	}
 	for _, s := range topo.PumpServers {
 		if s.Offline {
-			tombs = append(tombs, s)
+			return true
 		}
 	}
 	for _, s := range topo.Drainers {
 		if s.Offline {
-			tombs = append(tombs, s)
+			return true
 		}
 	}
 
-	return tombs
+	return false
 }
 
 // DestroyTombstone remove the tombstone node in spec and destroy them.

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -136,28 +136,31 @@ func Stop(
 }
 
 // NeedCheckTomebsome return true if we need to check and destroy some node.
-func NeedCheckTomebsome(spec *spec.Specification) bool {
-	for _, s := range spec.TiKVServers {
+func NeedCheckTomebsome(topo *spec.Specification) []spec.InstanceSpec {
+	tombs := []spec.InstanceSpec{}
+
+	for _, s := range topo.TiKVServers {
 		if s.Offline {
-			return true
+			tombs = append(tombs, s)
 		}
 	}
-	for _, s := range spec.TiFlashServers {
+	for _, s := range topo.TiFlashServers {
 		if s.Offline {
-			return true
+			tombs = append(tombs, s)
 		}
 	}
-	for _, s := range spec.PumpServers {
+	for _, s := range topo.PumpServers {
 		if s.Offline {
-			return true
+			tombs = append(tombs, s)
 		}
 	}
-	for _, s := range spec.Drainers {
+	for _, s := range topo.Drainers {
 		if s.Offline {
-			return true
+			tombs = append(tombs, s)
 		}
 	}
-	return false
+
+	return tombs
 }
 
 // DestroyTombstone remove the tombstone node in spec and destroy them.

--- a/pkg/cluster/operation/scale_in.go
+++ b/pkg/cluster/operation/scale_in.go
@@ -237,7 +237,7 @@ func ScaleInCluster(
 					return errors.Annotatef(err, "failed to destroy %s", component.Name())
 				}
 			} else {
-				log.Warnf(color.YellowString("The component `%s` will be destroyed when display cluster info when it become tombstone, maybe exists in several minutes or hours",
+				log.Warnf(color.YellowString("The component `%s` will become tombstone, maybe exists in several minutes or hours, after that you can use the prune command to clean it",
 					component.Name()))
 			}
 		}

--- a/tests/tiup-cluster/script/util.sh
+++ b/tests/tiup-cluster/script/util.sh
@@ -48,7 +48,7 @@ function wait_instance_num_reach() {
         sleep 1
     done
 
-    echo "fail to wait instance number reach $target_num, retry num: $i"
+    echo "fail to wait instance number reach $target_num, count $count, retry num: $i"
     tiup-cluster $client display $name
     exit -1
 }

--- a/tests/tiup-cluster/script/util.sh
+++ b/tests/tiup-cluster/script/util.sh
@@ -49,5 +49,6 @@ function wait_instance_num_reach() {
 
     echo "fail to wait instance number reach $target_num, retry num: $i"
     tiup-cluster $client display $name
+    tiup-cluster $client prune $name --yes
     exit -1
 }

--- a/tests/tiup-cluster/script/util.sh
+++ b/tests/tiup-cluster/script/util.sh
@@ -16,6 +16,7 @@ function instance_num() {
         client="--native-ssh"
     fi
 
+    tiup-cluster $client prune $name --yes
     count=$(tiup-cluster $client display $name | grep "Total nodes" | awk -F ' ' '{print $3}')
 
     echo $count
@@ -49,6 +50,5 @@ function wait_instance_num_reach() {
 
     echo "fail to wait instance number reach $target_num, retry num: $i"
     tiup-cluster $client display $name
-    tiup-cluster $client prune $name --yes
     exit -1
 }

--- a/tests/tiup-cluster/script/util.sh
+++ b/tests/tiup-cluster/script/util.sh
@@ -16,7 +16,6 @@ function instance_num() {
         client="--native-ssh"
     fi
 
-    tiup-cluster $client prune $name --yes
     count=$(tiup-cluster $client display $name | grep "Total nodes" | awk -F ' ' '{print $3}')
 
     echo $count
@@ -37,6 +36,7 @@ function wait_instance_num_reach() {
 
     for ((i=0;i<120;i++))
     do
+        tiup-cluster $client prune $name --yes
         count=$(instance_num $name $native_ssh)
         if [ "$count" == "$target_num" ]; then
             echo "instance number reach $target_num"

--- a/tests/tiup-dm/script/util.sh
+++ b/tests/tiup-dm/script/util.sh
@@ -9,7 +9,7 @@ set -eu
 # coverage: 12.7% of statements in github.com/pingcap/tiup/components/dm/...
 function instance_num() {
 	name=$1
-	tiup-dm prune $name --yes
+
 	count=$(tiup-dm display $name | grep "Total nodes" | awk -F ' ' '{print $3}')
 
 	echo $count
@@ -24,6 +24,7 @@ function wait_instance_num_reach() {
 
 	for ((i=0;i<120;i++))
 	do
+		tiup-dm prune $name --yes
 		count=$(instance_num $name)
 		if [ "$count" == "$target_num" ]; then
 			echo "instance number reach $target_num"
@@ -35,7 +36,7 @@ function wait_instance_num_reach() {
 		sleep 1
 	done
 
-	echo "fail to wait instance number reach $target_num, retry num: $i"
+	echo "fail to wait instance number reach $target_num, count $count, retry num: $i"
 	tiup-dm display $name
 	exit -1
 }

--- a/tests/tiup-dm/script/util.sh
+++ b/tests/tiup-dm/script/util.sh
@@ -9,6 +9,7 @@ set -eu
 # coverage: 12.7% of statements in github.com/pingcap/tiup/components/dm/...
 function instance_num() {
 	name=$1
+	tiup-dm prune $name --yes
 	count=$(tiup-dm display $name | grep "Total nodes" | awk -F ' ' '{print $3}')
 
 	echo $count


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
With TiUP, if we want to offline a TiKV server, we need do this first:

```sh
tiup cluster scale-in <cluster-name> -N <tikv-node-id>
```

This will send a request to PD servers to tell them that we want to offline this TiKV server, then PD servers will transfer all regions in this TiKV to some other place. After transferring data, the state of this TiKV server will be tombstone. At this point, the data of this server will be deleted (see the yellow line in the picture below).

<img width="1479" alt="屏幕快照 2020-10-22 下午12 20 46" src="https://user-images.githubusercontent.com/8718109/96824307-17496000-1461-11eb-9139-b0b46b9adbdb.png">

 But oncel the user execute the `display` command:

```sh
tiup cluster display <cluster-name>
```

The TiKV server in tombstone state will be destroyed and cleanup at once, this may confuse users and it's unsafe.

### What is changed and how it works?

DO NOT cleanup tombstone TiKV servers in display command, but add a prune command to do this, and give the user a choice to cancel the action:

<img width="809" alt="屏幕快照 2020-10-22 下午12 23 34" src="https://user-images.githubusercontent.com/8718109/96824469-7a3af700-1461-11eb-98f6-5f80fa30f2f4.png">


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```