### PR TITLE
Remove env that should not be set by user

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -23,8 +23,6 @@ import (
 
 var envList = []string{
 	localdata.EnvNameHome,
-	localdata.EnvNameTelemetryStatus,
-	localdata.EnvNameTelemetryUUID,
 	localdata.EnvNameSSHPassPrompt,
 	localdata.EnvNameSSHPath,
 	localdata.EnvNameSCPPath,


### PR DESCRIPTION
TIUP_TELEMETRY_STATUS and TIUP_TELEMETRY_UUID is passed to component
by TiUP itself, and it should not be set by user, so we should NOT
list it in tiup env