### PR TITLE
Support --node/-n config to specific node in tiup cluster clean(#742)

### DIFF
--- a/components/cluster/command/clean.go
+++ b/components/cluster/command/clean.go
@@ -32,7 +32,9 @@ You can retain some nodes and roles data when cleanup the cluster, eg:
     $ tiup cluster clean <cluster-name> --data
     $ tiup cluster clean <cluster-name> --all --ignore-role prometheus
     $ tiup cluster clean <cluster-name> --all --ignore-node 172.16.13.11:9000
-    $ tiup cluster clean <cluster-name> --all --ignore-node 172.16.13.12`,
+    $ tiup cluster clean <cluster-name> --all --ignore-node 172.16.13.12
+    $ tiup cluster clean <cluster-name> --all -n 172.16.13.12
+    $ tiup cluster clean <cluster-name> --all --node 172.16.13.11:9000`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return cmd.Help()
@@ -56,6 +58,7 @@ You can retain some nodes and roles data when cleanup the cluster, eg:
 
 	cmd.Flags().StringArrayVar(&cleanOpt.RetainDataNodes, "ignore-node", nil, "Specify the nodes or hosts whose data will be retained")
 	cmd.Flags().StringArrayVar(&cleanOpt.RetainDataRoles, "ignore-role", nil, "Specify the roles whose data will be retained")
+	cmd.Flags().StringArrayVarP(&cleanOpt.CleanDataNodes, "node", "n", nil, "Specify the nodes whose log will be clean")
 	cmd.Flags().BoolVar(&cleanOpt.CleanupData, "data", false, "Cleanup data")
 	cmd.Flags().BoolVar(&cleanOpt.CleanupLog, "log", false, "Cleanup log")
 	cmd.Flags().BoolVar(&cleanALl, "all", false, "Cleanup both log and data")

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -307,11 +307,12 @@ func (m *Manager) CleanCluster(clusterName string, gOpt operator.Options, cleanO
 			target = "log"
 		}
 		if err := cliutil.PromptForConfirmOrAbortError(
-			"This operation will clean %s %s cluster %s's %s.\nNodes will be ignored: %s\nRoles will be ignored: %s\nDo you want to continue? [y/N]:",
+			"This operation will clean %s %s cluster %s's %s.\nNodes will be included:%s\nNodes will be ignored: %s\nRoles will be ignored: %s\nDo you want to continue? [y/N]:",
 			m.sysName,
 			color.HiYellowString(base.Version),
 			color.HiYellowString(clusterName),
 			target,
+			cleanOpt.CleanDataNodes,
 			cleanOpt.RetainDataNodes,
 			cleanOpt.RetainDataRoles); err != nil {
 			return err

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -237,10 +237,20 @@ func DestroyMonitored(getter ExecutorGetter, inst spec.Instance, options *spec.M
 func CleanupComponent(getter ExecutorGetter, instances []spec.Instance, cls spec.Topology, options Options) error {
 	retainDataRoles := set.NewStringSet(options.RetainDataRoles...)
 	retainDataNodes := set.NewStringSet(options.RetainDataNodes...)
+	cleanDataNodes := set.NewStringSet(options.CleanDataNodes...)
 
 	for _, ins := range instances {
+		dataRetained := false
+		// cleanDataNodes specified, instance not included well be retained
+		if len(cleanDataNodes) > 0 {
+			dataRetained = !(cleanDataNodes.Exist(ins.ID()) || cleanDataNodes.Exist(ins.GetHost()))
+			if dataRetained {
+				continue
+			}
+		}
+
 		// Some data of instances will be retained
-		dataRetained := retainDataRoles.Exist(ins.ComponentName()) ||
+		dataRetained = retainDataRoles.Exist(ins.ComponentName()) ||
 			retainDataNodes.Exist(ins.ID()) || retainDataNodes.Exist(ins.GetHost())
 
 		if dataRetained {

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -34,8 +34,9 @@ type Options struct {
 	SSHType           executor.SSHType // the ssh type: 'builtin', 'system', 'none'
 
 	// What type of things should we cleanup in clean command
-	CleanupData bool // should we cleanup data
-	CleanupLog  bool // should we clenaup log
+	CleanupData    bool     // should we cleanup data
+	CleanupLog     bool     // should we clenaup log
+	CleanDataNodes []string // clean data on specific nodes.
 
 	// Some data will be retained when destroying instances
 	RetainDataRoles []string

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -94,6 +94,12 @@ function cmd_subtest() {
     tiup-cluster $client exec $name -R tidb --command="systemctl status tidb-4000|grep 'enabled;'"
     tiup-cluster $client exec $name -R pd --command="systemctl status pd-2379|grep 'enabled;'"
 
+    tiup-cluster $client --yes clean $name --log -n $ipprefix.102:9090
+
+    echo "checking clean specific node log"
+    tiup-cluster $client exec $name $ipprefix.101 --command "ls /home/tidb/deploy/prometheus-9090/log/prometheus.log"
+    ! tiup-cluster $client exec $name $ipprefix.102 --command "ls /home/tidb/deploy/tidb-4000/log/tidb.log"
+
     tiup-cluster $client --yes clean $name --data --all --ignore-node $ipprefix.101:9090
 
     echo "checking cleanup data and log"


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
(#742) Support -n config in tiup cluster clean command.

### What is changed and how it works?
``` bash
 $ tiup cluster clean <cluster-name> --log -n 172.16.13.12
 $ tiup cluster clean <cluster-name> --all -n 172.16.13.12
 $ tiup cluster clean <cluster-name> --all --node 172.16.13.11:9000
 $ tiup cluster clean <cluster-name> --log -n 172.19.0.105 -n 172.19.0.104 --ignore-node 172.19.0.105
```

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
