### PR TITLE
respository: update root before snapshot

### DIFF
--- a/pkg/repository/v1_repository_test.go
+++ b/pkg/repository/v1_repository_test.go
@@ -443,7 +443,7 @@ func TestEnsureManifests(t *testing.T) {
 	assert.NotContains(t, local.Saved, v1manifest.ManifestFilenameRoot)
 
 	// Happy update
-	root2, priv2 := rootManifest(t)
+	root2, priv2 := rootManifest(t) // generate new root key
 	root, _ := repo.loadRoot()
 	root2.Version = root.Version + 1
 	mirror.Resources["/43.root.json"] = serialize(t, root2, priv, priv2)
@@ -451,11 +451,11 @@ func TestEnsureManifests(t *testing.T) {
 	rootMeta := snapshot.Meta[v1manifest.ManifestURLRoot]
 	rootMeta.Version = root2.Version
 	snapshot.Meta[v1manifest.ManifestURLRoot] = rootMeta
-	snapStr = serialize(t, snapshot, priv)
+	snapStr = serialize(t, snapshot, priv2) // sign snapshot with new key
 	ts.Meta[v1manifest.ManifestURLSnapshot].Hashes[v1manifest.SHA256] = hash(snapStr)
 	ts.Version++
 	mirror.Resources[v1manifest.ManifestURLSnapshot] = snapStr
-	mirror.Resources[v1manifest.ManifestURLTimestamp] = serialize(t, ts, priv)
+	mirror.Resources[v1manifest.ManifestURLTimestamp] = serialize(t, ts, priv2)
 	local.Saved = []string{}
 
 	err = repo.ensureManifests()


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The `root.json` should be updated before `snapshot.json`.

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
