### PR TITLE
Change the playground info for connecting to TiDB

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -872,7 +872,7 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		fmt.Println(color.GreenString("CLUSTER START SUCCESSFULLY, Enjoy it ^-^"))
 		for _, dbAddr := range succ {
 			ss := strings.Split(dbAddr, ":")
-			fmt.Println(color.GreenString("To connect TiDB: mysql --host %s --port %s -u root", ss[0], ss[1]))
+			fmt.Println(color.GreenString("To connect TiDB: mysql --host %s --port %s -u root -p (no password)", ss[0], ss[1]))
 		}
 	}
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

A `tiup playground nightly` results in:
```
To connect TiDB: mysql --host 127.0.0.1 --port 4000 -u root
```

Running this doesn't work:
```
$ mysql --host 127.0.0.1 --port 4000 -u root
ERROR 1045 (28000): Access denied for user 'root'@'127.0.0.1' (using password: YES)
```

This happens if a `~/.mylogin.cnf` is present or if a password is configured in `~/.my.cnf`.

```
$ mysql_config_editor print
[client]
password = *****

```


### What is changed and how it works?

Adding a `-p` to `mysql` will cause this to prompt for passwords, just pressing
enter then results in a working connection.

Another option would be to set a password for the root user and use `-p<passwd>`
on the command.


Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
