### PR TITLE
Fix the issue that the expires shortened after merging cloned mirror

### DIFF
--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -420,9 +420,18 @@ func RenewManifest(m ValidManifest, startTime time.Time) {
 	if m.Base().Version > 0 {
 		m.Base().Version++
 	}
-	m.Base().Expires = startTime.Add(
-		ManifestsConfig[m.Base().Ty].Expire,
-	).Format(time.RFC3339)
+
+	// only update expire field when it's old than target expire time
+	targetExpire := startTime.Add(ManifestsConfig[m.Base().Ty].Expire)
+	currentExpire, err := time.Parse(time.RFC3339, m.Base().Expires)
+	if err != nil {
+		m.Base().Expires = targetExpire.Format(time.RFC3339)
+		return
+	}
+
+	if currentExpire.Before(targetExpire) {
+		m.Base().Expires = targetExpire.Format(time.RFC3339)
+	}
 }
 
 // loadKeys stores all keys declared in manifest into ks.


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
For the cloned mirror, we set the expires filed expire after 50 years since the user rarely modify the mirror so we can assume that's safe. However, when the user try to publish component to the cloned mirror, the problem occurred：the expire time will be shortened to just one. month because we think it's unsafe if the user need to modify it. It's OK when the user need to modify it frequently, because every time he modify it, the expire time will be push forward to a month latter. However, what if the user just modify it once and use it alone the time? The mirror will expire after a month so that the user must modify it again in a month even though he don't want to do that.

### What is changed and how it works?
We compare the new expire time and the old one, use the longer one.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
