### PR TITLE
Fix the dependencies field to match the specification

### DIFF
--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -44,7 +44,7 @@ const (
 	ManifestFilenameTimestamp = "timestamp.json"
 
 	// SpecVersion of current, maybe we could expand it later
-	CurrentSpecVersion = "0.1.1"
+	CurrentSpecVersion = "0.1.0"
 
 	// AnyPlatform is the ID for platform independent components
 	AnyPlatform = "any/any"
@@ -98,7 +98,6 @@ var ManifestsConfig = map[string]ty{
 
 var knownVersions = map[string]bool{
 	"0.1.0": true,
-	"0.1.1": true,
 }
 
 // AddSignature adds one or more signatures to the manifest

--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -44,7 +44,7 @@ const (
 	ManifestFilenameTimestamp = "timestamp.json"
 
 	// SpecVersion of current, maybe we could expand it later
-	CurrentSpecVersion = "0.1.0"
+	CurrentSpecVersion = "0.1.1"
 
 	// AnyPlatform is the ID for platform independent components
 	AnyPlatform = "any/any"

--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -96,7 +96,10 @@ var ManifestsConfig = map[string]ty{
 	},
 }
 
-var knownVersions = map[string]struct{}{"0.1.0": {}}
+var knownVersions = map[string]bool{
+	"0.1.0": true,
+	"0.1.1": true,
+}
 
 // AddSignature adds one or more signatures to the manifest
 func (manifest *Manifest) AddSignature(sigs []Signature) {
@@ -201,7 +204,7 @@ func (s *SignedBase) isValid(filename string) error {
 		return fmt.Errorf("unknown manifest type: `%s`", s.Ty)
 	}
 
-	if _, ok := knownVersions[s.SpecVersion]; !ok {
+	if !knownVersions[s.SpecVersion] {
 		return fmt.Errorf("unknown manifest version: `%s`, you might need to update TiUp", s.SpecVersion)
 	}
 

--- a/pkg/repository/v1manifest/types.go
+++ b/pkg/repository/v1manifest/types.go
@@ -100,11 +100,11 @@ type Owner struct {
 
 // VersionItem is the manifest structure of a version of a component
 type VersionItem struct {
-	URL          string   `json:"url"`
-	Yanked       bool     `json:"yanked"`
-	Entry        string   `json:"entry"`
-	Released     string   `json:"released"`
-	Dependencies []string `json:"dependencies"`
+	URL          string            `json:"url"`
+	Yanked       bool              `json:"yanked"`
+	Entry        string            `json:"entry"`
+	Released     string            `json:"released"`
+	Dependencies map[string]string `json:"dependencies"`
 
 	FileHash
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
As https://github.com/pingcap/tiup/blame/master/doc/design/manifest.md#L256 specified, the dependencies filed should be `map[string]string`. But in the current implementation, it's `[]string`, fortunately, this field is not used up until now and it's aways a `null` in the manifest json file, which adopted both `[]string` and `map[string]string`. But in the future, we may use this field, so it's better to correct it as early as possible.

### What is changed and how it works?

- change `[]string` to `map[string]string`
- upgrade the spec version from `v0.1.0` to `v0.1.1`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
