### PR TITLE
cluster: updateTopology maybe hang forever

### DIFF
--- a/pkg/cluster/task/update_topology.go
+++ b/pkg/cluster/task/update_topology.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -37,6 +38,11 @@ func (u *UpdateTopology) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// fix https://github.com/pingcap/tiup/issues/333
+	// etcd client defaults to wait forever
+	// if all pd were down, don't hang forever
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 	txn := client.Txn(ctx)
 
 	topo := u.metadata.Topology

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -92,6 +92,10 @@ function cmd_subtest() {
 
     tiup-cluster $client --yes stop $name
 
+    # test start prometheus,grafana won't hang-forever(can't update topology)
+    # let the CI to stop the job if hang forever
+    ! tiup-cluster $client --yes start $name -R prometheus,grafana
+
     tiup-cluster $client --yes restart $name
 
     tiup-cluster $client _test $name writable


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix #333 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
fixed an issue with hang forever when updating topology
```
