### PR TITLE
mirror: clone in concurrent jobs 

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -810,6 +810,7 @@ func newMirrorCloneCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&options.Archs, "arch", "a", []string{"amd64", "arm64"}, "Specify the downloading architecture")
 	cmd.Flags().StringSliceVarP(&options.OSs, "os", "o", []string{"linux", "darwin"}, "Specify the downloading os")
 	cmd.Flags().BoolVarP(&options.Prefix, "prefix", "", false, "Download the version with matching prefix")
+	cmd.Flags().UintVarP(&options.Jobs, "jobs", "", 1, "Specify the number of concurrent download jobs")
 
 	originHelpFunc := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(command *cobra.Command, args []string) {

--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -315,12 +315,16 @@ func cloneComponents(repo *V1Repository,
 					// The component or the version is yanked, skip download binary
 					continue
 				}
-				versionItem := versionItem
+				name, versionItem := name, versionItem
 				errG.Go(func() error {
 					tickets <- struct{}{}
 					defer func() { <-tickets }()
 
-					return download(targetDir, tmpDir, repo, &versionItem)
+					err := download(targetDir, tmpDir, repo, &versionItem)
+					if err != nil {
+						return errors.Annotatef(err, "download resource: %s", name)
+					}
+					return nil
 				})
 			}
 		}

--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -57,25 +57,19 @@ func CloneMirror(repo *V1Repository,
 	fmt.Printf("Start to clone mirror, targetDir is %s, selectedVersions are [%s]\n", targetDir, strings.Join(selectedVersions, ","))
 	fmt.Println("If this does not meet expectations, please abort this process, read `tiup mirror clone --help` and run again")
 
-	if utils.IsNotExist(targetDir) {
-		if err := os.MkdirAll(targetDir, 0755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return err
 	}
 
 	// Temporary directory is used to save the unverified tarballs
 	tmpDir := filepath.Join(targetDir, fmt.Sprintf("_tmp_%d", time.Now().UnixNano()))
 	keyDir := filepath.Join(targetDir, "keys")
 
-	if utils.IsNotExist(tmpDir) {
-		if err := os.MkdirAll(tmpDir, 0755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		return err
 	}
-	if utils.IsNotExist(keyDir) {
-		if err := os.MkdirAll(keyDir, 0755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(keyDir, 0755); err != nil {
+		return err
 	}
 	defer os.RemoveAll(tmpDir)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

Currently `mirror clone` is in serial mode, it's slow to clone the entire mirror site. So I add `--jobs` to specify the number of download jobs to speed up.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
