### PR TITLE
cluster&dm/display: add an option to only show cluster version

### DIFF
--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -33,6 +33,7 @@ func newDisplayCmd() *cobra.Command {
 	var (
 		clusterName       string
 		showDashboardOnly bool
+		showVersionOnly   bool
 	)
 	cmd := &cobra.Command{
 		Use:   "display <cluster-name>",
@@ -59,6 +60,12 @@ func newDisplayCmd() *cobra.Command {
 				!errors.Is(perrs.Cause(err), spec.ErrNoTiSparkMaster) {
 				return err
 			}
+
+			if showVersionOnly {
+				fmt.Println(metadata.Version)
+				return nil
+			}
+
 			if showDashboardOnly {
 				tlsCfg, err := metadata.Topology.TLSConfig(tidbSpec.Path(clusterName, spec.TLSCertKeyDir))
 				if err != nil {
@@ -74,6 +81,7 @@ func newDisplayCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only display specified roles")
 	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only display specified nodes")
 	cmd.Flags().BoolVar(&showDashboardOnly, "dashboard", false, "Only display TiDB Dashboard information")
+	cmd.Flags().BoolVar(&showVersionOnly, "version", false, "Only display TiDB cluster version")
 
 	return cmd
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add an option `--version` to `display` subcommand of `cluster` and `dm` to only print cluster version to console.

This could be helpful for scripting, an sample usage case would be getting `ctl` with the same version as an deployed cluster.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
![图片](https://user-images.githubusercontent.com/596538/110929440-e95aae80-8362-11eb-8c42-e483fdb8e9e2.png)

Related changes

 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Add an option to `display` subcommand to only show cluster version.
```
