### PR TITLE
cluster: allow type change when editing topology

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/pingcap/tidb-insight v0.3.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/prom2json v1.3.0
-	github.com/r3labs/diff v0.0.0-20200627101315-aecd9dd05dd2
+	github.com/r3labs/diff v0.0.0-20201223155434-f54a0724e0a9
 	github.com/relex/aini v1.2.1
 	github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44
 	github.com/shirou/gopsutil v2.20.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -740,8 +740,8 @@ github.com/prometheus/procfs v0.0.6/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/prom2json v1.3.0 h1:BlqrtbT9lLH3ZsOVhXPsHzFrApCTKRifB7gjJuypu6Y=
 github.com/prometheus/prom2json v1.3.0/go.mod h1:rMN7m0ApCowcoDlypBHlkNbp5eJQf/+1isKykIP5ZnM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/r3labs/diff v0.0.0-20200627101315-aecd9dd05dd2 h1:786HUIrynbbk5PzUf9Rp3aAUkNRksUiiipSAlyJ68As=
-github.com/r3labs/diff v0.0.0-20200627101315-aecd9dd05dd2/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
+github.com/r3labs/diff v0.0.0-20201223155434-f54a0724e0a9 h1:yYXmPsvu4dcU8JOq0LkLHGn+ppLfSk1BmIDn4ZTZZaw=
+github.com/r3labs/diff v0.0.0-20201223155434-f54a0724e0a9/go.mod h1:bm6mTdenBKzjqJIHWySotVAOuPnzotpjl6poqMQElLE=
 github.com/rakyll/statik v0.1.6/go.mod h1:OEi9wJV/fMUAGx1eNjq75DKDsJVuEv1U0oYdX6GX8Zs=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/relex/aini v1.2.1 h1:EN89emh21lgFi5BlLlMEB6IfZKbQ4kUD4vOXyla/Ewk=
@@ -900,6 +900,8 @@ github.com/urfave/negroni v0.3.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKn
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vertica/vertica-sql-go v0.1.6/go.mod h1:2LGtkNSdFF5CTJYeUA5qWfREuvYaql+51fNzmoD5W7c=
+github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
+github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1/go.mod h1:xlngVLeyQ/Qi05oQxhQ+oTuqa03RjMwMfk/7/TCs+QI=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
@@ -1182,6 +1184,8 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.2/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
+google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/pkg/utils/diff.go
+++ b/pkg/utils/diff.go
@@ -77,6 +77,7 @@ func validateExpandable(fromField, toField interface{}) bool {
 func ValidateSpecDiff(s1, s2 interface{}) error {
 	differ, err := diff.NewDiffer(
 		diff.TagName(validateTagName),
+		diff.AllowTypeMismatch(true),
 	)
 	if err != nil {
 		return err

--- a/pkg/utils/diff_test.go
+++ b/pkg/utils/diff_test.go
@@ -32,11 +32,11 @@ type sampleDataMeta struct {
 }
 
 type sampleDataElem struct {
-	StrElem1       string                   `yaml:"str1" validate:"str1:editable"`
-	StrElem2       string                   `yaml:"str2,omitempty" validate:"str2:editable"`
-	IntElem        int                      `yaml:"int"`
-	InterfaceElem  interface{}              `yaml:"interface,omitempty" validate:"interface:editable"`
-	InterfaceSlice []map[string]interface{} `yaml:"mapslice,omitempty" validate:"mapslice:editable"`
+	StrElem1       string                 `yaml:"str1" validate:"str1:editable"`
+	StrElem2       string                 `yaml:"str2,omitempty" validate:"str2:editable"`
+	IntElem        int                    `yaml:"int"`
+	InterfaceElem  interface{}            `yaml:"interface,omitempty" validate:"interface:editable"`
+	InterfaceSlice map[string]interface{} `yaml:"mapslice,omitempty" validate:"mapslice:editable"`
 }
 
 type sampleDataEditable struct {
@@ -469,6 +469,49 @@ maps:
   - key0: 0
   - dot.key1: 1
   - dotkey.subkey.1: "12"
+`), &d2)
+	c.Assert(err, IsNil)
+	err = ValidateSpecDiff(d1, d2)
+	c.Assert(err, IsNil)
+}
+
+func (d *diffSuite) TestValidateSpecDiffType(c *C) {
+	var d1 sampleDataMeta
+	var d2 sampleDataMeta
+	var err error
+
+	err = yaml.Unmarshal([]byte(`
+ints: [11, 12, 13]
+slice3:
+  - key0: 0
+`), &d1)
+	c.Assert(err, IsNil)
+
+	// Modify key in editable map, with the same type
+	err = yaml.Unmarshal([]byte(`
+ints: [11, 12, 13]
+slice3:
+  - key0: 1
+`), &d2)
+	c.Assert(err, IsNil)
+	err = ValidateSpecDiff(d1, d2)
+	c.Assert(err, IsNil)
+
+	// Modify key in editable map, with value type changed
+	err = yaml.Unmarshal([]byte(`
+ints: [11, 12, 13]
+slice3:
+  - key0: 2.0
+`), &d2)
+	c.Assert(err, IsNil)
+	err = ValidateSpecDiff(d1, d2)
+	c.Assert(err, IsNil)
+
+	// Modify key in editable map, with value type changed
+	err = yaml.Unmarshal([]byte(`
+ints: [11, 12, 13]
+slice3:
+  - key0: sss
 `), &d2)
 	c.Assert(err, IsNil)
 	err = ValidateSpecDiff(d1, d2)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Allowing value type change for `edit-config`. Especially useful when editing configs.

### What is changed and how it works?
The latest version of `r3labs/diff` has an option to ignore type mismatch error, so we upgrade the dependency and enable that option.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
(Change `tikv_servers.(server).config.key: 10` to `tikv_servers.(server).config.key: "10MB"`)
Before:
![image](https://user-images.githubusercontent.com/596538/104000290-fd562880-51d8-11eb-88fa-6a171adbfd5c.png)

After:
Save as normal.

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: allow value type change in `edit-config`
```
