### PR TITLE
cliutil: return user's answer on prompt

### DIFF
--- a/pkg/cliutil/tui.go
+++ b/pkg/cliutil/tui.go
@@ -70,32 +70,32 @@ func Prompt(prompt string) string {
 
 // PromptForConfirmYes accepts yes / no from console by user, default to No and only return true
 // if the user input is Yes
-func PromptForConfirmYes(format string, a ...interface{}) bool {
+func PromptForConfirmYes(format string, a ...interface{}) (bool, string) {
 	ans := Prompt(fmt.Sprintf(format, a...))
 	switch strings.TrimSpace(strings.ToLower(ans)) {
 	case "y", "yes":
-		return true
+		return true, ans
 	default:
-		return false
+		return false, ans
 	}
 }
 
 // PromptForConfirmNo accepts yes / no from console by user, default to Yes and only return true
 // if the user input is No
-func PromptForConfirmNo(format string, a ...interface{}) bool {
+func PromptForConfirmNo(format string, a ...interface{}) (bool, string) {
 	ans := Prompt(fmt.Sprintf(format, a...))
 	switch strings.TrimSpace(strings.ToLower(ans)) {
 	case "n", "no":
-		return true
+		return true, ans
 	default:
-		return false
+		return false, ans
 	}
 }
 
 // PromptForConfirmOrAbortError accepts yes / no from console by user, generates AbortError if user does not input yes.
 func PromptForConfirmOrAbortError(format string, a ...interface{}) error {
-	if !PromptForConfirmYes(format, a...) {
-		return errOperationAbort.New("Operation aborted by user")
+	if pass, ans := PromptForConfirmYes(format, a...); !pass {
+		return errOperationAbort.New("Operation aborted by user (with answer '%s')", ans)
 	}
 	return nil
 }

--- a/pkg/cluster/manager/edit_config.go
+++ b/pkg/cluster/manager/edit_config.go
@@ -103,7 +103,7 @@ func (m *Manager) editTopo(origTopo spec.Topology, data []byte, skipConfirm bool
 	if err != nil {
 		fmt.Print(color.RedString("New topology could not be saved: "))
 		log.Infof("Failed to parse topology file: %v", err)
-		if !cliutil.PromptForConfirmNo("Do you want to continue editing? [Y/n]: ") {
+		if pass, _ := cliutil.PromptForConfirmNo("Do you want to continue editing? [Y/n]: "); !pass {
 			return m.editTopo(origTopo, newData, skipConfirm)
 		}
 		log.Infof("Nothing changed.")
@@ -114,7 +114,7 @@ func (m *Manager) editTopo(origTopo spec.Topology, data []byte, skipConfirm bool
 	if err := utils.ValidateSpecDiff(origTopo, newTopo); err != nil {
 		fmt.Print(color.RedString("New topology could not be saved: "))
 		log.Errorf("%s", err)
-		if !cliutil.PromptForConfirmNo("Do you want to continue editing? [Y/n]: ") {
+		if pass, _ := cliutil.PromptForConfirmNo("Do you want to continue editing? [Y/n]: "); !pass {
 			return m.editTopo(origTopo, newData, skipConfirm)
 		}
 		log.Infof("Nothing changed.")


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1090 

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
tui: add user's answer in the error message if prompted challenge didn't pass
```
