### PR TITLE
fix: tiup supports define root_url and enable anonymous in grafana.ini

### DIFF
--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -41,6 +41,8 @@ type GrafanaSpec struct {
 	DashboardDir    string               `yaml:"dashboard_dir,omitempty" validate:"dashboard_dir:editable"`
 	Username        string               `yaml:"username,omitempty" default:"admin" validate:"username:editable"`
 	Password        string               `yaml:"password,omitempty" default:"admin" validate:"password:editable"`
+	AnonymousEnable bool                 `yaml:"anonymous_enable" default:"false" validate:"anonymous_enable:editable"`
+	RootURL         string               `yaml:"root_url" validate:"root_url:editable"`
 }
 
 // Role returns the component role of the instance
@@ -148,6 +150,8 @@ func (i *GrafanaInstance) InitConfig(
 		WithPort(uint64(i.GetPort())).
 		WithUsername(spec.Username).
 		WithPassword(spec.Password).
+		WithAnonymousenable(spec.AnonymousEnable).
+		WithRootURL(spec.RootURL).
 		ConfigToFile(fp); err != nil {
 		return err
 	}

--- a/pkg/cluster/template/config/grafana.go
+++ b/pkg/cluster/template/config/grafana.go
@@ -24,11 +24,13 @@ import (
 
 // GrafanaConfig represent the data to generate Grafana config
 type GrafanaConfig struct {
-	DeployDir string
-	IP        string
-	Port      uint64
-	Username  string // admin_user
-	Password  string // admin_password
+	DeployDir       string
+	IP              string
+	Port            uint64
+	Username        string // admin_user
+	Password        string // admin_password
+	AnonymousEnable bool   // anonymous enable
+	RootURL         string //root_url
 }
 
 // NewGrafanaConfig returns a GrafanaConfig
@@ -55,6 +57,18 @@ func (c *GrafanaConfig) WithUsername(user string) *GrafanaConfig {
 // WithPassword sets password of admin user
 func (c *GrafanaConfig) WithPassword(passwd string) *GrafanaConfig {
 	c.Password = passwd
+	return c
+}
+
+// WithAnonymousenable sets anonymousEnable of anonymousEnable
+func (c *GrafanaConfig) WithAnonymousenable(anonymousEnable bool) *GrafanaConfig {
+	c.AnonymousEnable = anonymousEnable
+	return c
+}
+
+// WithRootURL sets rootURL of root url
+func (c *GrafanaConfig) WithRootURL(rootURL string) *GrafanaConfig {
+	c.RootURL = rootURL
 	return c
 }
 

--- a/templates/config/grafana.ini.tpl
+++ b/templates/config/grafana.ini.tpl
@@ -46,7 +46,10 @@ domain = {{.IP}}
 ;enforce_domain = false
 
 # The full public facing url
-;root_url = %(protocol)s://%(domain)s:%(http_port)s/
+{{- if .RootURL}}
+root_url = {{.RootURL}}
+server_from_sub_path = true
+{{- end}}
 
 # Log web requests
 ;router_logging = false
@@ -166,8 +169,9 @@ admin_password = {{.Password}}
 
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
-# enable anonymous access
-;enabled = false
+{{- if .AnonymousEnable}}
+enabled = true
+{{- end}}
 
 # specify organization name that should be used for unauthenticated users
 ;org_name = Main Org.


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix: #849 


### What is changed and how it works?
1. You can configure Grafana to run behind a reverse proxy.
   reference: https://grafana.com/tutorials/run-grafana-behind-a-proxy/#1
2. You can set grafana access anonymous

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
```
tiup cluster edit-config test_cluster

support config:
- host: 127.0.0.2
  ssh_port: 22
  arch: amd64
  os: linux
  username: admin
  password: admin
  anonymous_enable: true
  root_url: /tidb/grafana/test-cluster
```

 Then, you can get a grafana.ini like:
```
[auth.anonymous]
enabled = true
# The full public facing url
[server]
...
root_url = /tidb/grafana/test-cluster
server_from_sub_path = true
```
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
