### PR TITLE
cluster, dm: format semver input

### DIFF
--- a/components/cluster/command/deploy.go
+++ b/components/cluster/command/deploy.go
@@ -68,7 +68,10 @@ func newDeploy() *cobra.Command {
 			}
 
 			clusterName := args[0]
-			version := args[1]
+			version, err := utils.FmtVer(args[1])
+			if err != nil {
+				return err
+			}
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			teleCommand = append(teleCommand, version)
 

--- a/components/cluster/command/upgrade.go
+++ b/components/cluster/command/upgrade.go
@@ -14,6 +14,7 @@
 package command
 
 import (
+	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +28,10 @@ func newUpgradeCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
-			version := args[1]
+			version, err := utils.FmtVer(args[1])
+			if err != nil {
+				return err
+			}
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 			teleCommand = append(teleCommand, version)
 

--- a/components/dm/command/deploy.go
+++ b/components/dm/command/deploy.go
@@ -49,7 +49,10 @@ func newDeployCmd() *cobra.Command {
 			}
 
 			clusterName := args[0]
-			version := args[1]
+			version, err := utils.FmtVer(args[1])
+			if err != nil {
+				return err
+			}
 			topoFile := args[2]
 
 			if err := supportVersion(version); err != nil {

--- a/pkg/utils/semver.go
+++ b/pkg/utils/semver.go
@@ -24,6 +24,12 @@ import (
 // SemVer and fails to parse and convert it, an error is raised.
 func FmtVer(ver string) (string, error) {
 	v := ver
+
+	// nightly version is an alias
+	if strings.ToLower(v) == "nightly" {
+		return v, nil
+	}
+
 	if !strings.HasPrefix(ver, "v") {
 		v = fmt.Sprintf("v%s", ver)
 	}

--- a/pkg/utils/semver_test.go
+++ b/pkg/utils/semver_test.go
@@ -14,6 +14,8 @@ func (s *TestSemverSuite) TestSemverc(c *C) {
 		{"0.0.1", "v0.0.1", true},
 		{"invalid", "vinvalid", false},
 		{"", "v", false},
+		{"nightly", "nightly", true},
+		{"Nightly", "Nightly", true},
 	}
 
 	for _, cas := range cases {

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -63,9 +63,9 @@ function cmd_subtest() {
     tiup-cluster exec $name -N n3 --command "grep /home/tidb/my_kv_data /home/tidb/deploy/tikv-20160/scripts/run_tikv.sh"
 
     # test patch overwrite
-    tiup-cluster $client --yes patch $name ~/.tiup/storage/cluster/packages/tidb-$version-linux-amd64.tar.gz -R tidb --overwrite
+    tiup-cluster $client --yes patch $name ~/.tiup/storage/cluster/packages/tidb-v$version-linux-amd64.tar.gz -R tidb --overwrite
     # overwrite with the same tarball twice
-    tiup-cluster $client --yes patch $name ~/.tiup/storage/cluster/packages/tidb-$version-linux-amd64.tar.gz -R tidb --overwrite
+    tiup-cluster $client --yes patch $name ~/.tiup/storage/cluster/packages/tidb-v$version-linux-amd64.tar.gz -R tidb --overwrite
 
     tiup-cluster $client --yes stop $name
 

--- a/tests/tiup-cluster/test_cmd.sh
+++ b/tests/tiup-cluster/test_cmd.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/cmd_subtest.sh
 
-echo "test cluster for verision v4.0.4 wo/ TLS, via easy ssh"
-cmd_subtest v4.0.4 false false
+echo "test cluster for verision v4.0.9 wo/ TLS, via easy ssh"
+cmd_subtest 4.0.9 false false

--- a/tests/tiup-cluster/test_cmd_tls_native_ssh.sh
+++ b/tests/tiup-cluster/test_cmd_tls_native_ssh.sh
@@ -5,7 +5,7 @@ set -eu
 source script/cmd_subtest.sh
 export GO_FAILPOINTS='github.com/pingcap/tiup/pkg/cluster/executor/assertNativeSSH=return(true)' 
 
-echo "test cluster for verision v4.0.4 w/ TLS, via native ssh"
-cmd_subtest v4.0.4 true true
+echo "test cluster for verision v4.0.9 w/ TLS, via native ssh"
+cmd_subtest v4.0.9 true true
 
 unset GO_FAILPOINTS


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. prepend `v` to bare version number, so that `v4.0.8` and `4.0.8` are both valid input
2. validate input version to ensure it's a valid semver string

Close #350 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster, dm: support version input without leading 'v'
```
