### PR TITLE
cluster: refine log_dir handling on `clean` (part 1)

### DIFF
--- a/components/cluster/command/clean.go
+++ b/components/cluster/command/clean.go
@@ -24,8 +24,11 @@ func newCleanCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "clean <cluster-name>",
-		Short: "Cleanup a specified cluster",
-		Long: `Cleanup a specified cluster without destroying it (experimental).
+		Short: "(EXPERIMENTAL) Cleanup a specified cluster",
+		Long: `EXPERIMENTAL: This is an experimental feature, things may or may not work,
+please backup your data before process.
+
+Cleanup a specified cluster without destroying it.
 You can retain some nodes and roles data when cleanup the cluster, eg:
     $ tiup cluster clean <cluster-name> --all
     $ tiup cluster clean <cluster-name> --log

--- a/components/cluster/command/deploy.go
+++ b/components/cluster/command/deploy.go
@@ -82,7 +82,7 @@ func newDeploy() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opt.User, "user", "u", utils.CurrentUser(), "The user name to login via SSH. The user must has root (or sudo) privilege.")
-	cmd.Flags().BoolVarP(&opt.SkipCreateUser, "skip-create-user", "", false, "Skip creating the user specified in topology (experimental).")
+	cmd.Flags().BoolVarP(&opt.SkipCreateUser, "skip-create-user", "", false, "(EXPERIMENTAL) Skip creating the user specified in topology.")
 	cmd.Flags().StringVarP(&opt.IdentityFile, "identity_file", "i", opt.IdentityFile, "The path of the SSH identity file. If specified, public key authentication will be used.")
 	cmd.Flags().BoolVarP(&opt.UsePassword, "password", "p", false, "Use password of target hosts. If specified, password authentication will be used.")
 	cmd.Flags().BoolVarP(&opt.IgnoreConfigCheck, "ignore-config-check", "", opt.IgnoreConfigCheck, "Ignore the config check result")

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -136,8 +136,8 @@ func init() {
 	// start/stop operations is 90s, the default value of this argument is better be longer than that
 	rootCmd.PersistentFlags().Uint64Var(&gOpt.OptTimeout, "wait-timeout", 120, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 	rootCmd.PersistentFlags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip all confirmations and assumes 'yes'")
-	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "Use the native SSH client installed on local system instead of the build-in one (experimental).")
-	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "(experimental) The executor type: 'builtin', 'system', 'none'.")
+	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "(EXPERIMENTAL) Use the native SSH client installed on local system instead of the build-in one.")
+	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "(EXPERIMENTAL) The executor type: 'builtin', 'system', 'none'.")
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")
 
 	rootCmd.AddCommand(

--- a/components/cluster/command/scale_out.go
+++ b/components/cluster/command/scale_out.go
@@ -64,7 +64,7 @@ func newScaleOutCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opt.User, "user", "u", utils.CurrentUser(), "The user name to login via SSH. The user must has root (or sudo) privilege.")
-	cmd.Flags().BoolVarP(&opt.SkipCreateUser, "skip-create-user", "", false, "Skip creating the user specified in topology (experimental).")
+	cmd.Flags().BoolVarP(&opt.SkipCreateUser, "skip-create-user", "", false, "(EXPERIMENTAL) Skip creating the user specified in topology.")
 	cmd.Flags().StringVarP(&opt.IdentityFile, "identity_file", "i", opt.IdentityFile, "The path of the SSH identity file. If specified, public key authentication will be used.")
 	cmd.Flags().BoolVarP(&opt.UsePassword, "password", "p", false, "Use password of target hosts. If specified, password authentication will be used.")
 	cmd.Flags().BoolVarP(&opt.NoLabels, "no-labels", "", false, "Don't check TiKV labels")

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -64,8 +64,10 @@ func init() {
 	}
 
 	rootCmd = &cobra.Command{
-		Use:           cliutil.OsArgs0(),
-		Short:         "Deploy a DM cluster (experimental)",
+		Use:   cliutil.OsArgs0(),
+		Short: "(EXPERIMENTAL) Deploy a DM cluster",
+		Long: `EXPERIMENTAL: This is an experimental feature, things may or may not work,
+please backup your data before process.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Version:       version.NewTiUPVersion().String(),

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -308,18 +308,22 @@ func CleanupComponent(getter ExecutorGetter, instances []spec.Instance, cls spec
 		log.Infof("Cleanup instance %s", ins.GetHost())
 
 		delFiles := set.NewStringSet()
+		dataPaths := set.NewStringSet()
+		logPaths := set.NewStringSet()
 
 		if options.CleanupData && len(ins.DataDir()) > 0 {
 			for _, dataDir := range strings.Split(ins.DataDir(), ",") {
-				delFiles.Insert(path.Join(dataDir, "*"))
+				dataPaths.Insert(path.Join(dataDir, "*"))
 			}
 		}
 
 		if options.CleanupLog && len(ins.LogDir()) > 0 {
 			for _, logDir := range strings.Split(ins.LogDir(), ",") {
-				delFiles.Insert(path.Join(logDir, "*"))
+				logPaths.Insert(path.Join(logDir, "*.log"))
 			}
 		}
+
+		delFiles.Join(logPaths).Join(dataPaths)
 
 		log.Debugf("Deleting paths on %s: %s", ins.GetHost(), strings.Join(delFiles.Slice(), " "))
 		c := module.ShellModuleConfig{

--- a/pkg/set/string_set.go
+++ b/pkg/set/string_set.go
@@ -36,6 +36,14 @@ func (s StringSet) Insert(val string) {
 	s[val] = struct{}{}
 }
 
+// Join add all elements of `add` to `s`.
+func (s StringSet) Join(add StringSet) StringSet {
+	for elt := range add {
+		s.Insert(elt)
+	}
+	return s
+}
+
 // Intersection returns the intersection of two sets
 func (s StringSet) Intersection(rhs StringSet) StringSet {
 	newSet := NewStringSet()


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Part of #947 

### What is changed and how it works?
 - Mark experimental features more visible
 - Check for paths to avoid deleting files if data dir is a sub path of log dir
 - Only delete `*.log` when deleting log files

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has persistent data change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: adjust checking process when cleaning log files
```
