### PR TITLE
typo(cmd/mirror): add warning if key already exists

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/localdata"
+	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/pingcap/tiup/pkg/repository"
 	"github.com/pingcap/tiup/pkg/repository/model"
 	ru "github.com/pingcap/tiup/pkg/repository/utils"
@@ -153,7 +154,7 @@ func newMirrorSetCmd() *cobra.Command {
 			addr := args[0]
 			profile := environment.GlobalEnv().Profile()
 			if err := profile.ResetMirror(addr, root); err != nil {
-				fmt.Printf("Failed to set mirror: %s\n", err.Error())
+				log.Errorf("Failed to set mirror: %s\n", err.Error())
 				return err
 			}
 			fmt.Printf("Set mirror to %s success\n", addr)
@@ -548,7 +549,7 @@ func newMirrorGenkeyCmd() *cobra.Command {
 				fmt.Printf("KeyID: %s\nKeyContent: \n%s\n", id, string(content))
 			} else {
 				if utils.IsExist(privPath) {
-					fmt.Println("Warning: Key already exists, skipped")
+					log.Warnf("Warning: private key already exists(%s), skip", privPath)
 					return nil
 				}
 
@@ -580,10 +581,11 @@ func newMirrorGenkeyCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if err = v1manifest.SaveKeyInfo(pubKey, "public", ""); err != nil {
+				pubPath, err := v1manifest.SaveKeyInfo(pubKey, "public", "")
+				if err != nil {
 					return err
 				}
-				fmt.Printf("Public key has been written to current working dir\n")
+				fmt.Printf("Public key has been written to current working dir: %s\n", pubPath)
 			}
 			return nil
 		},

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -548,7 +548,7 @@ func newMirrorGenkeyCmd() *cobra.Command {
 				fmt.Printf("KeyID: %s\nKeyContent: \n%s\n", id, string(content))
 			} else {
 				if utils.IsExist(privPath) {
-					fmt.Println("Key already exists, skipped")
+					fmt.Println("Warning: Key already exists, skipped")
 					return nil
 				}
 
@@ -572,7 +572,7 @@ func newMirrorGenkeyCmd() *cobra.Command {
 					return err
 				}
 
-				fmt.Printf("private key have been write to %s\n", privPath)
+				fmt.Printf("Private key has been writeen to %s\n", privPath)
 			}
 
 			if saveKey {
@@ -583,7 +583,7 @@ func newMirrorGenkeyCmd() *cobra.Command {
 				if err = v1manifest.SaveKeyInfo(pubKey, "public", ""); err != nil {
 					return err
 				}
-				fmt.Printf("public key have been write to current working dir\n")
+				fmt.Printf("Public key has been written to current working dir\n")
 			}
 			return nil
 		},

--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -132,7 +132,7 @@ func CloneMirror(repo *V1Repository,
 		return errors.Trace(err)
 	}
 	// save owner key
-	if err := v1manifest.SaveKeyInfo(ownerkeyInfo, "pingcap", keyDir); err != nil {
+	if _, err := v1manifest.SaveKeyInfo(ownerkeyInfo, "pingcap", keyDir); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -304,8 +304,8 @@ func cloneComponents(repo *V1Repository,
 						continue
 					}
 				}
-			  if _, err := repo.FetchComponentManifest(name, false); err != nil || versionItem.Yanked {
-				  // The component or the version is yanked, skip download binary
+				if _, err := repo.FetchComponentManifest(name, false); err != nil || versionItem.Yanked {
+					// The component or the version is yanked, skip download binary
 					continue
 				}
 				if err := download(targetDir, tmpDir, repo, &versionItem); err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?
Add `Warning` if the private key exists

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
