### PR TITLE
Fix push with template

### DIFF
--- a/pkg/cluster/manager/transfer.go
+++ b/pkg/cluster/manager/transfer.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"reflect"
 	"strings"
 
 	"github.com/google/uuid"
@@ -135,6 +136,10 @@ func renderInstanceSpec(t string, inst spec.Instance) ([]string, error) {
 }
 
 func renderSpec(t string, s interface{}, id string) (string, error) {
+	if reflect.ValueOf(s).Kind() == reflect.Ptr {
+		s = reflect.ValueOf(s).Elem().Interface()
+	}
+
 	tpl, err := template.New(id).Option("missingkey=error").Parse(t)
 	if err != nil {
 		return "", err

--- a/pkg/cluster/manager/transfer.go
+++ b/pkg/cluster/manager/transfer.go
@@ -117,7 +117,7 @@ func renderInstanceSpec(t string, inst spec.Instance) ([]string, error) {
 			tf := inst
 			tfs, ok := tf.(*spec.TiFlashInstance).InstanceSpec.(spec.TiFlashSpec)
 			if !ok {
-				return result, fmt.Errorf("instance type mismatch for %v", inst)
+				return result, perrs.Errorf("instance type mismatch for %v", inst)
 			}
 			tfs.DataDir = d
 			key := inst.ID() + d + uuid.New().String()
@@ -128,7 +128,7 @@ func renderInstanceSpec(t string, inst spec.Instance) ([]string, error) {
 	default:
 		s, err := renderSpec(t, inst, inst.ID())
 		if err != nil {
-			return result, fmt.Errorf("error rendering path for instance %v", inst)
+			return result, perrs.Errorf("error rendering path for instance %v", inst)
 		}
 		result = append(result, s)
 	}
@@ -136,8 +136,18 @@ func renderInstanceSpec(t string, inst spec.Instance) ([]string, error) {
 }
 
 func renderSpec(t string, s interface{}, id string) (string, error) {
-	if reflect.ValueOf(s).Kind() == reflect.Ptr {
-		s = reflect.ValueOf(s).Elem().Interface()
+	// Only apply on *spec.TiDBInstance and *spec.PDInstance etc.
+	if v := reflect.ValueOf(s); v.Kind() == reflect.Ptr {
+		if v = v.Elem(); !v.IsValid() {
+			return "", perrs.Errorf("invalid spec")
+		}
+		if v = v.FieldByName("BaseInstance"); !v.IsValid() {
+			return "", perrs.Errorf("field BaseInstance not found")
+		}
+		if v = v.FieldByName("InstanceSpec"); !v.IsValid() {
+			return "", perrs.Errorf("field InstanceSpec not found")
+		}
+		s = v.Interface()
 	}
 
 	tpl, err := template.New(id).Option("missingkey=error").Parse(t)

--- a/pkg/cluster/manager/transfer_test.go
+++ b/pkg/cluster/manager/transfer_test.go
@@ -33,7 +33,24 @@ func TestRenderSpec(t *testing.T) {
 			OS:         "linux",
 		},
 	}}
-	dir, err := renderSpec("{{.DataDir}}", s, "test")
+	dir, err := renderSpec("{{.DataDir}}", s, "test-tidb")
 	assert.NotNil(t, err)
 	assert.Empty(t, dir)
+
+	s = &spec.PDInstance{BaseInstance: spec.BaseInstance{
+		InstanceSpec: spec.PDSpec{
+			Host:       "172.16.5.140",
+			SSHPort:    22,
+			Imported:   false,
+			Name:       "pd-1",
+			ClientPort: 2379,
+			PeerPort:   2380,
+			DeployDir:  "/home/test/deploy/pd-2379",
+			DataDir:    "/home/test/deploy/pd-2379/data",
+		},
+	}}
+	//s.BaseInstance.InstanceSpec
+	dir, err = renderSpec("{{.DataDir}}", s, "test-pd")
+	assert.Nil(t, err)
+	assert.NotEmpty(t, dir)
 }

--- a/pkg/cluster/manager/transfer_test.go
+++ b/pkg/cluster/manager/transfer_test.go
@@ -1,0 +1,39 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"testing"
+
+	"github.com/pingcap/tiup/pkg/cluster/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderSpec(t *testing.T) {
+	var s spec.Instance = &spec.TiDBInstance{BaseInstance: spec.BaseInstance{
+		InstanceSpec: spec.TiDBSpec{
+			Host:       "172.16.5.140",
+			SSHPort:    22,
+			Imported:   false,
+			Port:       4000,
+			StatusPort: 10080,
+			DeployDir:  "/home/test/deploy/tidb-4000",
+			Arch:       "amd64",
+			OS:         "linux",
+		},
+	}}
+	dir, err := renderSpec("{{.DataDir}}", s, "test")
+	assert.NotNil(t, err)
+	assert.Empty(t, dir)
+}

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -103,8 +103,8 @@ function cmd_subtest() {
 
     # Test push and pull
     echo "test_transfer $name $RANDOM `date`" > test_transfer_1.txt
-    tiup-cluster $client push $name test_transfer_1.txt "{{ .LogDir }}/test_transfer.txt" -R grafana
-    tiup-cluster $client pull $name "{{ .LogDir }}/test_transfer.txt" test_transfer_2.txt -R grafana
+    tiup-cluster $client push $name test_transfer_1.txt "{{ .DeployDir }}/test_transfer.txt" -R grafana
+    tiup-cluster $client pull $name "{{ .DeployDir }}/test_transfer.txt" test_transfer_2.txt -R grafana
     diff test_transfer_1.txt test_transfer_2.txt
 
     echo "checking cleanup data and log"


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Introduced by https://github.com/pingcap/tiup/pull/1044, TiUP can't notice that the TiDBSpec don't have DataDir and will render an empty string

### What is changed and how it works?
Convert pointer to struct it point to if the `s` of renderSpec is a pointer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
