### PR TITLE
cluster: validate cluster name for all cluster ops

### DIFF
--- a/pkg/cluster/manager/cleanup.go
+++ b/pkg/cluster/manager/cleanup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/joomcode/errorx"
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -32,6 +33,10 @@ import (
 
 // CleanCluster cleans the cluster without destroying it
 func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt operator.Options, skipConfirm bool) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	metadata, err := m.meta(name)
 	if err != nil {
 		return err

--- a/pkg/cluster/manager/destroy.go
+++ b/pkg/cluster/manager/destroy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/joomcode/errorx"
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -31,6 +32,10 @@ import (
 
 // DestroyCluster destroy the cluster.
 func (m *Manager) DestroyCluster(name string, gOpt operator.Options, destroyOpt operator.Options, skipConfirm bool) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	metadata, err := m.meta(name)
 	if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) &&
 		!errors.Is(perrs.Cause(err), spec.ErrNoTiSparkMaster) &&

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -25,6 +25,7 @@ import (
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/api"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/executor"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
@@ -52,6 +53,10 @@ type InstInfo struct {
 
 // Display cluster meta and topology.
 func (m *Manager) Display(name string, opt operator.Options) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	clusterInstInfos, err := m.GetClusterTopology(name, opt)
 	if err != nil {
 		return err

--- a/pkg/cluster/manager/edit_config.go
+++ b/pkg/cluster/manager/edit_config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fatih/color"
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/pingcap/tiup/pkg/meta"
@@ -32,6 +33,10 @@ import (
 
 // EditConfig lets the user edit the cluster's config.
 func (m *Manager) EditConfig(name string, skipConfirm bool) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	metadata, err := m.meta(name)
 	if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) {
 		return err

--- a/pkg/cluster/manager/exec.go
+++ b/pkg/cluster/manager/exec.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
 	perrs "github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -37,6 +38,10 @@ type ExecOptions struct {
 
 // Exec shell command on host in the tidb cluster.
 func (m *Manager) Exec(name string, opt ExecOptions, gOpt operator.Options) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	metadata, err := m.meta(name)
 	if err != nil {
 		return err

--- a/pkg/cluster/manager/patch.go
+++ b/pkg/cluster/manager/patch.go
@@ -34,6 +34,10 @@ import (
 
 // Patch the cluster.
 func (m *Manager) Patch(name string, packagePath string, opt operator.Options, overwrite, offline bool) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	metadata, err := m.meta(name)
 	if err != nil {
 		return err

--- a/pkg/cluster/manager/reload.go
+++ b/pkg/cluster/manager/reload.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/joomcode/errorx"
 	perrs "github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -26,6 +27,10 @@ import (
 
 // Reload the cluster.
 func (m *Manager) Reload(name string, opt operator.Options, skipRestart bool) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	sshTimeout := opt.SSHTimeout
 
 	metadata, err := m.meta(name)

--- a/pkg/cluster/manager/rename.go
+++ b/pkg/cluster/manager/rename.go
@@ -17,6 +17,7 @@ import (
 	"os"
 
 	"github.com/pingcap/tiup/pkg/cliutil"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/logger/log"
@@ -25,10 +26,17 @@ import (
 
 // Rename the cluster
 func (m *Manager) Rename(name string, opt operator.Options, newName string) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
 	if !utils.IsExist(m.specManager.Path(name)) {
 		return errorRenameNameNotExist.
 			New("Cluster name '%s' not exist", name).
 			WithProperty(cliutil.SuggestionFromFormat("Please double check your cluster name"))
+	}
+
+	if err := clusterutil.ValidateClusterNameOrError(newName); err != nil {
+		return err
 	}
 	if utils.IsExist(m.specManager.Path(newName)) {
 		return errorRenameNameDuplicate.

--- a/pkg/cluster/manager/scale_in.go
+++ b/pkg/cluster/manager/scale_in.go
@@ -23,6 +23,7 @@ import (
 	"github.com/joomcode/errorx"
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -38,6 +39,10 @@ func (m *Manager) ScaleIn(
 	gOpt operator.Options,
 	scale func(builer *task.Builder, metadata spec.Metadata, tlsCfg *tls.Config),
 ) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	var (
 		force bool     = gOpt.Force
 		nodes []string = gOpt.Nodes

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -22,6 +22,7 @@ import (
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
 	"github.com/pingcap/tiup/pkg/cluster/api"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/executor"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
@@ -51,6 +52,10 @@ func (m *Manager) ScaleOut(
 	skipConfirm bool,
 	gOpt operator.Options,
 ) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	metadata, err := m.meta(name)
 	// allow specific validation errors so that user can recover a broken
 	// cluster if it is somehow in a bad state.

--- a/pkg/cluster/manager/transfer.go
+++ b/pkg/cluster/manager/transfer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/joomcode/errorx"
 	perrs "github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -41,6 +42,10 @@ type TransferOptions struct {
 
 // Transfer copies files from or to host in the tidb cluster.
 func (m *Manager) Transfer(name string, opt TransferOptions, gOpt operator.Options) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	metadata, err := m.meta(name)
 	if err != nil {
 		return err

--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -22,6 +22,7 @@ import (
 	"github.com/joomcode/errorx"
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cliutil"
+	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -35,6 +36,10 @@ import (
 
 // Upgrade the cluster.
 func (m *Manager) Upgrade(name string, clusterVersion string, opt operator.Options, skipConfirm, offline bool) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
 	metadata, err := m.meta(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1176 

### What is changed and how it works?
Validate cluster name for all cluster operations.

Related changes

 - Need to cherry-pick to the release branch

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: validate cluster name for all cluster operations
```
