### PR TITLE
fix:command 'tiup mirror clone --full' break by NOT_FOUND component

### DIFF
--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -15,6 +15,7 @@ package repository
 
 import (
 	"fmt"
+	"github.com/pingcap/tiup/pkg/colorutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -309,7 +310,11 @@ func cloneComponents(repo *V1Repository,
 					continue
 				}
 				if err := download(targetDir, tmpDir, repo, &versionItem); err != nil {
-					return nil, errors.Annotatef(err, "download resource: %s", name)
+					if strings.Contains(err.Error(), "not found") {
+						_, _ = colorutil.ColorErrorMsg.Printf("download resource: %s.err:%s\n", name, err)
+					} else {
+						return nil, errors.Annotatef(err, "download resource: %s", name)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix: #1111 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 exec command:
 ```
tiup mirror clone path/to/dir --full --os=linux --arch=amd64
```
output:
```
Skip exists file: /home/work/opbin/ftp/tiup_mirror/v4.2/cluster-v0.4.9-linux-amd64.tar.gz
download https://tiup-mirrors.pingcap.com/cluster-v0.7.0-linux-amd64.tar.gz 0 B ?% ? p/s
download resource: cluster.err:url https://tiup-mirrors.pingcap.com/cluster-v0.7.0-linux-amd64.tar.gz: not found
Skip exists file: /home/work/opbin/ftp/tiup_mirror/v4.2/cluster-v0.0.4-linux-amd64.tar.gz
Skip exists file: /home/work/opbin/ftp/tiup_mirror/v4.2/cluster-v1.0.2-linux-amd64.tar.gz
```
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
