### PR TITLE
fix(install): install script export path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,8 +68,8 @@ echo "Shell profile:  ${bold}$PROFILE${sgr0}"
 
 case :$PATH: in
     *:$bin_dir:*) : "PATH already contains $bin_dir" ;;
-    *) printf 'export PATH=%s:$PATH\n' "$bin_dir" >> "$PROFILE"
-        echo "$PROFILE has been modified to to add tiup to PATH"
+    *) printf '\nexport PATH=%s:$PATH\n' "$bin_dir" >> "$PROFILE"
+        echo "$PROFILE has been modified to add tiup to PATH"
         echo "open a new terminal or ${bold}source ${PROFILE}${sgr0} to use it"
         ;;
 esac


### PR DESCRIPTION
Add a new line for the export path of TIUP, fix the issue caused by adding the path export to the previous line.

### What is changed and how it works?
Adding a `\n` new line in front of the inject sentence

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

Code changes


Release notes:
```release-note
NONE
```
