### PR TITLE
cluster: support spec template for `exec`

### DIFF
--- a/components/cluster/command/check.go
+++ b/components/cluster/command/check.go
@@ -204,6 +204,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, gO
 				Shell(
 					inst.GetHost(),
 					filepath.Join(task.CheckToolsPathDir, "bin", "insight"),
+					"",
 					false,
 				).
 				BuildAsStep(fmt.Sprintf("  - Getting system info of %s:%d", inst.GetHost(), inst.GetSSHPort()))
@@ -230,6 +231,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, gO
 				Shell(
 					inst.GetHost(),
 					"ss -lnt",
+					"",
 					false,
 				).
 				CheckSys(
@@ -243,6 +245,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, gO
 				Shell(
 					inst.GetHost(),
 					"cat /etc/security/limits.conf",
+					"",
 					false,
 				).
 				CheckSys(
@@ -256,6 +259,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, gO
 				Shell(
 					inst.GetHost(),
 					"sysctl -a",
+					"",
 					true,
 				).
 				CheckSys(
@@ -459,11 +463,13 @@ func fixFailedChecks(ctx *task.Context, host string, res *operator.CheckResult, 
 				"/etc/selinux/config",
 				"setenforce 0",
 			),
+			"",
 			true)
 		msg = fmt.Sprintf("will try to %s, reboot might be needed", color.HiBlueString("disable SELinux"))
 	case operator.CheckNameTHP:
 		t.Shell(host,
 			"echo never > /sys/kernel/mm/transparent_hugepage/enabled && echo never > /sys/kernel/mm/transparent_hugepage/defrag",
+			"",
 			true)
 		msg = fmt.Sprintf("will try to %s, please check again after reboot", color.HiBlueString("disable THP"))
 	default:

--- a/pkg/cluster/manager/exec.go
+++ b/pkg/cluster/manager/exec.go
@@ -47,9 +47,9 @@ func (m *Manager) Exec(name string, opt ExecOptions, gOpt operator.Options) erro
 	filterNodes := set.NewStringSet(gOpt.Nodes...)
 
 	var shellTasks []task.Task
-	uniqueHosts := map[string]set.StringSet{} // host-sshPort-port -> {command}
+	uniqueHosts := map[string]set.StringSet{} // host-sshPort -> {command}
 	topo.IterInstance(func(inst spec.Instance) {
-		key := fmt.Sprintf("%s-%d-%d", inst.GetHost(), inst.GetSSHPort(), inst.GetPort())
+		key := fmt.Sprintf("%s-%d", inst.GetHost(), inst.GetSSHPort())
 		if _, found := uniqueHosts[key]; !found {
 			if len(gOpt.Roles) > 0 && !filterRoles.Exist(inst.Role()) {
 				return

--- a/pkg/cluster/manager/transfer.go
+++ b/pkg/cluster/manager/transfer.go
@@ -51,9 +51,9 @@ func (m *Manager) Transfer(name string, opt TransferOptions, gOpt operator.Optio
 
 	var shellTasks []task.Task
 
-	uniqueHosts := map[string]set.StringSet{} // host-sshPort-port -> {remote-path}
+	uniqueHosts := map[string]set.StringSet{} // host-sshPort -> {remote-path}
 	topo.IterInstance(func(inst spec.Instance) {
-		key := fmt.Sprintf("%s-%d-%d", inst.GetHost(), inst.GetSSHPort(), inst.GetPort())
+		key := fmt.Sprintf("%s-%d", inst.GetHost(), inst.GetSSHPort())
 		if _, found := uniqueHosts[key]; !found {
 			if len(gOpt.Roles) > 0 && !filterRoles.Exist(inst.Role()) {
 				return

--- a/pkg/cluster/manager/transfer.go
+++ b/pkg/cluster/manager/transfer.go
@@ -67,6 +67,7 @@ func (m *Manager) Transfer(name string, opt TransferOptions, gOpt operator.Optio
 			instPath := opt.Remote
 			paths, err := renderInstanceSpec(instPath, inst)
 			if err != nil {
+				log.Debugf("error rendering remote path with spec: %s", err)
 				return // skip
 			}
 			pathSet := set.NewStringSet(paths...)
@@ -113,8 +114,7 @@ func renderInstanceSpec(t string, inst spec.Instance) ([]string, error) {
 	switch inst.ComponentName() {
 	case spec.ComponentTiFlash:
 		for _, d := range strings.Split(inst.DataDir(), ",") {
-			tf := inst
-			tfs, ok := tf.(*spec.TiFlashInstance).InstanceSpec.(spec.TiFlashSpec)
+			tfs, ok := inst.(*spec.TiFlashInstance).InstanceSpec.(spec.TiFlashSpec)
 			if !ok {
 				return result, fmt.Errorf("instance type mismatch for %v", inst)
 			}

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -291,11 +291,12 @@ func (b *Builder) Rmdir(host string, dirs ...string) *Builder {
 }
 
 // Shell command on cluster host
-func (b *Builder) Shell(host, command string, sudo bool) *Builder {
+func (b *Builder) Shell(host, command, cmdID string, sudo bool) *Builder {
 	b.tasks = append(b.tasks, &Shell{
 		host:    host,
 		command: command,
 		sudo:    sudo,
+		cmdID:   cmdID,
 	})
 	return b
 }
@@ -364,6 +365,7 @@ func (b *Builder) DeploySpark(inst spec.Instance, sparkVersion, srcPath, deployD
 			deployDir,
 			filepath.Join(deployDir, sparkSubPath),
 		),
+		"",
 		false, // (not) sudo
 	).CopyComponent(
 		inst.ComponentName(),
@@ -380,6 +382,7 @@ func (b *Builder) DeploySpark(inst spec.Instance, sparkVersion, srcPath, deployD
 			filepath.Join(deployDir, "bin"),
 			deployDir,
 		),
+		"",
 		false, // (not) sudo
 	)
 }

--- a/pkg/cluster/task/shell.go
+++ b/pkg/cluster/task/shell.go
@@ -25,6 +25,7 @@ type Shell struct {
 	host    string
 	command string
 	sudo    bool
+	cmdID   string
 }
 
 // Execute implements the Task interface
@@ -37,7 +38,11 @@ func (m *Shell) Execute(ctx *Context) error {
 	log.Infof("Run command on %s(sudo:%v): %s", m.host, m.sudo, m.command)
 
 	stdout, stderr, err := exec.Execute(m.command, m.sudo)
-	ctx.SetOutputs(m.host, stdout, stderr)
+	outputID := m.host
+	if m.cmdID != "" {
+		outputID = m.cmdID
+	}
+	ctx.SetOutputs(outputID, stdout, stderr)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/cluster/task/task.go
+++ b/pkg/cluster/task/task.go
@@ -133,19 +133,19 @@ func (ctx *Context) SetExecutor(host string, e executor.Executor) {
 }
 
 // GetOutputs get the outputs of a host (if has any)
-func (ctx *Context) GetOutputs(host string) ([]byte, []byte, bool) {
+func (ctx *Context) GetOutputs(hostID string) ([]byte, []byte, bool) {
 	ctx.exec.RLock()
-	stdout, ok1 := ctx.exec.stderrs[host]
-	stderr, ok2 := ctx.exec.stdouts[host]
+	stdout, ok1 := ctx.exec.stderrs[hostID]
+	stderr, ok2 := ctx.exec.stdouts[hostID]
 	ctx.exec.RUnlock()
 	return stdout, stderr, ok1 && ok2
 }
 
 // SetOutputs set the outputs of a host
-func (ctx *Context) SetOutputs(host string, stdout []byte, stderr []byte) {
+func (ctx *Context) SetOutputs(hostID string, stdout []byte, stderr []byte) {
 	ctx.exec.Lock()
-	ctx.exec.stderrs[host] = stdout
-	ctx.exec.stdouts[host] = stderr
+	ctx.exec.stderrs[hostID] = stdout
+	ctx.exec.stdouts[hostID] = stderr
 	ctx.exec.Unlock()
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
We had added a simple implementation of rendering input as template with instance specification in #1044 which makes it easier to close #894 

### What is changed and how it works?
Render command string as template before sending it to executor.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Increased code complexity


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
