### PR TITLE
feat(cmd): add tiup as completion's prefix name

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -38,10 +38,10 @@ func newCompletionCmd() *cobra.Command {
   ## Load the tiup completion code for bash into the current shell
   source <(tiup completion bash)
   ## Write bash completion code to a file and source if from .bash_profile
-  tiup completion bash > ~/.completion.bash.inc
+  tiup completion bash > ~/.tiup.completion.bash
   printf "
   # tiup shell completion
-  source '$HOME/.completion.bash.inc'
+  source '$HOME/.tiup.completion.bash'
   " >> $HOME/.bash_profile
   source $HOME/.bash_profile
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

rename the completion's filename from `~/.completion.bash.inc` to `~/.tiup.completion.bash`

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
