### PR TITLE
Fix tiup dm patch can't detect correct version

### DIFF
--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -1758,12 +1758,12 @@ func instancesToPatch(topo spec.Topology, options operator.Options) ([]spec.Inst
 }
 
 func checkPackage(bindVersion spec.BindVersion, specManager *spec.SpecManager, clusterName, comp, nodeOS, arch, packagePath string) error {
-	metadata, err := spec.ClusterMetadata(clusterName)
-	if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) {
+	metadata := specManager.NewMetadata()
+	if err := specManager.Metadata(clusterName, metadata); err != nil {
 		return err
 	}
 
-	ver := bindVersion(comp, metadata.Version)
+	ver := bindVersion(comp, metadata.GetBaseMeta().Version)
 	repo, err := clusterutil.NewRepository(nodeOS, arch)
 	if err != nil {
 		return err


### PR DESCRIPTION


<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tiup/issues/883

### What is changed and how it works?
Use metadata from specManager instead of hardcoded cluster metadata

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```sh
JoshuadeMacBook-Pro:dm joshua$ tiup dm patch test ~/.tiup/storage/dm/packages/dm-worker-v2.0.0-linux-amd64.tar.gz -R dm-worker
Starting component `dm`: /Users/joshua/.tiup/components/dm/v1.2.0/tiup-dm patch test /Users/joshua/.tiup/storage/dm/packages/dm-worker-v2.0.0-linux-amd64.tar.gz -R dm-worker
+ [ Serial ] - SSHKeySet: privateKey=/Users/joshua/.tiup/storage/dm/clusters/test/ssh/id_rsa, publicKey=/Users/joshua/.tiup/storage/dm/clusters/test/ssh/id_rsa.pub
+ [Parallel] - UserSSH: user=tidb, host=172.16.5.139
+ [Parallel] - UserSSH: user=tidb, host=172.16.5.139
+ [Parallel] - UserSSH: user=tidb, host=172.16.5.140
+ [Parallel] - UserSSH: user=tidb, host=172.16.5.140
+ [Parallel] - UserSSH: user=tidb, host=172.16.5.134
+ [Parallel] - UserSSH: user=tidb, host=172.16.5.139
+ [Parallel] - UserSSH: user=tidb, host=172.16.5.139
+ [Parallel] - UserSSH: user=tidb, host=172.16.5.134
+ [ Serial ] - BackupComponent: component=dm-worker, currentVersion=v2.0.0, remote=172.16.5.134:/home/tidb/deploy/dm-worker-8262
+ [ Serial ] - BackupComponent: component=dm-worker, currentVersion=v2.0.0, remote=172.16.5.140:/home/tidb/deploy/dm-worker-8262
+ [ Serial ] - BackupComponent: component=dm-worker, currentVersion=v2.0.0, remote=172.16.5.139:/home/tidb/deploy/dm-worker-8262
+ [ Serial ] - InstallPackage: srcPath=/Users/joshua/.tiup/storage/dm/packages/dm-worker-v2.0.0-linux-amd64.tar.gz, remote=172.16.5.139:/home/tidb/deploy/dm-worker-8262
+ [ Serial ] - InstallPackage: srcPath=/Users/joshua/.tiup/storage/dm/packages/dm-worker-v2.0.0-linux-amd64.tar.gz, remote=172.16.5.134:/home/tidb/deploy/dm-worker-8262
+ [ Serial ] - InstallPackage: srcPath=/Users/joshua/.tiup/storage/dm/packages/dm-worker-v2.0.0-linux-amd64.tar.gz, remote=172.16.5.140:/home/tidb/deploy/dm-worker-8262
+ [ Serial ] - UpgradeCluster
Restarting component dm-worker
        Restarting instance 172.16.5.140
        Restart 172.16.5.140 success
        Restarting instance 172.16.5.139
        Restart 172.16.5.139 success
        Restarting instance 172.16.5.134
        Restart 172.16.5.134 success
```

Related changes

 - Need to cherry-pick to the release branch

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
