### PR TITLE
cluster: fix tispark master scaling handling

### DIFF
--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -1481,18 +1481,15 @@ func (m *Manager) ScaleOut(
 	sshType executor.SSHType,
 ) error {
 	metadata, err := m.meta(clusterName)
-	if err != nil { // not allowing validation errors
+	// allow specific validation errors so that user can recover a broken
+	// cluster if it is somehow in a bad state.
+	if err != nil &&
+		!errors.Is(perrs.Cause(err), spec.ErrNoTiSparkMaster) {
 		return perrs.AddStack(err)
 	}
 
 	topo := metadata.GetTopology()
 	base := metadata.GetBaseMeta()
-
-	// not allowing validation errors
-	if err := topo.Validate(); err != nil {
-		return err
-	}
-
 	// Inherit existing global configuration. We must assign the inherited values before unmarshalling
 	// because some default value rely on the global options and monitored options.
 	newPart := topo.NewPart()

--- a/pkg/cluster/operation/scale_in.go
+++ b/pkg/cluster/operation/scale_in.go
@@ -117,6 +117,24 @@ func ScaleInCluster(
 		return errors.New("cannot delete all TiKV servers")
 	}
 
+	// Cannot delete TiSpark master server if there's any TiSpark worker remains
+	if len(deletedDiff[spec.ComponentTiSpark]) > 0 {
+		var cntDiffTiSparkMaster int
+		var cntDiffTiSparkWorker int
+		for _, inst := range deletedDiff[spec.ComponentTiSpark] {
+			switch inst.Role() {
+			case spec.RoleTiSparkMaster:
+				cntDiffTiSparkMaster++
+			case spec.RoleTiSparkWorker:
+				cntDiffTiSparkWorker++
+			}
+		}
+		if cntDiffTiSparkMaster == len(cluster.TiSparkMasters) &&
+			cntDiffTiSparkWorker < len(cluster.TiSparkWorkers) {
+			return errors.New("cannot delete tispark master when there are workers left")
+		}
+	}
+
 	var pdEndpoint []string
 	for _, instance := range (&spec.PDComponent{Topology: cluster}).Instances() {
 		if !deletedNodes.Exist(instance.ID()) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Make it possible for broken clusters to fix no tispark master error by scaling out a new tispark master node

### What is changed and how it works?
Ignore topology validation error when listing clusters, this is a following up of #920

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
