### PR TITLE
Fix check-lint.sh can't run on macOS

### DIFF
--- a/tools/check/check-lint.sh
+++ b/tools/check/check-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # check for io/ioutil
 GREP_IOUTIL=`find -name "*.go" | xargs grep -ns "io\/ioutil"`

--- a/tools/check/check-lint.sh
+++ b/tools/check/check-lint.sh
@@ -8,4 +8,3 @@ if [[ ! -z $GREP_IOUTIL ]]; then
     echo "use of \"io/ioutil\" is deprecated in Go 1.16, please update to use \"io\" and \"os\""
     exit 1
 fi
-


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

check-lint.sh can't work on macOS

```
> make
gofmt (simplify)
goimports (if installed)
linting
./tools/check/check-lint.sh
bash: ./tools/check/check-lint.sh: /bin/env: bad interpreter: No such file or directory
make: *** [lint] Error 126
```

### What is changed and how it works?

Change `/bin/env` to `/usr/bin/env`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Run `make` command to do manual test.

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
