### PR TITLE
cluster: ignore no tispark master error when listing clusters

### DIFF
--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -262,7 +262,8 @@ func (m *Manager) ListCluster() error {
 
 	for _, name := range names {
 		metadata, err := m.meta(name)
-		if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) {
+		if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) &&
+			!errors.Is(perrs.Cause(err), spec.ErrNoTiSparkMaster) {
 			return perrs.Trace(err)
 		}
 
@@ -347,7 +348,9 @@ func (m *Manager) CleanCluster(clusterName string, gOpt operator.Options, cleanO
 func (m *Manager) DestroyCluster(clusterName string, gOpt operator.Options, destroyOpt operator.Options, skipConfirm bool) error {
 	metadata, err := m.meta(clusterName)
 	if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) &&
-		!errors.Is(perrs.Cause(err), spec.ErrNoTiSparkMaster) {
+		!errors.Is(perrs.Cause(err), spec.ErrNoTiSparkMaster) &&
+		!errors.Is(perrs.Cause(err), spec.ErrMultipleTiSparkMaster) &&
+		!errors.Is(perrs.Cause(err), spec.ErrMultipleTisparkWorker) {
 		return perrs.AddStack(err)
 	}
 
@@ -1366,7 +1369,9 @@ func (m *Manager) ScaleIn(
 	}
 
 	metadata, err := m.meta(clusterName)
-	if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) {
+	if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) &&
+		!errors.Is(perrs.Cause(err), spec.ErrMultipleTiSparkMaster) &&
+		!errors.Is(perrs.Cause(err), spec.ErrMultipleTisparkWorker) {
 		// ignore conflict check error, node may be deployed by former version
 		// that lack of some certain conflict checks
 		return perrs.AddStack(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #909 

### What is changed and how it works?
Ignore no tispark master error when listing clusters

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: ignore no tispark master error when listing installed clusters
```
