### PR TITLE
Fix tail newline on thp check

### DIFF
--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -669,7 +669,7 @@ func CheckTHP(e executor.Executor) *CheckResult {
 		return result
 	}
 
-	for _, line := range strings.Split(string(stdout), "\n") {
+	for _, line := range strings.Split(strings.Trim(string(stdout), "\n"), "\n") {
 		if !strings.Contains(line, "[never]") {
 			result.Err = fmt.Errorf("THP is enabled, please disable it for best performance")
 			return result


### PR DESCRIPTION
Introduced by https://github.com/pingcap/tiup/pull/964

Related issue: https://github.com/pingcap/tiup/issues/1006
There is a newline at the end of output of cat command,
so the '[never]' check will fail on the empty newline.
