### PR TITLE
Fix bug for only one directory in TiFlash storage.* configuration

### DIFF
--- a/pkg/cluster/spec/parse_topology_test.go
+++ b/pkg/cluster/spec/parse_topology_test.go
@@ -381,6 +381,24 @@ tiflash_servers:
 		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "")
 	})
 
+	// test if there is only one path in storage.main.dir
+	withTempFile(`
+tiflash_servers:
+  - host: 172.16.5.140
+    data_dir: /hhd0/tiflash
+    config:
+      storage.main.dir: [/ssd0/tiflash]
+`, func(file string) {
+		topo := Specification{}
+		err := ParseTopologyYaml(file, &topo)
+		c.Assert(err, check.IsNil)
+		ExpandRelativeDir(&topo)
+
+		c.Assert(topo.TiFlashServers[0].DeployDir, check.Equals, "/home/tidb/deploy/tiflash-9000")
+		c.Assert(topo.TiFlashServers[0].DataDir, check.Equals, "/ssd0/tiflash")
+		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "")
+	})
+
 	// test tiflash storage section defined data dir
 	// should always define storage.main.dir if any 'storage.*' is defined
 	withTempFile(`

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -177,7 +177,11 @@ func (s TiFlashSpec) GetOverrideDataDir() (string, error) {
 		i++
 	}
 	sort.Strings(keys)
-	return firstPath + "," + strings.Join(keys, ","), nil
+	joinedPaths := firstPath
+	if len(keys) > 0 {
+		joinedPaths += "," + strings.Join(keys, ",")
+	}
+	return joinedPaths, nil
 }
 
 // TiFlashComponent represents TiFlash component.


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If there is only one directory in TiFlash storage.* configuration, the TiFlashSpec DataDir become unexpected value.
Introduced by #931 

### What is changed and how it works?

Fix a bug that if there is only one directory in TiFlash storage.* configuration

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - N/A

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
