### PR TITLE
Tiny fix for the problem that the Drainer monitoring configuration of Prometheus is lost due to spelling.

### DIFF
--- a/pkg/cluster/spec/prometheus.go
+++ b/pkg/cluster/spec/prometheus.go
@@ -199,7 +199,7 @@ func (i *MonitorInstance) InitConfig(
 			cfig.AddPump(pump.Host, uint64(pump.Port))
 		}
 	}
-	if servers, found := topoHasField("Trainers"); found {
+	if servers, found := topoHasField("Drainers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			drainer := servers.Index(i).Interface().(DrainerSpec)
 			uniqueHosts.Insert(drainer.Host)


### PR DESCRIPTION
Tiny fix for the problem that the Drainer monitoring configuration of Prometheus is lost due to spelling.
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Tiny fix for the problem that the Drainer monitoring configuration of Prometheus is lost due to spelling.

### What is changed and how it works?
Fix the spelling of "Drainer"

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
