### PR TITLE
Add darwin-arm64 not support hint for install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,11 @@ if [ -z "$arch" ]; then
     exit 1
 fi
 
+if [ "$os-$arch" == "darwin-arm64" ]; then
+    echo "Architecture darwin-arm64 not supported." >&2
+    exit 1
+fi
+
 if [ -z "$TIUP_HOME" ]; then
     TIUP_HOME=$HOME/.tiup
 fi

--- a/pkg/cluster/template/install/local_install.sh.go
+++ b/pkg/cluster/template/install/local_install.sh.go
@@ -44,6 +44,11 @@ if [ -z "$arch" ]; then
     exit 1
 fi
 
+if [ "$os-$arch" == "darwin-arm64" ]; then
+    echo "Architecture darwin-arm64 not supported." >&2
+    exit 1
+fi
+
 if [ -z "$TIUP_HOME" ]; then
     TIUP_HOME=$HOME/.tiup
 fi


### PR DESCRIPTION
The darwin-arm64 is not supported currently, and add some friendly hint.

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

temporary fix for #1122 

### What is changed and how it works?

Add some hints 


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
