### PR TITLE
cluster/clean: prompt list of paths to be delete before processing (part 2)

### DIFF
--- a/pkg/cluster/manager/cleanup.go
+++ b/pkg/cluster/manager/cleanup.go
@@ -45,7 +45,7 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 	}
 
 	// calculate file paths to be deleted before the prompt
-	delFileMaps := make(map[string]set.StringSet)
+	delFileMap := make(map[string]set.StringSet)
 	for _, com := range topo.ComponentsByStopOrder() {
 		instances := com.Instances()
 		retainDataRoles := set.NewStringSet(cleanOpt.RetainDataRoles...)
@@ -75,10 +75,10 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 				}
 			}
 
-			if delFileMaps[ins.GetHost()] == nil {
-				delFileMaps[ins.GetHost()] = set.NewStringSet()
+			if delFileMap[ins.GetHost()] == nil {
+				delFileMap[ins.GetHost()] = set.NewStringSet()
 			}
-			delFileMaps[ins.GetHost()].Join(logPaths).Join(dataPaths)
+			delFileMap[ins.GetHost()].Join(logPaths).Join(dataPaths)
 		}
 	}
 
@@ -95,7 +95,7 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 
 		// build file list string
 		delFileList := ""
-		for host, fileList := range delFileMaps {
+		for host, fileList := range delFileMap {
 			delFileList += fmt.Sprintf("\n%s:", color.CyanString(host))
 			for _, dfp := range fileList.Slice() {
 				delFileList += fmt.Sprintf("\n %s", dfp)
@@ -121,7 +121,7 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 			return operator.Stop(ctx, topo, operator.Options{}, tlsCfg)
 		}).
 		Func("CleanupCluster", func(ctx *task.Context) error {
-			return operator.CleanupComponent(ctx, delFileMaps)
+			return operator.CleanupComponent(ctx, delFileMap)
 		}).
 		Build()
 

--- a/pkg/cluster/manager/cleanup.go
+++ b/pkg/cluster/manager/cleanup.go
@@ -67,7 +67,7 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 			return operator.Stop(ctx, topo, operator.Options{}, tlsCfg)
 		}).
 		Func("CleanupCluster", func(ctx *task.Context) error {
-			return operator.Cleanup(ctx, topo, cleanOpt)
+			return operator.CleanupComponent(ctx, topo, cleanOpt)
 		}).
 		Build()
 

--- a/pkg/cluster/manager/cleanup.go
+++ b/pkg/cluster/manager/cleanup.go
@@ -14,6 +14,10 @@
 package manager
 
 import (
+	"fmt"
+	"path"
+	"strings"
+
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
 	perrs "github.com/pingcap/errors"
@@ -22,6 +26,7 @@ import (
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/cluster/task"
 	"github.com/pingcap/tiup/pkg/logger/log"
+	"github.com/pingcap/tiup/pkg/set"
 )
 
 // CleanCluster cleans the cluster without destroying it
@@ -39,6 +44,44 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 		return err
 	}
 
+	// calculate file paths to be deleted before the prompt
+	delFileMaps := make(map[string]set.StringSet)
+	for _, com := range topo.ComponentsByStopOrder() {
+		instances := com.Instances()
+		retainDataRoles := set.NewStringSet(cleanOpt.RetainDataRoles...)
+		retainDataNodes := set.NewStringSet(cleanOpt.RetainDataNodes...)
+
+		for _, ins := range instances {
+			// Some data of instances will be retained
+			dataRetained := retainDataRoles.Exist(ins.ComponentName()) ||
+				retainDataNodes.Exist(ins.ID()) || retainDataNodes.Exist(ins.GetHost())
+
+			if dataRetained {
+				continue
+			}
+
+			dataPaths := set.NewStringSet()
+			logPaths := set.NewStringSet()
+
+			if cleanOpt.CleanupData && len(ins.DataDir()) > 0 {
+				for _, dataDir := range strings.Split(ins.DataDir(), ",") {
+					dataPaths.Insert(path.Join(dataDir, "*"))
+				}
+			}
+
+			if cleanOpt.CleanupLog && len(ins.LogDir()) > 0 {
+				for _, logDir := range strings.Split(ins.LogDir(), ",") {
+					logPaths.Insert(path.Join(logDir, "*.log"))
+				}
+			}
+
+			if delFileMaps[ins.GetHost()] == nil {
+				delFileMaps[ins.GetHost()] = set.NewStringSet()
+			}
+			delFileMaps[ins.GetHost()].Join(logPaths).Join(dataPaths)
+		}
+	}
+
 	if !skipConfirm {
 		target := ""
 		switch {
@@ -49,14 +92,25 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 		case cleanOpt.CleanupLog:
 			target = "log"
 		}
+
+		// build file list string
+		delFileList := ""
+		for host, fileList := range delFileMaps {
+			delFileList += fmt.Sprintf("\n%s:", color.CyanString(host))
+			for _, dfp := range fileList.Slice() {
+				delFileList += fmt.Sprintf("\n %s", dfp)
+			}
+		}
+
 		if err := cliutil.PromptForConfirmOrAbortError(
-			"This operation will clean %s %s cluster %s's %s.\nNodes will be ignored: %s\nRoles will be ignored: %s\nDo you want to continue? [y/N]:",
+			"This operation will clean %s %s cluster %s's %s.\nNodes will be ignored: %s\nRoles will be ignored: %s\nFiles to be deleted are: %s\nDo you want to continue? [y/N]:",
 			m.sysName,
 			color.HiYellowString(base.Version),
 			color.HiYellowString(name),
 			target,
 			cleanOpt.RetainDataNodes,
-			cleanOpt.RetainDataRoles); err != nil {
+			cleanOpt.RetainDataRoles,
+			delFileList); err != nil {
 			return err
 		}
 		log.Infof("Cleanup cluster...")
@@ -67,7 +121,7 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 			return operator.Stop(ctx, topo, operator.Options{}, tlsCfg)
 		}).
 		Func("CleanupCluster", func(ctx *task.Context) error {
-			return operator.CleanupComponent(ctx, topo, cleanOpt)
+			return operator.CleanupComponent(ctx, delFileMaps)
 		}).
 		Build()
 

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -273,68 +272,32 @@ func DestroyMonitored(getter ExecutorGetter, inst spec.Instance, options *spec.M
 }
 
 // CleanupComponent cleanup the instances
-func CleanupComponent(getter ExecutorGetter, cls spec.Topology, options Options) error {
-	coms := cls.ComponentsByStopOrder()
-
-	for _, com := range coms {
-		instances := com.Instances()
-		retainDataRoles := set.NewStringSet(options.RetainDataRoles...)
-		retainDataNodes := set.NewStringSet(options.RetainDataNodes...)
-
-		for _, ins := range instances {
-			// Some data of instances will be retained
-			dataRetained := retainDataRoles.Exist(ins.ComponentName()) ||
-				retainDataNodes.Exist(ins.ID()) || retainDataNodes.Exist(ins.GetHost())
-
-			if dataRetained {
-				continue
-			}
-
-			e := getter.Get(ins.GetHost())
-			log.Infof("Cleanup instance %s", ins.GetHost())
-
-			delFiles := set.NewStringSet()
-			dataPaths := set.NewStringSet()
-			logPaths := set.NewStringSet()
-
-			if options.CleanupData && len(ins.DataDir()) > 0 {
-				for _, dataDir := range strings.Split(ins.DataDir(), ",") {
-					dataPaths.Insert(path.Join(dataDir, "*"))
-				}
-			}
-
-			if options.CleanupLog && len(ins.LogDir()) > 0 {
-				for _, logDir := range strings.Split(ins.LogDir(), ",") {
-					logPaths.Insert(path.Join(logDir, "*.log"))
-				}
-			}
-
-			delFiles.Join(logPaths).Join(dataPaths)
-
-			log.Debugf("Deleting paths on %s: %s", ins.GetHost(), strings.Join(delFiles.Slice(), " "))
-			c := module.ShellModuleConfig{
-				Command:  fmt.Sprintf("rm -rf %s;", strings.Join(delFiles.Slice(), " ")),
-				Sudo:     true, // the .service files are in a directory owned by root
-				Chdir:    "",
-				UseShell: true,
-			}
-			shell := module.NewShellModule(c)
-			stdout, stderr, err := shell.Execute(e)
-
-			if len(stdout) > 0 {
-				fmt.Println(string(stdout))
-			}
-			if len(stderr) > 0 {
-				log.Errorf(string(stderr))
-			}
-
-			if err != nil {
-				return errors.Annotatef(err, "failed to cleanup: %s", ins.GetHost())
-			}
-
-			log.Infof("Cleanup %s success", ins.GetHost())
-			log.Infof("- Clanup %s files: %v", ins.ComponentName(), delFiles.Slice())
+func CleanupComponent(getter ExecutorGetter, delFileMaps map[string]set.StringSet) error {
+	for host, delFiles := range delFileMaps {
+		e := getter.Get(host)
+		log.Infof("Cleanup instance %s", host)
+		log.Debugf("Deleting paths on %s: %s", host, strings.Join(delFiles.Slice(), " "))
+		c := module.ShellModuleConfig{
+			Command:  fmt.Sprintf("rm -rf %s;", strings.Join(delFiles.Slice(), " ")),
+			Sudo:     true, // the .service files are in a directory owned by root
+			Chdir:    "",
+			UseShell: true,
 		}
+		shell := module.NewShellModule(c)
+		stdout, stderr, err := shell.Execute(e)
+
+		if len(stdout) > 0 {
+			fmt.Println(string(stdout))
+		}
+		if len(stderr) > 0 {
+			log.Errorf(string(stderr))
+		}
+
+		if err != nil {
+			return errors.Annotatef(err, "failed to cleanup: %s", host)
+		}
+
+		log.Infof("Cleanup %s success", host)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Prompt the user for file paths that are going to be delete and ask for confirmation, so that the user has a chance to cancel the process if there's anything unexpected.

This is a following up of #981 and closes #947 

### What is changed and how it works?
Calculate the file list before promoting for confirmation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
![图片](https://user-images.githubusercontent.com/596538/102190505-1548ce00-3ef3-11eb-8be0-92335b30558a.png)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: refine `clean` sub command for better usability
```
