### PR TITLE
Support host names in TLS certificates

### DIFF
--- a/pkg/cluster/task/tls.go
+++ b/pkg/cluster/task/tls.go
@@ -16,6 +16,7 @@ package task
 import (
 	"encoding/pem"
 	"fmt"
+	"net"
 	"path/filepath"
 
 	"github.com/pingcap/errors"
@@ -38,8 +39,13 @@ func (c *TLSCert) Execute(ctx *Context) error {
 	if err != nil {
 		return err
 	}
-	// we don't support hostname yet, only iplist is used
-	csr, err := privKey.CSR(c.inst.Role(), c.inst.ComponentName(), []string{}, []string{c.inst.GetHost()})
+
+	hosts := []string{c.inst.GetHost()}
+	ips := []string{}
+	if net.ParseIP(c.inst.GetHost()) != nil {
+		hosts, ips = ips, hosts
+	}
+	csr, err := privKey.CSR(c.inst.Role(), c.inst.ComponentName(), hosts, ips)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What problem does this PR solve?

This PR updates TLS certificate generator to support issuing certificates for host names, not only IP addresses.

This contributes towards fixing #337.

### What is changed and how it works?

If host name is detected field `DNSNames` of x509 SAN extenstion is used instead of `IPAddresses`.

* https://en.wikipedia.org/wiki/Subject_Alternative_Name
* https://tools.ietf.org/html/rfc5280#section-4.2.1.6

### Check List

Tests

Integration tests that cover this functionality is available in #950.

Release notes:
```release-note
NONE
```
