### PR TITLE
cluster: refine the process of getting latest store info from pd

### DIFF
--- a/pkg/cluster/api/error.go
+++ b/pkg/cluster/api/error.go
@@ -1,0 +1,41 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import "fmt"
+
+var (
+	// ErrNoStore is an empty NoStoreErr object, useful for type checking
+	ErrNoStore = &NoStoreErr{}
+)
+
+// NoStoreErr is the error that no store matching address can be found in PD
+type NoStoreErr struct {
+	addr string
+}
+
+// Error implement the error interface
+func (e *NoStoreErr) Error() string {
+	return fmt.Sprintf("no store matching address \"%s\" found", e.addr)
+}
+
+// Is implements the error interface
+func (e *NoStoreErr) Is(target error) bool {
+	t, ok := target.(*NoStoreErr)
+	if !ok {
+		return false
+	}
+
+	return e.addr == t.addr || t.addr == ""
+}

--- a/pkg/cluster/api/error_test.go
+++ b/pkg/cluster/api/error_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/pingcap/check"
+)
+
+func TestNoStoreErrIs(t *testing.T) {
+	var c *check.C
+	err0 := &NoStoreErr{
+		addr: "1.2.3.4",
+	}
+	// identical errors are equal
+	c.Assert(errors.Is(err0, err0), check.IsTrue)
+	c.Assert(errors.Is(ErrNoStore, ErrNoStore), check.IsTrue)
+	c.Assert(errors.Is(ErrNoStore, &NoStoreErr{}), check.IsTrue)
+	c.Assert(errors.Is(&NoStoreErr{}, ErrNoStore), check.IsTrue)
+	// not equal for different error types
+	c.Assert(errors.Is(err0, errors.New("")), check.IsFalse)
+	// default Value matches any error
+	c.Assert(errors.Is(err0, ErrNoStore), check.IsTrue)
+	// error with values are not matching default ones
+	c.Assert(errors.Is(ErrNoStore, err0), check.IsFalse)
+
+	err1 := &NoStoreErr{
+		addr: "2.3.4.5",
+	}
+	c.Assert(errors.Is(err1, ErrNoStore), check.IsTrue)
+	// errors with different values are not equal
+	c.Assert(errors.Is(err0, err1), check.IsFalse)
+	c.Assert(errors.Is(err1, err0), check.IsFalse)
+}

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -391,7 +391,7 @@ func (pc *PDClient) EvictStoreLeader(host string, retryOpt *utils.RetryOption, c
 		return nil
 	}
 
-	log.Infof("Evicting %d leaders from store %s...", leaderCount, latestStore.Store.Address)
+	log.Infof("\tEvicting %d leaders from store %s...", leaderCount, latestStore.Store.Address)
 
 	// set scheduler for stores
 	scheduler, err := json.Marshal(pdSchedulerRequest{
@@ -431,8 +431,8 @@ func (pc *PDClient) EvictStoreLeader(host string, retryOpt *utils.RetryOption, c
 		if leaderCount == 0 {
 			return nil
 		}
-		log.Debugf(
-			"Still waitting for %d store leaders to transfer...",
+		log.Infof(
+			"\t  Still waitting for %d store leaders to transfer...",
 			leaderCount,
 		)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This is a following up of #1011 

### What is changed and how it works?
Some more functions than checking store state are querying for store info of the latest / current store from PD that matching a specific host, so use a dedicated function to archive that purpose and implement the workaround of non-monotonic ID issue of PD there.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
