### PR TITLE
fix(cluster/executor): local executor should in single quote command

### DIFF
--- a/pkg/cluster/executor/local.go
+++ b/pkg/cluster/executor/local.go
@@ -42,9 +42,9 @@ var _ Executor = &Local{}
 func (l *Local) Execute(cmd string, sudo bool, timeout ...time.Duration) ([]byte, []byte, error) {
 	// try to acquire root permission
 	if l.Sudo || sudo {
-		cmd = fmt.Sprintf("sudo -H -u root bash -c \"cd; %s\"", cmd)
+		cmd = fmt.Sprintf("sudo -H -u root bash -c 'cd; %s'", cmd)
 	} else {
-		cmd = fmt.Sprintf("sudo -H -u %s bash -c \"cd; %s\"", l.Config.User, cmd)
+		cmd = fmt.Sprintf("sudo -H -u %s bash -c 'cd; %s'", l.Config.User, cmd)
 	}
 
 	// set a basic PATH in case it's empty on login


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the issue triggerd in #1073 [grafana unit-test](https://github.com/pingcap/tiup/pull/1073/checks?check_run_id=1714008844#step:4:287): 

```bash
--- FAIL: TestLocalDashboards (0.10s)
    grafana_test.go:64: 
        	Error Trace:	grafana_test.go:64
        	Error:      	Expected nil, but got: stderr: bash: s/${DS_.*-CLUSTER}/tiup-test-cluster-fe80bb2e-9094-425c-ab5f-a258e928e759/g: bad substitution
        	            	: executor.ssh.execute_failed: Failed to execute command locally {ssh_stderr: bash: s/${DS_.*-CLUSTER}/tiup-test-cluster-fe80bb2e-9094-425c-ab5f-a258e928e759/g: bad substitution
        	            	, ssh_stdout: , ssh_command: export LANG=C; PATH=$PATH:/usr/bin:/usr/sbin sudo -H -u runner bash -c "cd; find /tmp/tiup-166443879/dashboards -type f -exec sed -i "s/\${DS_.*-CLUSTER}/tiup-test-cluster-fe80bb2e-9094-425c-ab5f-a258e928e759/g" {} \;"}, cause: exit status 1
        	Test:       	TestLocalDashboards
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
