### PR TITLE
Add --keys flag for server

### DIFF
--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -88,7 +88,7 @@ type (
 )
 
 // NewMirror returns a mirror instance Base on the schema of mirror
-func NewMirror(mirror string, options MirrorOptions) Mirror {
+func NewMirror(mirror, keyDir string, options MirrorOptions) Mirror {
 	if options.Progress == nil {
 		options.Progress = &ProgressBar{}
 	}
@@ -98,11 +98,12 @@ func NewMirror(mirror string, options MirrorOptions) Mirror {
 			options: options,
 		}
 	}
-	return &localFilesystem{rootPath: mirror, upstream: options.Upstream}
+	return &localFilesystem{rootPath: mirror, keyDir: keyDir, upstream: options.Upstream}
 }
 
 type localFilesystem struct {
 	rootPath string
+	keyDir   string
 	upstream string
 	keys     map[string]*v1manifest.KeyInfo
 }
@@ -122,7 +123,7 @@ func (l *localFilesystem) Open() error {
 		return errors.Errorf("local system mirror `%s` should be a directory", l.rootPath)
 	}
 
-	if utils.IsNotExist(filepath.Join(l.rootPath, "keys")) {
+	if utils.IsNotExist(l.keyDir) {
 		return nil
 	}
 
@@ -132,7 +133,7 @@ func (l *localFilesystem) Open() error {
 // load mirror keys
 func (l *localFilesystem) loadKeys() error {
 	l.keys = make(map[string]*v1manifest.KeyInfo)
-	return filepath.Walk(filepath.Join(l.rootPath, "keys"), func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(l.keyDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/server/handler/component.go
+++ b/server/handler/component.go
@@ -99,6 +99,8 @@ func (h *componentSigner) sign(r *http.Request, m *v1manifest.RawManifest) (sr *
 	switch err := h.mirror.Publish(manifest, info); err {
 	case model.ErrorConflict:
 		return nil, ErrorManifestConflict
+	case model.ErrorWrongSignature:
+		return nil, ErrorForbiden
 	case nil:
 		return nil, nil
 	default:

--- a/server/main.go
+++ b/server/main.go
@@ -16,7 +16,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/spf13/cobra"
@@ -35,10 +34,6 @@ func main() {
 				return cmd.Help()
 			}
 
-			if keyDir == "" {
-				keyDir = path.Join(args[0], "keys")
-			}
-
 			s, err := newServer(args[0], keyDir, upstream)
 			if err != nil {
 				return err
@@ -48,7 +43,7 @@ func main() {
 		},
 	}
 	cmd.Flags().StringVarP(&addr, "addr", "", addr, "addr to listen")
-	cmd.Flags().StringVarP(&keyDir, "keys", "", keyDir, "specify the directory where stores the private keys")
+	cmd.Flags().StringVarP(&keyDir, "key-dir", "", keyDir, "specify the directory where stores the private keys")
 	cmd.Flags().StringVarP(&upstream, "upstream", "", upstream, "specify the upstream mirror")
 
 	if err := cmd.Execute(); err != nil {

--- a/server/main.go
+++ b/server/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/spf13/cobra"
@@ -23,6 +24,7 @@ import (
 
 func main() {
 	addr := "0.0.0.0:8989"
+	keyDir := ""
 	upstream := "https://tiup-mirrors.pingcap.com"
 
 	cmd := &cobra.Command{
@@ -33,7 +35,11 @@ func main() {
 				return cmd.Help()
 			}
 
-			s, err := newServer(args[0], upstream)
+			if keyDir == "" {
+				keyDir = path.Join(args[0], "keys")
+			}
+
+			s, err := newServer(args[0], keyDir, upstream)
 			if err != nil {
 				return err
 			}
@@ -42,7 +48,8 @@ func main() {
 		},
 	}
 	cmd.Flags().StringVarP(&addr, "addr", "", addr, "addr to listen")
-	cmd.Flags().StringVarP(&upstream, "upstream", "", upstream, "specific the upstream mirror")
+	cmd.Flags().StringVarP(&keyDir, "keys", "", keyDir, "specify the directory where stores the private keys")
+	cmd.Flags().StringVarP(&upstream, "upstream", "", upstream, "specify the upstream mirror")
 
 	if err := cmd.Execute(); err != nil {
 		log.Errorf("Execute command: %s", err.Error())

--- a/server/server.go
+++ b/server/server.go
@@ -28,8 +28,8 @@ type server struct {
 }
 
 // NewServer returns a pointer to server
-func newServer(rootDir, upstream string) (*server, error) {
-	mirror := repository.NewMirror(rootDir, repository.MirrorOptions{Upstream: upstream})
+func newServer(rootDir, keyDir, upstream string) (*server, error) {
+	mirror := repository.NewMirror(rootDir, keyDir, repository.MirrorOptions{Upstream: upstream})
 	if err := mirror.Open(); err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ type server struct {
 
 // NewServer returns a pointer to server
 func newServer(rootDir, keyDir, upstream string) (*server, error) {
-	mirror := repository.NewMirror(rootDir, keyDir, repository.MirrorOptions{Upstream: upstream})
+	mirror := repository.NewMirror(rootDir, repository.MirrorOptions{Upstream: upstream, KeyDir: keyDir})
 	if err := mirror.Open(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
So that we can place the keys directory outside the mirror

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
At current tiup-server try to find private keys in the {mirror-root}/keys directory, this need the user put the private keys under the root directory, which is risky.

### What is changed and how it works?
Add a `keys` flag so that the user can specify a directory that stores the keys.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
