### PR TITLE
fix(cluster/audit): compatible with old second based ts

### DIFF
--- a/pkg/cluster/audit/audit_test.go
+++ b/pkg/cluster/audit/audit_test.go
@@ -14,14 +14,22 @@
 package audit
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"testing"
+	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tiup/pkg/base52"
 	"golang.org/x/sync/errgroup"
 )
+
+func Test(t *testing.T) { TestingT(t) }
 
 var _ = Suite(&testAuditSuite{})
 
@@ -36,17 +44,29 @@ func auditDir() string {
 	return path.Join(currentDir(), "testdata", "audit")
 }
 
-func (s *testAuditSuite) SetUpSuite(c *C) {
+func resetDir() {
 	_ = os.RemoveAll(auditDir())
 	_ = os.MkdirAll(auditDir(), 0777)
 }
 
+func readFakeStdout(f *os.File) string {
+	_, _ = f.Seek(0, 0)
+	read, _ := ioutil.ReadAll(f)
+	return string(read)
+}
+
+func (s *testAuditSuite) SetUpSuite(c *C) {
+	resetDir()
+}
+
 func (s *testAuditSuite) TearDownSuite(c *C) {
-	_ = os.RemoveAll(auditDir())
+	_ = os.RemoveAll(auditDir()) // path.Join(currentDir(), "testdata"))
 }
 
 func (s *testAuditSuite) TestOutputAuditLog(c *C) {
 	dir := auditDir()
+	resetDir()
+
 	var g errgroup.Group
 	for i := 0; i < 20; i++ {
 		g.Go(func() error { return OutputAuditLog(dir, []byte("audit log")) })
@@ -56,10 +76,74 @@ func (s *testAuditSuite) TestOutputAuditLog(c *C) {
 
 	var paths []string
 	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		// simply filter the not relate files.
-		paths = append(paths, path)
+		if !info.IsDir() {
+			paths = append(paths, path)
+		}
 		return nil
 	})
 	c.Assert(err, IsNil)
 	c.Assert(len(paths), Equals, 20)
+}
+
+func (s *testAuditSuite) TestShowAuditLog(c *C) {
+	dir := auditDir()
+	resetDir()
+
+	originStdout := os.Stdout
+	defer func() {
+		os.Stdout = originStdout
+	}()
+
+	fakeStdout := path.Join(currentDir(), "fake-stdout")
+	defer os.Remove(fakeStdout)
+
+	openStdout := func() *os.File {
+		_ = os.Remove(fakeStdout)
+		f, err := os.OpenFile(fakeStdout, os.O_CREATE|os.O_RDWR, 0644)
+		c.Assert(err, IsNil)
+		os.Stdout = f
+		return f
+	}
+
+	second := int64(1604413577)
+	nanoSecond := int64(1604413624836105381)
+
+	fname := filepath.Join(dir, base52.Encode(second))
+	c.Assert(ioutil.WriteFile(fname, []byte("test with second"), 0644), IsNil)
+	fname = filepath.Join(dir, base52.Encode(nanoSecond))
+	c.Assert(ioutil.WriteFile(fname, []byte("test with nanosecond"), 0644), IsNil)
+
+	f := openStdout()
+	c.Assert(ShowAuditList(dir), IsNil)
+	// tabby table size is based on column width, while time.RFC3339 maybe print out timezone like +08:00 or Z(UTC)
+	// skip the first two lines
+	list := strings.Join(strings.Split(readFakeStdout(f), "\n")[2:], "\n")
+	c.Assert(list, Equals, fmt.Sprintf(`ftmpqzww84Q  %s  test with nanosecond
+4F7ZTL       %s  test with second
+`,
+		time.Unix(nanoSecond/1e9, 0).Format(time.RFC3339),
+		time.Unix(second, 0).Format(time.RFC3339),
+	))
+	f.Close()
+
+	f = openStdout()
+	c.Assert(ShowAuditLog(dir, "4F7ZTL"), IsNil)
+	c.Assert(readFakeStdout(f), Equals, fmt.Sprintf(`---------------------------------------
+- OPERATION TIME: %s -
+---------------------------------------
+test with second`,
+		time.Unix(second, 0).Format("2006-01-02T15:04:05"),
+	))
+
+	f.Close()
+
+	f = openStdout()
+	c.Assert(ShowAuditLog(dir, "ftmpqzww84Q"), IsNil)
+	c.Assert(readFakeStdout(f), Equals, fmt.Sprintf(`---------------------------------------
+- OPERATION TIME: %s -
+---------------------------------------
+test with nanosecond`,
+		time.Unix(nanoSecond/1e9, 0).Format("2006-01-02T15:04:05"),
+	))
+	f.Close()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The old audit's filename was based on `second`, after #879 merged, the filename changed to `nanosecond` based. So this PR fixes the difference between those two situations. 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
