### PR TITLE
repository: move v0manifest.Version to dedicate package

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/environment"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/tui"
 	"github.com/pingcap/tiup/pkg/version"
@@ -202,7 +202,7 @@ func showComponentVersions(env *environment.Environment, component string, opt l
 	for plat := range comp.Platforms {
 		versions := comp.VersionList(plat)
 		for ver, verinfo := range versions {
-			if v0manifest.Version(ver).IsNightly() && ver == comp.Nightly {
+			if pkgver.Version(ver).IsNightly() && ver == comp.Nightly {
 				platforms[version.NightlyVersion] = append(platforms[version.NightlyVersion], plat)
 				released[version.NightlyVersion] = verinfo.Released
 			} else {
@@ -213,7 +213,7 @@ func showComponentVersions(env *environment.Environment, component string, opt l
 	}
 	verList := []string{}
 	for v := range platforms {
-		if v0manifest.Version(v).IsNightly() {
+		if pkgver.Version(v).IsNightly() {
 			continue
 		}
 		verList = append(verList, v)

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -30,8 +30,8 @@ import (
 	"github.com/pingcap/tiup/pkg/repository"
 	"github.com/pingcap/tiup/pkg/repository/model"
 	ru "github.com/pingcap/tiup/pkg/repository/utils"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/spf13/cobra"
@@ -208,7 +208,7 @@ func newMirrorModifyCmd() *cobra.Command {
 					publishInfo.Yank = &yanked
 				}
 			} else if flagSet.Exist("yank") {
-				if v0manifest.Version(ver).IsNightly() {
+				if pkgver.Version(ver).IsNightly() {
 					return errors.New("nightly version can't be yanked")
 				}
 				for p := range m.Platforms {

--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pingcap/tiup/components/playground/instance"
 	"github.com/pingcap/tiup/pkg/environment"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -205,7 +205,7 @@ http_port = %d
 	params := &tiupexec.PrepareCommandParams{
 		Ctx:         ctx,
 		Component:   "grafana",
-		Version:     v0manifest.Version(g.version),
+		Version:     pkgver.Version(g.version),
 		InstanceDir: dir,
 		WD:          dir,
 		Args:        args,

--- a/components/playground/instance/drainer.go
+++ b/components/playground/instance/drainer.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -71,7 +71,7 @@ func (d *Drainer) NodeID() string {
 }
 
 // Start implements Instance interface.
-func (d *Drainer) Start(ctx context.Context, version v0manifest.Version) error {
+func (d *Drainer) Start(ctx context.Context, version pkgver.Version) error {
 	if err := os.MkdirAll(d.Dir, 0755); err != nil {
 		return err
 	}

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 )
 
 // Config of the instance.
@@ -43,7 +43,7 @@ type Instance interface {
 	Pid() int
 	// Start the instance process.
 	// Will kill the process once the context is done.
-	Start(ctx context.Context, version v0manifest.Version) error
+	Start(ctx context.Context, version pkgver.Version) error
 	// Component Return the component name.
 	Component() string
 	// LogFile return the log file name
@@ -65,7 +65,7 @@ func (inst *instance) StatusAddrs() (addrs []string) {
 }
 
 // CompVersion return the format to run specified version of a component.
-func CompVersion(comp string, version v0manifest.Version) string {
+func CompVersion(comp string, version pkgver.Version) string {
 	if version.IsEmpty() {
 		return comp
 	}

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -66,7 +66,7 @@ func (inst *PDInstance) Name() string {
 }
 
 // Start calls set inst.cmd and Start
-func (inst *PDInstance) Start(ctx context.Context, version v0manifest.Version) error {
+func (inst *PDInstance) Start(ctx context.Context, version pkgver.Version) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}

--- a/components/playground/instance/process.go
+++ b/components/playground/instance/process.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/environment"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 )
 
 // Process represent process to be run by playground
@@ -85,7 +85,7 @@ func (p *process) Cmd() *exec.Cmd {
 }
 
 // NewComponentProcess create a Process instance.
-func NewComponentProcess(ctx context.Context, dir, binPath, component string, version v0manifest.Version, arg ...string) (Process, error) {
+func NewComponentProcess(ctx context.Context, dir, binPath, component string, version pkgver.Version, arg ...string) (Process, error) {
 	if dir == "" {
 		panic("dir must be set")
 	}

--- a/components/playground/instance/pump.go
+++ b/components/playground/instance/pump.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -82,7 +82,7 @@ func (p *Pump) Addr() string {
 }
 
 // Start implements Instance interface.
-func (p *Pump) Start(ctx context.Context, version v0manifest.Version) error {
+func (p *Pump) Start(ctx context.Context, version pkgver.Version) error {
 	if err := os.MkdirAll(p.Dir, 0755); err != nil {
 		return err
 	}

--- a/components/playground/instance/ticdc.go
+++ b/components/playground/instance/ticdc.go
@@ -16,11 +16,12 @@ package instance
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
-	"github.com/pingcap/tiup/pkg/utils"
 	"os"
 	"path/filepath"
 	"strings"
+
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
+	"github.com/pingcap/tiup/pkg/utils"
 )
 
 // TiCDC represent a ticdc instance.
@@ -50,7 +51,7 @@ func NewTiCDC(binPath string, dir, host, configPath string, id int, pds []*PDIns
 }
 
 // Start implements Instance interface.
-func (c *TiCDC) Start(ctx context.Context, version v0manifest.Version) error {
+func (c *TiCDC) Start(ctx context.Context, version pkgver.Version) error {
 	if err := os.MkdirAll(c.Dir, 0755); err != nil {
 		return err
 	}

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -51,7 +51,7 @@ func NewTiDBInstance(binPath string, dir, host, configPath string, id int, pds [
 }
 
 // Start calls set inst.cmd and Start
-func (inst *TiDBInstance) Start(ctx context.Context, version v0manifest.Version) error {
+func (inst *TiDBInstance) Start(ctx context.Context, version pkgver.Version) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pingcap/tiup/pkg/cluster/api"
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/repository"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -98,7 +98,7 @@ func (inst *TiFlashInstance) StatusAddrs() (addrs []string) {
 }
 
 // Start calls set inst.cmd and Start
-func (inst *TiFlashInstance) Start(ctx context.Context, version v0manifest.Version) error {
+func (inst *TiFlashInstance) Start(ctx context.Context, version pkgver.Version) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (inst *TiFlashInstance) StoreAddr() string {
 	return fmt.Sprintf("%s:%d", advertiseHost(inst.Host), inst.ServicePort)
 }
 
-func (inst *TiFlashInstance) checkConfig(deployDir, clusterManagerPath string, version v0manifest.Version, tidbStatusAddrs, endpoints []string) error {
+func (inst *TiFlashInstance) checkConfig(deployDir, clusterManagerPath string, version pkgver.Version, tidbStatusAddrs, endpoints []string) error {
 	if inst.ConfigPath == "" {
 		inst.ConfigPath = path.Join(inst.Dir, "tiflash.toml")
 	}

--- a/components/playground/instance/tiflash_proxy_config.go
+++ b/components/playground/instance/tiflash_proxy_config.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"golang.org/x/mod/semver"
 )
 
@@ -46,7 +46,7 @@ data-dir = "%[6]s"
 max-open-files = 256
 `
 
-func writeTiFlashProxyConfig(w io.Writer, version v0manifest.Version, ip, deployDir string, servicePort, proxyPort, proxyStatusPort int) error {
+func writeTiFlashProxyConfig(w io.Writer, version pkgver.Version, ip, deployDir string, servicePort, proxyPort, proxyStatusPort int) error {
 	// TODO: support multi-dir
 	dataDir := fmt.Sprintf("%s/flash", deployDir)
 	logDir := fmt.Sprintf("%s/log", deployDir)

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -55,7 +55,7 @@ func (inst *TiKVInstance) Addr() string {
 }
 
 // Start calls set inst.cmd and Start
-func (inst *TiKVInstance) Start(ctx context.Context, version v0manifest.Version) error {
+func (inst *TiKVInstance) Start(ctx context.Context, version pkgver.Version) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pingcap/tiup/components/playground/instance"
 	"github.com/pingcap/tiup/pkg/environment"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -142,7 +142,7 @@ scrape_configs:
 	params := &tiupexec.PrepareCommandParams{
 		Ctx:         ctx,
 		Component:   "prometheus",
-		Version:     v0manifest.Version(version),
+		Version:     pkgver.Version(version),
 		InstanceDir: dir,
 		WD:          dir,
 		Args:        args,

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -38,7 +38,7 @@ import (
 	"github.com/pingcap/tiup/pkg/cliutil/progress"
 	"github.com/pingcap/tiup/pkg/cluster/api"
 	"github.com/pingcap/tiup/pkg/environment"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
@@ -413,7 +413,7 @@ func (p *Playground) sanitizeComponentConfig(cid string, cfg *instance.Config) e
 
 func (p *Playground) startInstance(ctx context.Context, inst instance.Instance) error {
 	fmt.Printf("Start %s instance\n", inst.Component())
-	err := inst.Start(ctx, v0manifest.Version(p.bootOptions.version))
+	err := inst.Start(ctx, pkgver.Version(p.bootOptions.version))
 	if err != nil {
 		return errors.AddStack(err)
 	}
@@ -1003,7 +1003,7 @@ func (p *Playground) bootGrafana(ctx context.Context, env *environment.Environme
 	if err := installIfMissing(env.Profile(), "grafana", options.version); err != nil {
 		return nil, errors.AddStack(err)
 	}
-	installPath, err := env.Profile().ComponentInstalledPath("grafana", v0manifest.Version(options.version))
+	installPath, err := env.Profile().ComponentInstalledPath("grafana", pkgver.Version(options.version))
 	if err != nil {
 		return nil, errors.AddStack(err)
 	}

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -46,7 +46,7 @@ import (
 	"github.com/pingcap/tiup/pkg/file"
 	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/pingcap/tiup/pkg/meta"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/pingcap/tiup/pkg/version"
@@ -1238,7 +1238,7 @@ func (m *Manager) Deploy(
 			switch inst.ComponentName() {
 			case spec.ComponentTiSpark:
 				env := environment.GlobalEnv()
-				var sparkVer v0manifest.Version
+				var sparkVer pkgver.Version
 				if sparkVer, _, iterErr = env.V1Repository().LatestStableVersion(spec.ComponentSpark, false); iterErr != nil {
 					return
 				}
@@ -2015,7 +2015,7 @@ func buildScaleOutTask(
 			switch inst.ComponentName() {
 			case spec.ComponentTiSpark:
 				env := environment.GlobalEnv()
-				var sparkVer v0manifest.Version
+				var sparkVer pkgver.Version
 				if sparkVer, _, iterErr = env.V1Repository().LatestStableVersion(spec.ComponentSpark, false); iterErr != nil {
 					return
 				}

--- a/pkg/environment/env.go
+++ b/pkg/environment/env.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tiup/pkg/repository"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/verbose"
 	"github.com/pingcap/tiup/pkg/version"
 	"golang.org/x/mod/semver"
@@ -229,7 +230,7 @@ func (env *Environment) SelfUpdate() error {
 	return env.repo.DownloadTiup(env.LocalPath("bin"))
 }
 
-func (env *Environment) downloadComponentv1(component string, version v0manifest.Version, overwrite bool) error {
+func (env *Environment) downloadComponentv1(component string, version pkgver.Version, overwrite bool) error {
 	spec := repository.ComponentSpec{
 		ID:      component,
 		Version: string(version),
@@ -240,7 +241,7 @@ func (env *Environment) downloadComponentv1(component string, version v0manifest
 }
 
 // downloadComponent downloads the specific version of a component from repository
-func (env *Environment) downloadComponent(component string, version v0manifest.Version, overwrite bool) error {
+func (env *Environment) downloadComponent(component string, version pkgver.Version, overwrite bool) error {
 	if env.v1Repo != nil {
 		return env.downloadComponentv1(component, version, overwrite)
 	}
@@ -277,12 +278,12 @@ func (env *Environment) downloadComponent(component string, version v0manifest.V
 
 // SelectInstalledVersion selects the installed versions and the latest release version
 // will be chosen if there is an empty version
-func (env *Environment) SelectInstalledVersion(component string, version v0manifest.Version) (v0manifest.Version, error) {
+func (env *Environment) SelectInstalledVersion(component string, version pkgver.Version) (pkgver.Version, error) {
 	return env.profile.SelectInstalledVersion(component, version)
 }
 
 // DownloadComponentIfMissing downloads the specific version of a component if it is missing
-func (env *Environment) DownloadComponentIfMissing(component string, version v0manifest.Version) (v0manifest.Version, error) {
+func (env *Environment) DownloadComponentIfMissing(component string, version pkgver.Version) (pkgver.Version, error) {
 	versions, err := env.profile.InstalledVersions(component)
 	if err != nil {
 		return "", err
@@ -296,14 +297,14 @@ func (env *Environment) DownloadComponentIfMissing(component string, version v0m
 		sort.Slice(versions, func(i, j int) bool {
 			return semver.Compare(versions[i], versions[j]) < 0
 		})
-		version = v0manifest.Version(versions[len(versions)-1])
+		version = pkgver.Version(versions[len(versions)-1])
 	}
 
 	needDownload := version.IsEmpty()
 	if !version.IsEmpty() {
 		installed := false
 		for _, v := range versions {
-			if v0manifest.Version(v) == version {
+			if pkgver.Version(v) == version {
 				installed = true
 				break
 			}
@@ -339,12 +340,12 @@ func (env *Environment) latestManifest() (*v0manifest.ComponentManifest, error) 
 }
 
 // GetComponentInstalledVersion return the installed version of component.
-func (env *Environment) GetComponentInstalledVersion(component string, version v0manifest.Version) (v0manifest.Version, error) {
+func (env *Environment) GetComponentInstalledVersion(component string, version pkgver.Version) (pkgver.Version, error) {
 	return env.profile.GetComponentInstalledVersion(component, version)
 }
 
 // BinaryPath return the installed binary path.
-func (env *Environment) BinaryPath(component string, version v0manifest.Version) (string, error) {
+func (env *Environment) BinaryPath(component string, version pkgver.Version) (string, error) {
 	if env.v1Repo != nil {
 		installPath, err := env.profile.ComponentInstalledPath(component, version)
 		if err != nil {
@@ -357,10 +358,10 @@ func (env *Environment) BinaryPath(component string, version v0manifest.Version)
 }
 
 // ParseCompVersion parses component part from <component>[:version] specification
-func ParseCompVersion(spec string) (string, v0manifest.Version) {
+func ParseCompVersion(spec string) (string, pkgver.Version) {
 	if strings.Contains(spec, ":") {
 		parts := strings.SplitN(spec, ":", 2)
-		return parts[0], v0manifest.Version(parts[1])
+		return parts[0], pkgver.Version(parts[1])
 	}
 	return spec, ""
 }

--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -31,7 +31,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/localdata"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/telemetry"
 	"golang.org/x/mod/semver"
 )
@@ -134,7 +134,7 @@ func base62Tag() string {
 type PrepareCommandParams struct {
 	Ctx         context.Context
 	Component   string
-	Version     v0manifest.Version
+	Version     pkgver.Version
 	BinPath     string
 	Tag         string
 	InstanceDir string
@@ -241,7 +241,7 @@ func PrepareCommand(p *PrepareCommandParams) (*exec.Cmd, error) {
 	return c, nil
 }
 
-func launchComponent(ctx context.Context, component string, version v0manifest.Version, binPath string, tag string, args []string, env *environment.Environment) (*localdata.Process, error) {
+func launchComponent(ctx context.Context, component string, version pkgver.Version, binPath string, tag string, args []string, env *environment.Environment) (*localdata.Process, error) {
 	instanceDir := os.Getenv(localdata.EnvNameInstanceDataDir)
 	if instanceDir == "" {
 		// Generate a tag for current instance if the tag doesn't specified

--- a/pkg/localdata/constant.go
+++ b/pkg/localdata/constant.go
@@ -83,7 +83,7 @@ const (
 
 	// EnvNameMirrorSyncScript make it possible for user to sync mirror commit to other place (eg. CDN)
 	EnvNameMirrorSyncScript = "TIUP_MIRROR_SYNC_SCRIPT"
-  
+
 	// EnvNameLogPath is the variable name by which user can write the log files into
 	EnvNameLogPath = "TIUP_LOG_PATH"
 

--- a/pkg/localdata/profile.go
+++ b/pkg/localdata/profile.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 	"golang.org/x/mod/semver"
 )
@@ -80,7 +81,7 @@ func (p *Profile) Root() string {
 }
 
 // BinaryPathV0 returns the binary path of component specific version
-func (p *Profile) BinaryPathV0(component string, version v0manifest.Version) (string, error) {
+func (p *Profile) BinaryPathV0(component string, version pkgver.Version) (string, error) {
 	manifest := p.Versions(component)
 	if manifest == nil {
 		return "", errors.Errorf("component `%s` doesn't install", component)
@@ -106,7 +107,7 @@ func (p *Profile) BinaryPathV0(component string, version v0manifest.Version) (st
 }
 
 // GetComponentInstalledVersion return the installed version of component.
-func (p *Profile) GetComponentInstalledVersion(component string, version v0manifest.Version) (v0manifest.Version, error) {
+func (p *Profile) GetComponentInstalledVersion(component string, version pkgver.Version) (pkgver.Version, error) {
 	if !version.IsEmpty() {
 		return version, nil
 	}
@@ -123,7 +124,7 @@ func (p *Profile) GetComponentInstalledVersion(component string, version v0manif
 		sort.Slice(versions, func(i, j int) bool {
 			return semver.Compare(versions[i], versions[j]) < 0
 		})
-		version = v0manifest.Version(versions[len(versions)-1])
+		version = pkgver.Version(versions[len(versions)-1])
 	} else {
 		return "", fmt.Errorf("component not installed, please try `tiup install %s` to install it", component)
 	}
@@ -131,7 +132,7 @@ func (p *Profile) GetComponentInstalledVersion(component string, version v0manif
 }
 
 // ComponentInstalledPath returns the path where the component installed
-func (p *Profile) ComponentInstalledPath(component string, version v0manifest.Version) (string, error) {
+func (p *Profile) ComponentInstalledPath(component string, version pkgver.Version) (string, error) {
 	installedVersion, err := p.GetComponentInstalledVersion(component, version)
 	if err != nil {
 		return "", err
@@ -302,7 +303,7 @@ func (p *Profile) VersionIsInstalled(component, version string) (bool, error) {
 
 // SelectInstalledVersion selects the installed versions and the latest release version
 // will be chosen if there is an empty version
-func (p *Profile) SelectInstalledVersion(component string, version v0manifest.Version) (v0manifest.Version, error) {
+func (p *Profile) SelectInstalledVersion(component string, version pkgver.Version) (pkgver.Version, error) {
 	installed, err := p.InstalledVersions(component)
 	if err != nil {
 		return "", err
@@ -317,11 +318,11 @@ func (p *Profile) SelectInstalledVersion(component string, version v0manifest.Ve
 		sort.Slice(installed, func(i, j int) bool {
 			return semver.Compare(installed[i], installed[j]) < 0
 		})
-		version = v0manifest.Version(installed[len(installed)-1])
+		version = pkgver.Version(installed[len(installed)-1])
 	}
 	found := false
 	for _, v := range installed {
-		if v0manifest.Version(v) == version {
+		if pkgver.Version(v) == version {
 			found = true
 			break
 		}

--- a/pkg/meta/err_test.go
+++ b/pkg/meta/err_test.go
@@ -15,16 +15,13 @@ package meta
 
 import (
 	"errors"
+	"testing"
 
 	"github.com/pingcap/check"
 )
 
-type metaSuite struct {
-}
-
-var _ = check.Suite(&metaSuite{})
-
-func (s *metaSuite) TestValidateErrIs(c *check.C) {
+func TestValidateErrIs(t *testing.T) {
+	var c *check.C
 	err0 := &ValidateErr{
 		Type:   "dummy",
 		Target: "test",

--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/pingcap/errors"
 	ru "github.com/pingcap/tiup/pkg/repository/utils"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/pingcap/tiup/pkg/version"
@@ -435,7 +435,7 @@ func combineVersions(versions *[]string,
 					// Use the latest stable versionS if the selected version doesn't exist in specific platform
 					var latest string
 					for v := range versions {
-						if v0manifest.Version(v).IsNightly() {
+						if pkgver.Version(v).IsNightly() {
 							continue
 						}
 						if latest == "" || semver.Compare(v, latest) > 0 {

--- a/pkg/repository/merge_mirror.go
+++ b/pkg/repository/merge_mirror.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/repository/model"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/version"
 )
 
@@ -79,7 +79,7 @@ func component2Diff(name string, baseItem v1manifest.ComponentItem, baseManifest
 		versions := additionManifest.VersionList(plat)
 		for ver, verinfo := range versions {
 			// Don't merge nightly this time
-			if v0manifest.Version(ver).IsNightly() {
+			if pkgver.Version(ver).IsNightly() {
 				continue
 			}
 

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -36,8 +36,8 @@ import (
 	"github.com/pingcap/tiup/pkg/repository/store"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
 	"github.com/pingcap/tiup/pkg/utils"
-	"github.com/pingcap/tiup/pkg/utils/rand"
 	"github.com/pingcap/tiup/pkg/utils/mock"
+	"github.com/pingcap/tiup/pkg/utils/rand"
 	"github.com/pingcap/tiup/pkg/verbose"
 )
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 )
 
 // Repository represents a components repository. All logic concerning manifests and the locations of tarballs
@@ -88,7 +89,7 @@ func (r *Repository) ComponentVersions(component string) (*v0manifest.VersionMan
 }
 
 // LatestStableVersion returns the latest stable version of specific component
-func (r *Repository) LatestStableVersion(component string) (v0manifest.Version, error) {
+func (r *Repository) LatestStableVersion(component string) (pkgver.Version, error) {
 	ver, err := r.ComponentVersions(component)
 	if err != nil {
 		return "", err
@@ -103,7 +104,7 @@ func (r *Repository) DownloadTiup(targetDir string) error {
 
 // DownloadComponent downloads a component with specific version from repository
 // support `<component>[:version]` format
-func (r *Repository) DownloadComponent(compsDir, component string, version v0manifest.Version) error {
+func (r *Repository) DownloadComponent(compsDir, component string, version pkgver.Version) error {
 	versions, err := r.ComponentVersions(component)
 	if err != nil {
 		return err

--- a/pkg/repository/v0manifest/component.go
+++ b/pkg/repository/v0manifest/component.go
@@ -15,6 +15,8 @@ package v0manifest
 
 import (
 	"strings"
+
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 )
 
 type (
@@ -31,7 +33,7 @@ type (
 	ComponentManifest struct {
 		Description string          `json:"description"`
 		Modified    string          `json:"modified"`
-		TiUPVersion Version         `json:"tiup_version"`
+		TiUPVersion pkgver.Version  `json:"tiup_version"`
 		Components  []ComponentInfo `json:"components"`
 	}
 )

--- a/pkg/repository/v0manifest/version.go
+++ b/pkg/repository/v0manifest/version.go
@@ -16,21 +16,18 @@ package v0manifest
 import (
 	"fmt"
 	"sort"
-	"strings"
 
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"golang.org/x/mod/semver"
 )
 
 type (
-	// Version represents a version string, like: v3.1.2
-	Version string
-
 	// VersionInfo represents the version information of component
 	VersionInfo struct {
-		Version   Version  `json:"version"`
-		Date      string   `json:"date"`
-		Entry     string   `json:"entry"`
-		Platforms []string `json:"platforms"`
+		Version   pkgver.Version `json:"version"`
+		Date      string         `json:"date"`
+		Entry     string         `json:"entry"`
+		Platforms []string       `json:"platforms"`
 	}
 
 	// VersionManifest represents the all versions information of specific component
@@ -42,26 +39,6 @@ type (
 	}
 )
 
-// IsValid checks whether is the version string valid
-func (v Version) IsValid() bool {
-	return v != "" && semver.IsValid(string(v))
-}
-
-// IsEmpty returns true if the `Version` is a empty string
-func (v Version) IsEmpty() bool {
-	return v == ""
-}
-
-// IsNightly returns true if the version is nightly
-func (v Version) IsNightly() bool {
-	return strings.Contains(string(v), "nightly")
-}
-
-// String implements the fmt.Stringer interface
-func (v Version) String() string {
-	return string(v)
-}
-
 // Sort sorts all versions
 func (manifest *VersionManifest) Sort() {
 	sort.Slice(manifest.Versions, func(i, j int) bool {
@@ -72,7 +49,7 @@ func (manifest *VersionManifest) Sort() {
 }
 
 // LatestVersion returns the latest stable version
-func (manifest *VersionManifest) LatestVersion() Version {
+func (manifest *VersionManifest) LatestVersion() pkgver.Version {
 	if len(manifest.Versions) > 0 {
 		return manifest.Versions[len(manifest.Versions)-1].Version
 	}
@@ -80,7 +57,7 @@ func (manifest *VersionManifest) LatestVersion() Version {
 }
 
 // ContainsVersion returns if the versions contain the specific version
-func (manifest *VersionManifest) ContainsVersion(version Version) bool {
+func (manifest *VersionManifest) ContainsVersion(version pkgver.Version) bool {
 	if version.IsNightly() && manifest.Nightly != nil {
 		return true
 	}
@@ -93,7 +70,7 @@ func (manifest *VersionManifest) ContainsVersion(version Version) bool {
 }
 
 // FindVersion returns the specific version info
-func (manifest *VersionManifest) FindVersion(version Version) (VersionInfo, bool) {
+func (manifest *VersionManifest) FindVersion(version pkgver.Version) (VersionInfo, bool) {
 	if version.IsNightly() {
 		if manifest.Nightly != nil {
 			return *manifest.Nightly, true

--- a/pkg/repository/v0manifest/version_test.go
+++ b/pkg/repository/v0manifest/version_test.go
@@ -14,14 +14,14 @@
 package v0manifest
 
 import (
+	"testing"
+
 	. "github.com/pingcap/check"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 )
 
-type manifestSuite struct{}
-
-var _ = Suite(&manifestSuite{})
-
-func (s *manifestSuite) TestVersions(c *C) {
+func TestVersions(t *testing.T) {
+	var c *C
 	vm := VersionManifest{
 		Description: "test",
 		Modified:    "test1",
@@ -61,17 +61,9 @@ func (s *manifestSuite) TestVersions(c *C) {
 		},
 	}
 
-	c.Assert(Version("").IsValid(), IsFalse)
-	c.Assert(Version("v3.0.").IsValid(), IsFalse)
-	c.Assert(Version("").IsEmpty(), IsTrue)
-	c.Assert(Version("").IsNightly(), IsFalse)
-	c.Assert(Version("nightly").IsNightly(), IsTrue)
-
-	c.Assert(Version("v3.0.0").String(), Equals, "v3.0.0")
-
 	vm.Sort()
-	c.Assert(vm.Versions[1].Version, Equals, Version("v0.0.2"))
-	c.Assert(vm.LatestVersion(), Equals, Version("v0.0.3"))
+	c.Assert(vm.Versions[1].Version, Equals, pkgver.Version("v0.0.2"))
+	c.Assert(vm.LatestVersion(), Equals, pkgver.Version("v0.0.3"))
 	c.Assert(vm.ContainsVersion("v0.0.3"), IsTrue)
 	c.Assert(vm.ContainsVersion("v0.0.4"), IsFalse)
 

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -32,8 +32,8 @@ import (
 	cjson "github.com/gibson042/canonicaljson-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/localdata"
-	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/pingcap/tiup/pkg/verbose"
 	"github.com/pingcap/tiup/pkg/version"
@@ -127,7 +127,7 @@ func (r *V1Repository) UpdateComponents(specs []ComponentSpec) error {
 			spec.Force = true
 		}
 		specVersion := spec.Version
-		if v0manifest.Version(spec.Version).IsNightly() {
+		if pkgver.Version(spec.Version).IsNightly() {
 			specVersion = manifest.Nightly
 		}
 
@@ -239,7 +239,7 @@ func (r *V1Repository) selectVersion(id string, versions map[string]v1manifest.V
 		var latest string
 		var latestItem v1manifest.VersionItem
 		for version, item := range versions {
-			if v0manifest.Version(version).IsNightly() {
+			if pkgver.Version(version).IsNightly() {
 				continue
 			}
 
@@ -728,7 +728,7 @@ func (r *V1Repository) ComponentVersion(id, version string, includeYanked bool) 
 	if err != nil {
 		return nil, err
 	}
-	if v0manifest.Version(version).IsNightly() && manifest.Nightly != "" {
+	if pkgver.Version(version).IsNightly() && manifest.Nightly != "" {
 		version = manifest.Nightly
 	}
 	if version == "" {
@@ -746,7 +746,7 @@ func (r *V1Repository) ComponentVersion(id, version string, includeYanked bool) 
 }
 
 // LatestStableVersion returns the latest stable version of specific component
-func (r *V1Repository) LatestStableVersion(id string, withYanked bool) (v0manifest.Version, *v1manifest.VersionItem, error) {
+func (r *V1Repository) LatestStableVersion(id string, withYanked bool) (pkgver.Version, *v1manifest.VersionItem, error) {
 	com, err := r.FetchComponentManifest(id, withYanked)
 	if err != nil {
 		return "", nil, err
@@ -759,7 +759,7 @@ func (r *V1Repository) LatestStableVersion(id string, withYanked bool) (v0manife
 
 	var last string
 	for v := range versions {
-		if v0manifest.Version(v).IsNightly() {
+		if pkgver.Version(v).IsNightly() {
 			continue
 		}
 
@@ -772,7 +772,7 @@ func (r *V1Repository) LatestStableVersion(id string, withYanked bool) (v0manife
 		return "", nil, fmt.Errorf("component %s doesn't has a stable version", id)
 	}
 
-	return v0manifest.Version(last), com.VersionItem(r.PlatformString(), last, false), nil
+	return pkgver.Version(last), com.VersionItem(r.PlatformString(), last, false), nil
 }
 
 // BinaryPath return the binary path of the component.
@@ -800,7 +800,7 @@ func (r *V1Repository) BinaryPath(installPath string, componentID string, versio
 	}
 
 	specVersion := version
-	if v0manifest.Version(version).IsNightly() {
+	if pkgver.Version(version).IsNightly() {
 		specVersion = component.Nightly
 	}
 

--- a/pkg/repository/version/version.go
+++ b/pkg/repository/version/version.go
@@ -1,0 +1,45 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgver
+
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+type (
+	// Version represents a version string, like: v3.1.2
+	Version string
+)
+
+// IsValid checks whether is the version string valid
+func (v Version) IsValid() bool {
+	return v != "" && semver.IsValid(string(v))
+}
+
+// IsEmpty returns true if the `Version` is a empty string
+func (v Version) IsEmpty() bool {
+	return v == ""
+}
+
+// IsNightly returns true if the version is nightly
+func (v Version) IsNightly() bool {
+	return strings.Contains(string(v), "nightly")
+}
+
+// String implements the fmt.Stringer interface
+func (v Version) String() string {
+	return string(v)
+}

--- a/pkg/repository/version/version_test.go
+++ b/pkg/repository/version/version_test.go
@@ -1,0 +1,30 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgver
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+func TestVersion(t *testing.T) {
+	var c *C
+	c.Assert(Version("").IsValid(), IsFalse)
+	c.Assert(Version("v3.0.").IsValid(), IsFalse)
+	c.Assert(Version("").IsEmpty(), IsTrue)
+	c.Assert(Version("").IsNightly(), IsFalse)
+	c.Assert(Version("nightly").IsNightly(), IsTrue)
+	c.Assert(Version("v1.2.3").String(), Equals, "v1.2.3")
+}

--- a/server/package/package.go
+++ b/server/package/package.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/localdata"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/pingcap/tiup/pkg/version"
 	"github.com/spf13/cobra"
@@ -151,7 +152,7 @@ func manifestIndex(options packageOptions) error {
 	}
 	if err == errNotFound {
 		mIndex.Modified = time.Now().Format(time.RFC3339)
-		mIndex.TiUPVersion = v0manifest.Version(version.NewTiUPVersion().SemVer())
+		mIndex.TiUPVersion = pkgver.Version(version.NewTiUPVersion().SemVer())
 		mIndex.Description = "TiDB components manager"
 	}
 
@@ -198,7 +199,7 @@ func componentIndex(options packageOptions) error {
 		return err
 	}
 
-	version := v0manifest.Version(options.version)
+	version := pkgver.Version(options.version)
 
 	v := v0manifest.VersionInfo{
 		Version:   version,

--- a/tools/migrate/main.go
+++ b/tools/migrate/main.go
@@ -28,6 +28,7 @@ import (
 	ru "github.com/pingcap/tiup/pkg/repository/utils"
 	"github.com/pingcap/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	pkgver "github.com/pingcap/tiup/pkg/repository/version"
 	"github.com/pingcap/tiup/pkg/utils"
 	tiupver "github.com/pingcap/tiup/pkg/version"
 	"github.com/spf13/cobra"
@@ -334,7 +335,7 @@ func migrate(srcDir, dstDir string, rehash bool) error {
 		Description: tiupDesc,
 		Versions: []v0manifest.VersionInfo{
 			{
-				Version: v0manifest.Version(tiupver.NewTiUPVersion().SemVer()),
+				Version: pkgver.Version(tiupver.NewTiUPVersion().SemVer()),
 				Date:    time.Now().Format(time.RFC3339),
 				Entry:   "tiup",
 			},


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This is part (and the initial step) of #906 

### What is changed and how it works?
Move `v0manifest.Version` to a dedicated `pkgver` package to reduce dependencies of `v0manifest`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
