### PR TITLE
Fix ti-spark scale-out

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -670,8 +670,8 @@ func newMirrorCloneCmd() *cobra.Command {
 			}
 			defer repo.Mirror().Close()
 
-			var versionMapper = func(ver string) string {
-				return spec.TiDBComponentVersion(ver, "")
+			var versionMapper = func(comp string) string {
+				return spec.TiDBComponentVersion(comp, "")
 			}
 
 			return repository.CloneMirror(repo, components, versionMapper, args[0], args[1:], options)

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -817,9 +817,6 @@ func (m *Manager) Upgrade(clusterName string, clusterVersion string, opt operato
 	for _, comp := range topo.ComponentsByUpdateOrder() {
 		for _, inst := range comp.Instances() {
 			version := m.bindVersion(inst.ComponentName(), clusterVersion)
-			if version == "" {
-				return perrs.Errorf("unsupported component: %v", inst.ComponentName())
-			}
 			compInfo := componentInfo{
 				component: inst.ComponentName(),
 				version:   version,

--- a/pkg/cluster/spec/bindversion.go
+++ b/pkg/cluster/spec/bindversion.go
@@ -31,6 +31,8 @@ func TiDBComponentVersion(comp, version string) string {
 		return "v0.7.0"
 	case ComponentCheckCollector:
 		return "v0.3.1"
+	case ComponentSpark, ComponentTiSpark:
+		return "" // empty version should be treate as the the last stable one
 	default:
 		return version
 	}

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -731,6 +731,13 @@ func (r *V1Repository) ComponentVersion(id, version string, includeYanked bool) 
 	if v0manifest.Version(version).IsNightly() && manifest.Nightly != "" {
 		version = manifest.Nightly
 	}
+	if version == "" {
+		v, _, err := r.LatestStableVersion(id, includeYanked)
+		if err != nil {
+			return nil, err
+		}
+		version = v.String()
+	}
 	vi := manifest.VersionItem(r.PlatformString(), version, includeYanked)
 	if vi == nil {
 		return nil, fmt.Errorf("version %s on %s for component %s not found", version, r.PlatformString(), id)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://asktug.com/t/topic/37633

### What is changed and how it works?
Just return emtpy version in version mapper and in download and deploy stage, we use the latest stable one if the version is empty.

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
