### PR TITLE
Fix dataDir not deleted if containing comma

### DIFF
--- a/components/cluster/command/prune.go
+++ b/components/cluster/command/prune.go
@@ -52,7 +52,7 @@ func newPruneCmd() *cobra.Command {
 func destroyTombstoneIfNeed(clusterName string, metadata *spec.ClusterMeta, opt operator.Options, skipConfirm bool) error {
 	topo := metadata.Topology
 
-	if !operator.NeedCheckTomebsome(topo) {
+	if !operator.NeedCheckTombstone(topo) {
 		return nil
 	}
 

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -135,8 +135,8 @@ func Stop(
 	return nil
 }
 
-// NeedCheckTomebsome return true if we need to check and destroy some node.
-func NeedCheckTomebsome(topo *spec.Specification) bool {
+// NeedCheckTombstone return true if we need to check and destroy some node.
+func NeedCheckTombstone(topo *spec.Specification) bool {
 	for _, s := range topo.TiKVServers {
 		if s.Offline {
 			return true

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -609,18 +609,23 @@ func (s *Specification) dirConflictsDetect() error {
 
 			// Directory conflicts
 			for _, dirType := range dirTypes {
-				if j, found := findField(compSpec, dirType); found {
+				j, found := findField(compSpec, dirType)
+				if !found {
+					continue
+				}
+
+				// `yaml:"data_dir,omitempty"`
+				tp := strings.Split(compSpec.Type().Field(j).Tag.Get("yaml"), ",")[0]
+				for _, part := range strings.Split(compSpec.Field(j).String(), ",") {
 					item := usedDir{
 						host: host,
-						dir:  compSpec.Field(j).String(),
+						dir:  part,
 					}
 					// data_dir is relative to deploy_dir by default, so they can be with
 					// same (sub) paths as long as the deploy_dirs are different
 					if item.dir != "" && !strings.HasPrefix(item.dir, "/") {
 						continue
 					}
-					// `yaml:"data_dir,omitempty"`
-					tp := strings.Split(compSpec.Type().Field(j).Tag.Get("yaml"), ",")[0]
 					prev, exist := dirStats[item]
 					// not checking between imported nodes
 					if exist &&

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -711,7 +711,7 @@ global:
   deploy_dir: "test-deploy"
 tiflash_servers:
   - host: 172.19.0.104
-    data_dir: "/home/tidb/birdstorm/data1,/home/tidb/birdstorm/data3"
+    data_dir: "/home/tidb/birdstorm/data1, /home/tidb/birdstorm/data3"
 `), &topo)
 	c.Assert(err, IsNil)
 	cnt := topo.CountDir("172.19.0.104", "/home/tidb/birdstorm/data1")
@@ -758,7 +758,7 @@ global:
   data_dir: "test-data"
 tiflash_servers:
   - host: 172.16.5.138
-    data_dir: "/test-1,/test-2"
+    data_dir: " /test-1, /test-2"
 pd_servers:
   - host: 172.16.5.138
     data_dir: "/test-2"

--- a/tests/tiup-cluster/topo/full.yaml.tpl
+++ b/tests/tiup-cluster/topo/full.yaml.tpl
@@ -33,6 +33,7 @@ tikv_servers:
 # and binary is more than 1G..
 tiflash_servers:
   - host: __IPPREFIX__.103
+    data_dir: "data1,/data/tiflash-data"
 #   - host: __IPPREFIX__.104
 #   - host: __IPPREFIX__.105
 

--- a/tests/tiup-cluster/topo/full_scale_in_tiflash.yaml.tpl
+++ b/tests/tiup-cluster/topo/full_scale_in_tiflash.yaml.tpl
@@ -1,0 +1,2 @@
+tiflash_servers:
+  - host: __IPPREFIX__.103


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #865 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the issue when `dataDir` contains `,` can't detect `CountDir()` exceptions and `dirConflictsDetect()` 
```