### PR TITLE
cluster: fix parsing of paths if there are redundant slashes in it

### DIFF
--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -385,7 +385,7 @@ func DestroyComponent(getter ExecutorGetter, instances []spec.Instance, cls spec
 				dpCnt++
 			}
 		}
-		if cls.CountDir(ins.GetHost(), deployDir)-dpCnt == 1 {
+		if cls.CountDir(ins.GetHost(), deployDir)-dpCnt == 1 && !ins.IsImported() {
 			delPaths.Insert(deployDir)
 		}
 

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -385,7 +385,7 @@ func DestroyComponent(getter ExecutorGetter, instances []spec.Instance, cls spec
 				dpCnt++
 			}
 		}
-		if cls.CountDir(ins.GetHost(), deployDir)-dpCnt == 1 && !ins.IsImported() {
+		if !ins.IsImported() && cls.CountDir(ins.GetHost(), deployDir)-dpCnt == 1 {
 			delPaths.Insert(deployDir)
 		}
 

--- a/pkg/cluster/spec/testdata/countdir.yaml
+++ b/pkg/cluster/spec/testdata/countdir.yaml
@@ -1,0 +1,106 @@
+user: tidb
+tidb_version: v4.0.2
+last_ops_ver: |-
+  v1.3.0 tiup
+  Go Version: go1.13
+  Git Branch: release-1.3
+  GitHash: edb12b8
+topology:
+  global:
+    user: tidb
+    ssh_port: 22
+    ssh_type: builtin
+    deploy_dir: deploy
+    data_dir: data
+    os: linux
+    arch: amd64
+  monitored:
+    node_exporter_port: 21580
+    blackbox_exporter_port: 21581
+    deploy_dir: /home/tidb/deploy/monitor-21580
+    data_dir: /home/tidb/deploy/monitor-21580/data/monitor-21580
+    log_dir: /home/tidb/deploy/monitor-21580/deploy/monitor-21580/log
+  tidb_servers:
+  - host: 172.17.0.4
+    ssh_port: 22
+    imported: true
+    port: 21500
+    status_port: 21501
+    deploy_dir: /foo/bar/sometidbpath123/
+    log_dir: /foo/bar/sometidbpath123//log
+    arch: amd64
+    os: linux
+  tikv_servers:
+  - host: 172.16.81.162
+    ssh_port: 22
+    imported: true
+    port: 21520
+    status_port: 21530
+    deploy_dir: /work/foobar456
+    data_dir: /work/foobar456/data
+    log_dir: /work/foobar456/log
+    arch: amd64
+    os: linux
+  - host: 172.16.81.205
+    ssh_port: 22
+    imported: true
+    port: 21520
+    status_port: 21530
+    deploy_dir: /work/foobar456
+    data_dir: /work/foobar456/data
+    log_dir: /work/foobar456/log
+    arch: amd64
+    os: linux
+  - host: 172.16.100.199
+    ssh_port: 22
+    imported: true
+    port: 21520
+    status_port: 21530
+    deploy_dir: /work/foobar456
+    data_dir: /work/foobar456/data
+    log_dir: /work/foobar456/log
+    arch: amd64
+    os: linux
+  tiflash_servers: []
+  pd_servers:
+  - host: 172.18.222.51
+    ssh_port: 22
+    name: pd-172.18.222.51-21550
+    client_port: 21550
+    peer_port: 21551
+    deploy_dir: /foo/bar/sometidbpath123/deploy/pd-21550
+    data_dir: /foo/bar/sometidbpath123/deploy/pd-21550/data
+    log_dir: /foo/bar/sometidbpath123/log/pd-21550
+    arch: amd64
+    os: linux
+  - host: 172.18.4.42
+    ssh_port: 22
+    name: pd-172.18.4.42-21550
+    client_port: 21550
+    peer_port: 21551
+    deploy_dir: /foo/bar/sometidbpath123/deploy/pd-21550
+    data_dir: /foo/bar/sometidbpath123/deploy/pd-21550/data
+    log_dir: /foo/bar/sometidbpath123/log/pd-21550
+    arch: amd64
+    os: linux
+  - host: 172.18.10.16
+    ssh_port: 22
+    name: pd-172.18.10.16-21550
+    client_port: 21550
+    peer_port: 21551
+    deploy_dir: /foo/bar/sometidbpath123/deploy/pd-21550
+    data_dir: /foo/bar/sometidbpath123/deploy/pd-21550/data
+    log_dir: /foo/bar/sometidbpath123/log/pd-21550
+    arch: amd64
+    os: linux
+  monitoring_servers: []
+  grafana_servers:
+  - host: 172.17.0.4
+    ssh_port: 22
+    imported: true
+    port: 21570
+    deploy_dir: /foo/bar/sometidbpath123/
+    arch: amd64
+    os: linux
+    username: admin
+    password: admin

--- a/pkg/cluster/spec/util.go
+++ b/pkg/cluster/spec/util.go
@@ -133,10 +133,13 @@ func statusByURL(url string, tlsCfg *tls.Config) string {
 
 // Abs returns the absolute path
 func Abs(user, path string) string {
+	// trim whitespaces before joining
+	user = strings.TrimSpace(user)
+	path = strings.TrimSpace(path)
 	if !strings.HasPrefix(path, "/") {
-		return filepath.Join("/home", user, path)
+		path = filepath.Join("/home", user, path)
 	}
-	return path
+	return filepath.Clean(path)
 }
 
 // MultiDirAbs returns the absolute path for multi-dir separated by comma

--- a/pkg/cluster/spec/util_test.go
+++ b/pkg/cluster/spec/util_test.go
@@ -21,6 +21,30 @@ type utilSuite struct{}
 
 var _ = check.Suite(&utilSuite{})
 
+func (s utilSuite) TestAbs(c *check.C) {
+	var path string
+	path = Abs(" foo", "")
+	c.Assert(path, check.Equals, "/home/foo")
+	path = Abs("foo ", " ")
+	c.Assert(path, check.Equals, "/home/foo")
+	path = Abs("foo", "bar")
+	c.Assert(path, check.Equals, "/home/foo/bar")
+	path = Abs("foo", " bar")
+	c.Assert(path, check.Equals, "/home/foo/bar")
+	path = Abs("foo", "bar ")
+	c.Assert(path, check.Equals, "/home/foo/bar")
+	path = Abs("foo", " bar ")
+	c.Assert(path, check.Equals, "/home/foo/bar")
+	path = Abs("foo", "/bar")
+	c.Assert(path, check.Equals, "/bar")
+	path = Abs("foo", " /bar")
+	c.Assert(path, check.Equals, "/bar")
+	path = Abs("foo", "/bar ")
+	c.Assert(path, check.Equals, "/bar")
+	path = Abs("foo", " /bar ")
+	c.Assert(path, check.Equals, "/bar")
+}
+
 func (s *utilSuite) TestMultiDirAbs(c *check.C) {
 	paths := MultiDirAbs("tidb", "")
 	c.Assert(len(paths), check.Equals, 0)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If an imported cluster has deploy dir ending with `/`, and sub dirs as `<deploy-dir>//sub`, the result of `CountDir()` may not be accurate, and could results to delete wrong paths on `scale-in`.

One of the case is when:
 - The deploy dir is `/foo/`, and
 - The log dir is `/foo//log`, and
 - There **is and only is** 1 instance with only 1 sub directory under deploy dir (e.g., tidb with log dir under deploy dir) deployed on host `1.2.3.4`, and
 - There are other instances without log dir and data dir (e.g., grafana) deployed on the same host

The deploy dir will be deleted when `scale-in` the grafana instance, so that the tidb instance is also broken.

### What is changed and how it works?
1. Not deleting deploy dir for imported instance
2. Trim redundant slashes from the path when parsing meta file

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has persistent data change

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: fix parsing of paths if there are redundant slashes in it
```
