### PR TITLE
cluster: update dashboard metadata on reload

### DIFF
--- a/pkg/cluster/manager/reload.go
+++ b/pkg/cluster/manager/reload.go
@@ -62,14 +62,16 @@ func (m *Manager) Reload(name string, opt operator.Options, skipRestart bool) er
 		}
 	}
 
-	tb := m.sshTaskBuilder(name, topo, base.User, opt).
-		UpdateTopology(
+	tb := m.sshTaskBuilder(name, topo, base.User, opt)
+	if topo.Type() == spec.TopoTypeTiDB {
+		tb = tb.UpdateTopology(
 			name,
 			m.specManager.Path(name),
 			metadata.(*spec.ClusterMeta),
 			nil, /* deleteNodeIds */
-		).
-		ParallelStep("+ Refresh instance configs", opt.Force, refreshConfigTasks...)
+		)
+	}
+	tb = tb.ParallelStep("+ Refresh instance configs", opt.Force, refreshConfigTasks...)
 
 	if len(monitorConfigTasks) > 0 {
 		tb = tb.ParallelStep("+ Refresh monitor configs", opt.Force, monitorConfigTasks...)

--- a/pkg/cluster/manager/reload.go
+++ b/pkg/cluster/manager/reload.go
@@ -63,6 +63,12 @@ func (m *Manager) Reload(name string, opt operator.Options, skipRestart bool) er
 	}
 
 	tb := m.sshTaskBuilder(name, topo, base.User, opt).
+		UpdateTopology(
+			name,
+			m.specManager.Path(name),
+			metadata.(*spec.ClusterMeta),
+			nil, /* deleteNodeIds */
+		).
 		ParallelStep("+ Refresh instance configs", opt.Force, refreshConfigTasks...)
 
 	if len(monitorConfigTasks) > 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The prometheus URL in PD is not updated on `reload`, thus dashboard is not using the correct prometheus for querying.

Currently, run `reload` with any node (even a non-exist node) could trigger the update and workaround this. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: update dashboard metadata on reload
```
