### PR TITLE
Fix the issue that old nighlty may cause error

### DIFF
--- a/pkg/environment/env.go
+++ b/pkg/environment/env.go
@@ -193,6 +193,9 @@ func (env *Environment) SelectInstalledVersion(component string, ver pkgver.Vers
 	versions := []string{}
 	for _, v := range installed {
 		vi, err := env.v1Repo.ComponentVersion(component, v, true)
+		if errors.Cause(err) == repository.ErrUnknownVersion {
+			continue
+		}
 		if err != nil {
 			return ver, err
 		}

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	stderrors "errors"
 	"fmt"
 	"io"
 	"os"
@@ -41,7 +40,10 @@ import (
 )
 
 // ErrUnknownComponent represents the specific component cannot be found in index.json
-var ErrUnknownComponent = stderrors.New("unknown component")
+var ErrUnknownComponent = errors.New("unknown component")
+
+// ErrUnknownVersion represents the specific component version cannot be found in component.json
+var ErrUnknownVersion = errors.New("unknown version")
 
 // V1Repository represents a remote repository viewed with the v1 manifest design.
 type V1Repository struct {
@@ -713,7 +715,7 @@ func (r *V1Repository) ComponentVersion(id, ver string, includeYanked bool) (*v1
 	}
 	vi := manifest.VersionItem(r.PlatformString(), ver, includeYanked)
 	if vi == nil {
-		return nil, errors.Errorf("version %s on %s for component %s not found", ver, r.PlatformString(), id)
+		return nil, errors.Annotatef(ErrUnknownVersion, "version %s on %s for component %s not found", ver, r.PlatformString(), id)
 	}
 	return vi, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In `v1.3.4`, TiUP will check local installed version to filter yanked versions. However, if the version is not yanked but removed from component manifest, eg. an old nightly version will be removed from manifest daily, TiUP will report an error.

### What is changed and how it works?
In `SelectInstalledVersion`, ignore unknown version instead of reporting an error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
