### PR TITLE
cluster: fix tikv upgrade error not returned correctly

### DIFF
--- a/pkg/cluster/operation/upgrade.go
+++ b/pkg/cluster/operation/upgrade.go
@@ -16,6 +16,7 @@ package operator
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"reflect"
 	"strconv"
 	"time"
@@ -68,7 +69,12 @@ func Upgrade(
 			defer func() {
 				upgErr := decreaseScheduleLimit(pdClient, origLeaderScheduleLimit, origRegionScheduleLimit)
 				if upgErr != nil {
-					log.Warnf("failed decreasing schedule limit, please check if they are too high: %s", upgErr)
+					log.Warnf(
+						"failed decreasing schedule limit (original values should be: %s, %s), please check if their current values are reasonable: %s",
+						fmt.Sprintf("leader-schedule-limit=%d", origLeaderScheduleLimit),
+						fmt.Sprintf("region-schedule-limit=%d", origRegionScheduleLimit),
+						upgErr,
+					)
 				}
 			}()
 		default:

--- a/pkg/cluster/operation/upgrade.go
+++ b/pkg/cluster/operation/upgrade.go
@@ -41,7 +41,7 @@ func Upgrade(
 	topo spec.Topology,
 	options Options,
 	tlsCfg *tls.Config,
-) (upgErr error) {
+) error {
 	roleFilter := set.NewStringSet(options.Roles...)
 	nodeFilter := set.NewStringSet(options.Nodes...)
 	components := topo.ComponentsByUpdateOrder()
@@ -66,7 +66,10 @@ func Upgrade(
 				return err
 			}
 			defer func() {
-				upgErr = decreaseScheduleLimit(pdClient, origLeaderScheduleLimit, origRegionScheduleLimit)
+				upgErr := decreaseScheduleLimit(pdClient, origLeaderScheduleLimit, origRegionScheduleLimit)
+				if upgErr != nil {
+					log.Warnf("failed decreasing schedule limit, please check if they are too high: %s", upgErr)
+				}
 			}()
 		default:
 			// do nothing, kept for future usage with other components


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Upgrade errors for TiKV instances are overwritten and ignored.

This was introduced in #1161 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
