### PR TITLE
 Fix  help command does not display template

### DIFF
--- a/components/cluster/command/template.go
+++ b/components/cluster/command/template.go
@@ -34,7 +34,6 @@ func newTemplateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "template",
 		Short:  "Print topology template",
-		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opt.Full && opt.MultiDC {
 				return errors.New("at most one of 'full' and 'multi-dc' can be specified")

--- a/components/dm/command/template.go
+++ b/components/dm/command/template.go
@@ -32,7 +32,6 @@ func newTemplateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "template",
 		Short:  "Print topology template",
-		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := "minimal.yaml"
 			if opt.Full {


### PR DESCRIPTION
 Fix help command does not display template

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
