### PR TITLE
cluster/audit: audit log in seconds maybe leads to file overwriten

### DIFF
--- a/pkg/cluster/audit/audit.go
+++ b/pkg/cluster/audit/audit.go
@@ -60,7 +60,7 @@ func ShowAuditList(dir string) error {
 		if err != nil {
 			continue
 		}
-		t := time.Unix(ts, 0)
+		t := time.Unix(ts/1e9, 0)
 		cmd, err := firstLine(fi.Name())
 		if err != nil {
 			continue
@@ -82,7 +82,7 @@ func ShowAuditList(dir string) error {
 
 // OutputAuditLog outputs audit log.
 func OutputAuditLog(dir string, data []byte) error {
-	fname := filepath.Join(dir, base52.Encode(time.Now().Unix()))
+	fname := filepath.Join(dir, base52.Encode(time.Now().UnixNano()))
 	return ioutil.WriteFile(fname, data, 0644)
 }
 
@@ -103,7 +103,7 @@ func ShowAuditLog(dir string, auditID string) error {
 		return errors.Trace(err)
 	}
 
-	t := time.Unix(ts, 0)
+	t := time.Unix(ts/1e9, 0)
 	hint := fmt.Sprintf("- OPERATION TIME: %s -", t.Format("2006-01-02T15:04:05"))
 	line := strings.Repeat("-", len(hint))
 	_, _ = os.Stdout.WriteString(color.MagentaString("%s\n%s\n%s\n", line, hint, line))

--- a/pkg/cluster/audit/audit_test.go
+++ b/pkg/cluster/audit/audit_test.go
@@ -1,0 +1,65 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+
+	. "github.com/pingcap/check"
+	"golang.org/x/sync/errgroup"
+)
+
+var _ = Suite(&testAuditSuite{})
+
+type testAuditSuite struct{}
+
+func currentDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func auditDir() string {
+	return path.Join(currentDir(), "testdata", "audit")
+}
+
+func (s *testAuditSuite) SetUpSuite(c *C) {
+	_ = os.RemoveAll(auditDir())
+	_ = os.MkdirAll(auditDir(), 0777)
+}
+
+func (s *testAuditSuite) TearDownSuite(c *C) {
+	_ = os.RemoveAll(auditDir())
+}
+
+func (s *testAuditSuite) TestOutputAuditLog(c *C) {
+	dir := auditDir()
+	var g errgroup.Group
+	for i := 0; i < 20; i++ {
+		g.Go(func() error { return OutputAuditLog(dir, []byte("audit log")) })
+	}
+	err := g.Wait()
+	c.Assert(err, IsNil)
+
+	var paths []string
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		// simply filter the not relate files.
+		paths = append(paths, path)
+		return nil
+	})
+	c.Assert(err, IsNil)
+	c.Assert(len(paths), Equals, 20)
+}

--- a/tests/tiup-dm/run.sh
+++ b/tests/tiup-dm/run.sh
@@ -46,7 +46,7 @@ function tiup-dm() {
     mkdir -p ~/.tiup/bin && cp -f ./root.json ~/.tiup/bin/
     # echo "in function"
     if [ -f "./bin/tiup-dm.test" ]; then
-        ./bin/tiup-dm.test  -test.coverprofile=./cover/cov.itest-$(date +'%s')-$RANDOM.out __DEVEL--i-heard-you-like-tests "$@"
+        ./bin/tiup-dm.test -test.coverprofile=./cover/cov.itest-$(date +'%s')-$RANDOM.out __DEVEL--i-heard-you-like-tests "$@"
     else
         ../../bin/tiup-dm "$@"
     fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In my local dev's env, I've found the audit log file was base52 encoded with `time.Now().Unix()`, while at the same time, if the command is run fast enough, then the later file with the same name will cover the previous one.

In my local dev, I'm running `tiup-dm test-cmd`

```bash
bash /tiup-cluster/tests/tiup-dm/run.sh --native-ssh --do-cases test_cmd
# ... wait for this case finished
exit 1
```
the below case **maybe**(occasional) failed of this line https://github.com/pingcap/tiup/blob/11535d272a90f904ad5b8f73af5dddc224c2894d/tests/tiup-dm/test_cmd.sh#L28


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the issue which leads the audit log file be overwritten.
```
