### PR TITLE
fix(cluster/display): don't print dashboardAddr if none or auto

### DIFF
--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -108,7 +108,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 	if t, ok := topo.(*spec.Specification); ok {
 		var err error
 		dashboardAddr, err = t.GetDashboardAddress(tlsCfg, masterActive...)
-		if dashboardAddr != "" && err == nil {
+		if err == nil && !set.NewStringSet("", "auto", "none").Exist(dashboardAddr) {
 			schema := "http"
 			if tlsCfg != nil {
 				schema = "https"


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

the dashboardAddr maybe `none` or `auto`,  don't print it. 
ref https://github.com/pingcap/tiup/blob/9fd5a221df15ddc9d507383777d6c6f84c16fb00/components/cluster/command/display.go#L98-L102,
### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
