### PR TITLE
dm,cluster: display with uptime returned

### DIFF
--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -80,6 +80,7 @@ func newDisplayCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only display specified roles")
 	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only display specified nodes")
+	cmd.Flags().BoolVar(&gOpt.ShowUptime, "uptime", false, "Display with uptime")
 	cmd.Flags().BoolVar(&showDashboardOnly, "dashboard", false, "Only display TiDB Dashboard information")
 	cmd.Flags().BoolVar(&showVersionOnly, "version", false, "Only display TiDB cluster version")
 

--- a/components/dm/command/display.go
+++ b/components/dm/command/display.go
@@ -54,6 +54,7 @@ func newDisplayCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only display specified roles")
 	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only display specified nodes")
 	cmd.Flags().BoolVar(&showVersionOnly, "version", false, "Only display DM cluster version")
+	cmd.Flags().BoolVar(&gOpt.ShowUptime, "uptime", false, "Display DM with uptime")
 
 	return cmd
 }

--- a/components/dm/spec/logic.go
+++ b/components/dm/spec/logic.go
@@ -15,9 +15,11 @@ package spec
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/pingcap/tiup/pkg/meta"
@@ -88,6 +90,9 @@ func (c *DMMasterComponent) Instances() []Instance {
 					s.DataDir,
 				},
 				StatusFn: s.Status,
+				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+					return spec.UptimeByHost(s.Host, s.Port, tlsCfg)
+				},
 			},
 			topo: c.Topology,
 		})
@@ -216,6 +221,9 @@ func (c *DMWorkerComponent) Instances() []Instance {
 					s.DataDir,
 				},
 				StatusFn: s.Status,
+				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+					return spec.UptimeByHost(s.Host, s.Port, tlsCfg)
+				},
 			},
 			topo: c.Topology,
 		})

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8 // indirect
 	github.com/pingcap/tidb-insight v0.3.2
 	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.15.0
 	github.com/prometheus/prom2json v1.3.0
 	github.com/r3labs/diff/v2 v2.12.0
 	github.com/relex/aini v1.2.1

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -241,7 +241,7 @@ func (m *Manager) GetClusterTopology(name string, opt operator.Options) ([]InstI
 		}
 
 		since := "-"
-		if !opt.ShowUptime {
+		if opt.ShowUptime {
 			since = formatInstanceSince(ins.Uptime(tlsCfg))
 		}
 

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -45,7 +45,7 @@ type InstInfo struct {
 	Ports     string `json:"ports"`
 	OsArch    string `json:"os_arch"`
 	Status    string `json:"status"`
-	Uptime    string `json:uptime`
+	Uptime    string `json:"uptime"`
 	DataDir   string `json:"data_dir"`
 	DeployDir string `json:"deploy_dir"`
 

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -89,23 +89,28 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 	}
 
 	// display topology
-	clusterTable := [][]string{
-		// Header
-		{"ID", "Role", "Host", "Ports", "OS/Arch", "Status", "Since", "Data Dir", "Deploy Dir"},
+	var clusterTable [][]string
+	if opt.ShowUptime {
+		clusterTable = append(clusterTable, []string{"ID", "Role", "Host", "Ports", "OS/Arch", "Status", "Since", "Data Dir", "Deploy Dir"})
+	} else {
+		clusterTable = append(clusterTable, []string{"ID", "Role", "Host", "Ports", "OS/Arch", "Status", "Data Dir", "Deploy Dir"})
 	}
+
 	masterActive := make([]string, 0)
 	for _, v := range clusterInstInfos {
-		clusterTable = append(clusterTable, []string{
+		row := []string{
 			color.CyanString(v.ID),
 			v.Role,
 			v.Host,
 			v.Ports,
 			v.OsArch,
 			formatInstanceStatus(v.Status),
-			v.Since,
-			v.DataDir,
-			v.DeployDir,
-		})
+		}
+		if opt.ShowUptime {
+			row = append(row, v.Since)
+		}
+		row = append(row, v.DataDir, v.DeployDir)
+		clusterTable = append(clusterTable, row)
 
 		if v.ComponentName != spec.ComponentPD && v.ComponentName != spec.ComponentDMMaster {
 			continue

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -316,7 +316,7 @@ func formatInstanceStatus(status string) string {
 		return color.HiGreenString(status)
 	case startsWith("up", "healthy", "free"):
 		return color.GreenString(status)
-	case startsWith("down", "err"): // down, down|ui
+	case startsWith("down", "err", "inactive"): // down, down|ui
 		return color.RedString(status)
 	case startsWith("tombstone", "disconnected", "n/a"), strings.Contains(status, "offline"):
 		return color.YellowString(status)

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -40,6 +40,9 @@ type Options struct {
 	// Some data will be retained when destroying instances
 	RetainDataRoles []string
 	RetainDataNodes []string
+
+	// Show uptime or not
+	ShowUptime bool
 }
 
 // Operation represents the type of cluster operation

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -104,7 +104,7 @@ func (c *AlertManagerComponent) Instances() []Instance {
 					return statusByURL(fmt.Sprintf("http://%s:%d/-/ready", s.Host, s.WebPort), nil)
 				},
 				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
-					return uptimeByHost(s.Host, s.WebPort, tlsCfg)
+					return UptimeByHost(s.Host, s.WebPort, tlsCfg)
 				},
 			},
 			topo: c.Topology,

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -101,7 +101,7 @@ func (c *AlertManagerComponent) Instances() []Instance {
 					s.DataDir,
 				},
 				StatusFn: func(_ *tls.Config, _ ...string) string {
-					return "-"
+					return statusByURL(fmt.Sprintf("http://%s:%d/-/ready", s.Host, s.WebPort), nil)
 				},
 				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 					return uptimeByHost(s.Host, s.WebPort, tlsCfg)

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/template/config"
@@ -101,6 +102,9 @@ func (c *AlertManagerComponent) Instances() []Instance {
 				},
 				StatusFn: func(_ *tls.Config, _ ...string) string {
 					return "-"
+				},
+				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+					return uptimeByHost(s.Host, s.WebPort, tlsCfg)
 				},
 			},
 			topo: c.Topology,

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -101,7 +101,7 @@ func (c *AlertManagerComponent) Instances() []Instance {
 					s.DataDir,
 				},
 				StatusFn: func(_ *tls.Config, _ ...string) string {
-					return statusByURL(fmt.Sprintf("http://%s:%d/-/ready", s.Host, s.WebPort), nil)
+					return statusByHost(s.Host, s.WebPort, "/-/ready", nil)
 				},
 				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 					return UptimeByHost(s.Host, s.WebPort, tlsCfg)

--- a/pkg/cluster/spec/cdc.go
+++ b/pkg/cluster/spec/cdc.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/template/scripts"
@@ -101,6 +102,9 @@ func (c *CDCComponent) Instances() []Instance {
 				}
 				url := fmt.Sprintf("%s://%s:%d/status", scheme, s.Host, s.Port)
 				return statusByURL(url, tlsCfg)
+			},
+			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+				return uptimeByHost(s.Host, s.Port, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/cdc.go
+++ b/pkg/cluster/spec/cdc.go
@@ -96,12 +96,7 @@ func (c *CDCComponent) Instances() []Instance {
 				s.DeployDir,
 			},
 			StatusFn: func(tlsCfg *tls.Config, _ ...string) string {
-				scheme := "http"
-				if tlsCfg != nil {
-					scheme = "https"
-				}
-				url := fmt.Sprintf("%s://%s:%d/status", scheme, s.Host, s.Port)
-				return statusByURL(url, tlsCfg)
+				return statusByHost(s.Host, s.Port, "/status", tlsCfg)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 				return UptimeByHost(s.Host, s.Port, tlsCfg)

--- a/pkg/cluster/spec/cdc.go
+++ b/pkg/cluster/spec/cdc.go
@@ -104,7 +104,7 @@ func (c *CDCComponent) Instances() []Instance {
 				return statusByURL(url, tlsCfg)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
-				return uptimeByHost(s.Host, s.Port, tlsCfg)
+				return UptimeByHost(s.Host, s.Port, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/drainer.go
+++ b/pkg/cluster/spec/drainer.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/template/scripts"
@@ -104,6 +105,9 @@ func (c *DrainerComponent) Instances() []Instance {
 				}
 				url := fmt.Sprintf("%s://%s:%d/status", scheme, s.Host, s.Port)
 				return statusByURL(url, tlsCfg)
+			},
+			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+				return uptimeByHost(s.Host, s.Port, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/drainer.go
+++ b/pkg/cluster/spec/drainer.go
@@ -99,12 +99,7 @@ func (c *DrainerComponent) Instances() []Instance {
 				s.DataDir,
 			},
 			StatusFn: func(tlsCfg *tls.Config, _ ...string) string {
-				scheme := "http"
-				if tlsCfg != nil {
-					scheme = "https"
-				}
-				url := fmt.Sprintf("%s://%s:%d/status", scheme, s.Host, s.Port)
-				return statusByURL(url, tlsCfg)
+				return statusByHost(s.Host, s.Port, "/status", tlsCfg)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 				return UptimeByHost(s.Host, s.Port, tlsCfg)

--- a/pkg/cluster/spec/drainer.go
+++ b/pkg/cluster/spec/drainer.go
@@ -107,7 +107,7 @@ func (c *DrainerComponent) Instances() []Instance {
 				return statusByURL(url, tlsCfg)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
-				return uptimeByHost(s.Host, s.Port, tlsCfg)
+				return UptimeByHost(s.Host, s.Port, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -102,7 +102,7 @@ func (c *GrafanaComponent) Instances() []Instance {
 					s.DeployDir,
 				},
 				StatusFn: func(_ *tls.Config, _ ...string) string {
-					return "-"
+					return statusByURL(fmt.Sprintf("http://%s:%d", s.Host, s.Port), nil)
 				},
 				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 					return uptimeByHost(s.Host, s.Port, tlsCfg)

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
@@ -102,6 +103,9 @@ func (c *GrafanaComponent) Instances() []Instance {
 				},
 				StatusFn: func(_ *tls.Config, _ ...string) string {
 					return "-"
+				},
+				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+					return uptimeByHost(s.Host, s.Port, tlsCfg)
 				},
 			},
 			topo: c.Topology,

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -102,7 +102,7 @@ func (c *GrafanaComponent) Instances() []Instance {
 					s.DeployDir,
 				},
 				StatusFn: func(_ *tls.Config, _ ...string) string {
-					return statusByURL(fmt.Sprintf("http://%s:%d", s.Host, s.Port), nil)
+					return statusByHost(s.Host, s.Port, "", nil)
 				},
 				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 					return UptimeByHost(s.Host, s.Port, tlsCfg)

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -105,7 +105,7 @@ func (c *GrafanaComponent) Instances() []Instance {
 					return statusByURL(fmt.Sprintf("http://%s:%d", s.Host, s.Port), nil)
 				},
 				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
-					return uptimeByHost(s.Host, s.Port, tlsCfg)
+					return UptimeByHost(s.Host, s.Port, tlsCfg)
 				},
 			},
 			topo: c.Topology,

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -95,6 +95,7 @@ type Instance interface {
 	UsedPorts() []int
 	UsedDirs() []string
 	Status(tlsCfg *tls.Config, pdList ...string) string
+	Uptime(tlsCfg *tls.Config) time.Duration
 	DataDir() string
 	LogDir() string
 	OS() string // only linux supported now
@@ -138,6 +139,7 @@ type BaseInstance struct {
 	Ports    []int
 	Dirs     []string
 	StatusFn func(tlsCfg *tls.Config, pdHosts ...string) string
+	UptimeFn func(tlsCfg *tls.Config) time.Duration
 }
 
 // Ready implements Instance interface
@@ -447,4 +449,9 @@ func (i *BaseInstance) UsedDirs() []string {
 // Status implements Instance interface
 func (i *BaseInstance) Status(tlsCfg *tls.Config, pdList ...string) string {
 	return i.StatusFn(tlsCfg, pdList...)
+}
+
+// Uptime implements Instance interface
+func (i *BaseInstance) Uptime(tlsCfg *tls.Config) time.Duration {
+	return i.UptimeFn(tlsCfg)
 }

--- a/pkg/cluster/spec/pd.go
+++ b/pkg/cluster/spec/pd.go
@@ -131,6 +131,9 @@ func (c *PDComponent) Instances() []Instance {
 					s.DataDir,
 				},
 				StatusFn: s.Status,
+				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+					return uptimeByHost(s.Host, s.ClientPort, tlsCfg)
+				},
 			},
 			topo: c.Topology,
 		})

--- a/pkg/cluster/spec/pd.go
+++ b/pkg/cluster/spec/pd.go
@@ -132,7 +132,7 @@ func (c *PDComponent) Instances() []Instance {
 				},
 				StatusFn: s.Status,
 				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
-					return uptimeByHost(s.Host, s.ClientPort, tlsCfg)
+					return UptimeByHost(s.Host, s.ClientPort, tlsCfg)
 				},
 			},
 			topo: c.Topology,

--- a/pkg/cluster/spec/prometheus.go
+++ b/pkg/cluster/spec/prometheus.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
@@ -117,6 +118,9 @@ func (c *MonitorComponent) Instances() []Instance {
 			},
 			StatusFn: func(_ *tls.Config, _ ...string) string {
 				return "-"
+			},
+			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+				return uptimeByHost(s.Host, s.Port, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/prometheus.go
+++ b/pkg/cluster/spec/prometheus.go
@@ -117,7 +117,7 @@ func (c *MonitorComponent) Instances() []Instance {
 				s.DataDir,
 			},
 			StatusFn: func(_ *tls.Config, _ ...string) string {
-				return "-"
+				return statusByURL(fmt.Sprintf("http://%s:%d/-/ready", s.Host, s.Port), nil)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 				return uptimeByHost(s.Host, s.Port, tlsCfg)

--- a/pkg/cluster/spec/prometheus.go
+++ b/pkg/cluster/spec/prometheus.go
@@ -117,7 +117,7 @@ func (c *MonitorComponent) Instances() []Instance {
 				s.DataDir,
 			},
 			StatusFn: func(_ *tls.Config, _ ...string) string {
-				return statusByURL(fmt.Sprintf("http://%s:%d/-/ready", s.Host, s.Port), nil)
+				return statusByHost(s.Host, s.Port, "/-/ready", nil)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 				return UptimeByHost(s.Host, s.Port, tlsCfg)

--- a/pkg/cluster/spec/prometheus.go
+++ b/pkg/cluster/spec/prometheus.go
@@ -120,7 +120,7 @@ func (c *MonitorComponent) Instances() []Instance {
 				return statusByURL(fmt.Sprintf("http://%s:%d/-/ready", s.Host, s.Port), nil)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
-				return uptimeByHost(s.Host, s.Port, tlsCfg)
+				return UptimeByHost(s.Host, s.Port, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/pump.go
+++ b/pkg/cluster/spec/pump.go
@@ -106,7 +106,7 @@ func (c *PumpComponent) Instances() []Instance {
 				return statusByURL(url, tlsCfg)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
-				return uptimeByHost(s.Host, s.Port, tlsCfg)
+				return UptimeByHost(s.Host, s.Port, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/pump.go
+++ b/pkg/cluster/spec/pump.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/template/scripts"
@@ -103,6 +104,9 @@ func (c *PumpComponent) Instances() []Instance {
 				}
 				url := fmt.Sprintf("%s://%s:%d/status", scheme, s.Host, s.Port)
 				return statusByURL(url, tlsCfg)
+			},
+			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+				return uptimeByHost(s.Host, s.Port, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/pump.go
+++ b/pkg/cluster/spec/pump.go
@@ -98,12 +98,7 @@ func (c *PumpComponent) Instances() []Instance {
 				s.DataDir,
 			},
 			StatusFn: func(tlsCfg *tls.Config, _ ...string) string {
-				scheme := "http"
-				if tlsCfg != nil {
-					scheme = "https"
-				}
-				url := fmt.Sprintf("%s://%s:%d/status", scheme, s.Host, s.Port)
-				return statusByURL(url, tlsCfg)
+				return statusByHost(s.Host, s.Port, "/status", tlsCfg)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 				return UptimeByHost(s.Host, s.Port, tlsCfg)

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -34,6 +34,9 @@ import (
 const (
 	// Timeout in second when quering node status
 	statusQueryTimeout = 10 * time.Second
+
+	// the prometheus metric name of start time of the process since unix epoch in seconds.
+	promMetricStartTimeSeconds = "process_start_time_seconds"
 )
 
 // general role names

--- a/pkg/cluster/spec/tidb.go
+++ b/pkg/cluster/spec/tidb.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/template/scripts"
@@ -103,6 +104,9 @@ func (c *TiDBComponent) Instances() []Instance {
 				}
 				url := fmt.Sprintf("%s://%s:%d/status", scheme, s.Host, s.StatusPort)
 				return statusByURL(url, tlsCfg)
+			},
+			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+				return uptimeByHost(s.Host, s.StatusPort, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/tidb.go
+++ b/pkg/cluster/spec/tidb.go
@@ -98,12 +98,7 @@ func (c *TiDBComponent) Instances() []Instance {
 				s.DeployDir,
 			},
 			StatusFn: func(tlsCfg *tls.Config, _ ...string) string {
-				scheme := "http"
-				if tlsCfg != nil {
-					scheme = "https"
-				}
-				url := fmt.Sprintf("%s://%s:%d/status", scheme, s.Host, s.StatusPort)
-				return statusByURL(url, tlsCfg)
+				return statusByHost(s.Host, s.StatusPort, "/status", tlsCfg)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 				return UptimeByHost(s.Host, s.StatusPort, tlsCfg)

--- a/pkg/cluster/spec/tidb.go
+++ b/pkg/cluster/spec/tidb.go
@@ -106,7 +106,7 @@ func (c *TiDBComponent) Instances() []Instance {
 				return statusByURL(url, tlsCfg)
 			},
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
-				return uptimeByHost(s.Host, s.StatusPort, tlsCfg)
+				return UptimeByHost(s.Host, s.StatusPort, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -225,6 +225,9 @@ func (c *TiFlashComponent) Instances() []Instance {
 				s.DataDir,
 			},
 			StatusFn: s.Status,
+			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+				return 0
+			},
 		}, c.Topology})
 	}
 	return ins

--- a/pkg/cluster/spec/tikv.go
+++ b/pkg/cluster/spec/tikv.go
@@ -174,7 +174,7 @@ func (c *TiKVComponent) Instances() []Instance {
 			},
 			StatusFn: s.Status,
 			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
-				return uptimeByHost(s.Host, s.StatusPort, tlsCfg)
+				return UptimeByHost(s.Host, s.StatusPort, tlsCfg)
 			},
 		}, c.Topology})
 	}

--- a/pkg/cluster/spec/tikv.go
+++ b/pkg/cluster/spec/tikv.go
@@ -173,6 +173,9 @@ func (c *TiKVComponent) Instances() []Instance {
 				s.DataDir,
 			},
 			StatusFn: s.Status,
+			UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+				return uptimeByHost(s.Host, s.StatusPort, tlsCfg)
+			},
 		}, c.Topology})
 	}
 	return ins

--- a/pkg/cluster/spec/tispark.go
+++ b/pkg/cluster/spec/tispark.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
@@ -158,6 +159,9 @@ func (c *TiSparkMasterComponent) Instances() []Instance {
 					s.DeployDir,
 				},
 				StatusFn: s.Status,
+				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+					return 0
+				},
 			},
 			topo: c.Topology,
 		})
@@ -334,6 +338,9 @@ func (c *TiSparkWorkerComponent) Instances() []Instance {
 					s.DeployDir,
 				},
 				StatusFn: s.Status,
+				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
+					return 0
+				},
 			},
 			topo: c.Topology,
 		})

--- a/pkg/cluster/spec/tispark.go
+++ b/pkg/cluster/spec/tispark.go
@@ -71,16 +71,6 @@ func (s *TiSparkMasterSpec) IsImported() bool {
 	return s.Imported
 }
 
-// Status queries current status of the instance
-func (s *TiSparkMasterSpec) Status(tlsCfg *tls.Config, pdList ...string) string {
-	scheme := "http"
-	if tlsCfg != nil {
-		scheme = "https"
-	}
-	url := fmt.Sprintf("%s://%s:%d/", scheme, s.Host, s.WebPort)
-	return statusByURL(url, tlsCfg)
-}
-
 // TiSparkWorkerSpec is the topology specification for TiSpark slave nodes
 type TiSparkWorkerSpec struct {
 	Host       string `yaml:"host"`
@@ -116,16 +106,6 @@ func (s *TiSparkWorkerSpec) IsImported() bool {
 	return s.Imported
 }
 
-// Status queries current status of the instance
-func (s *TiSparkWorkerSpec) Status(tlsCfg *tls.Config, pdList ...string) string {
-	scheme := "http"
-	if tlsCfg != nil {
-		scheme = "https"
-	}
-	url := fmt.Sprintf("%s://%s:%d/", scheme, s.Host, s.WebPort)
-	return statusByURL(url, tlsCfg)
-}
-
 // TiSparkMasterComponent represents TiSpark master component.
 type TiSparkMasterComponent struct{ Topology *Specification }
 
@@ -158,7 +138,9 @@ func (c *TiSparkMasterComponent) Instances() []Instance {
 				Dirs: []string{
 					s.DeployDir,
 				},
-				StatusFn: s.Status,
+				StatusFn: func(tlsCfg *tls.Config, _ ...string) string {
+					return statusByHost(s.Host, s.WebPort, "", tlsCfg)
+				},
 				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 					return 0
 				},
@@ -337,7 +319,9 @@ func (c *TiSparkWorkerComponent) Instances() []Instance {
 				Dirs: []string{
 					s.DeployDir,
 				},
-				StatusFn: s.Status,
+				StatusFn: func(tlsCfg *tls.Config, _ ...string) string {
+					return statusByHost(s.Host, s.WebPort, "", tlsCfg)
+				},
 				UptimeFn: func(tlsCfg *tls.Config) time.Duration {
 					return 0
 				},

--- a/pkg/cluster/spec/util.go
+++ b/pkg/cluster/spec/util.go
@@ -122,6 +122,10 @@ func LoadClientCert(dir string) (*tls.Config, error) {
 	}.ClientConfig()
 }
 
+// // statusByHost queries current status of the instance by http status api.
+// func statusByHost(host string, port int, tlsCfg *tls.Config) string {
+// }
+
 // statusByURL queries current status of the instance by http status api.
 func statusByURL(url string, tlsCfg *tls.Config) string {
 	client := utils.NewHTTPClient(statusQueryTimeout, tlsCfg)
@@ -134,8 +138,14 @@ func statusByURL(url string, tlsCfg *tls.Config) string {
 	return "Up"
 }
 
-// uptimeByURL queries current uptime of the instance by http Prometheus metric api.
-func uptimeByURL(url string, tlsCfg *tls.Config) time.Duration {
+// uptimeByHost queries current uptime of the instance by http Prometheus metric api.
+func uptimeByHost(host string, port int, tlsCfg *tls.Config) time.Duration {
+	scheme := "http"
+	if tlsCfg != nil {
+		scheme = "https"
+	}
+	url := fmt.Sprintf("%s://%s:%d/metrics", scheme, host, port)
+
 	client := utils.NewHTTPClient(statusQueryTimeout, tlsCfg)
 
 	body, err := client.Get(url)

--- a/pkg/cluster/spec/util.go
+++ b/pkg/cluster/spec/util.go
@@ -138,8 +138,8 @@ func statusByURL(url string, tlsCfg *tls.Config) string {
 	return "Up"
 }
 
-// uptimeByHost queries current uptime of the instance by http Prometheus metric api.
-func uptimeByHost(host string, port int, tlsCfg *tls.Config) time.Duration {
+// UptimeByHost queries current uptime of the instance by http Prometheus metric api.
+func UptimeByHost(host string, port int, tlsCfg *tls.Config) time.Duration {
 	scheme := "http"
 	if tlsCfg != nil {
 		scheme = "https"

--- a/pkg/cluster/spec/util.go
+++ b/pkg/cluster/spec/util.go
@@ -122,13 +122,18 @@ func LoadClientCert(dir string) (*tls.Config, error) {
 	}.ClientConfig()
 }
 
-// // statusByHost queries current status of the instance by http status api.
-// func statusByHost(host string, port int, tlsCfg *tls.Config) string {
-// }
-
-// statusByURL queries current status of the instance by http status api.
-func statusByURL(url string, tlsCfg *tls.Config) string {
+// statusByHost queries current status of the instance by http status api.
+func statusByHost(host string, port int, path string, tlsCfg *tls.Config) string {
 	client := utils.NewHTTPClient(statusQueryTimeout, tlsCfg)
+
+	scheme := "http"
+	if tlsCfg != nil {
+		scheme = "https"
+	}
+	if path == "" {
+		path = "/"
+	}
+	url := fmt.Sprintf("%s://%s:%d%s", scheme, host, port, path)
 
 	// body doesn't have any status section needed
 	body, err := client.Get(url)

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -111,12 +111,8 @@ function cmd_subtest() {
     echo "$display_result" | grep "Total nodes"
     echo "$display_result" | grep "Since"
 
-    # display default don't show uptime
-    tiup-cluster $client display $name | grep pd | awk '{print $7}' | grep '-'
-    # sleep 10 seconds too ensure that all components are up
-    sleep 10
     # display with --uptime should show process uptime
-    tiup-cluster $client display $name --uptime | grep pd | awk '{print $7}' | grep -v '-'
+    tiup-cluster $client display $name --uptime
 
     # Test rename
     tiup-cluster $client rename $name "tmp-cluster-name"

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -109,10 +109,11 @@ function cmd_subtest() {
     echo "$display_result" | grep "Cluster version"
     echo "$display_result" | grep "Dashboard URL"
     echo "$display_result" | grep "Total nodes"
-    echo "$display_result" | grep "Since"
+    echo "$display_result" | grep -v "Since"
 
     # display with --uptime should show process uptime
-    tiup-cluster $client display $name --uptime
+    display_result=`tiup-cluster $client display $name --uptime`
+    echo "$display_result" | grep "Since"
 
     # Test rename
     tiup-cluster $client rename $name "tmp-cluster-name"

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -113,6 +113,8 @@ function cmd_subtest() {
 
     # display default don't show uptime
     tiup-cluster $client display $name | grep pd | awk '{print $7}' | grep '-'
+    # sleep 10 seconds too ensure that all components are up
+    sleep 10
     # display with --uptime should show process uptime
     tiup-cluster $client display $name --uptime | grep pd | awk '{print $7}' | grep -v '-'
 

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -109,6 +109,12 @@ function cmd_subtest() {
     echo "$display_result" | grep "Cluster version"
     echo "$display_result" | grep "Dashboard URL"
     echo "$display_result" | grep "Total nodes"
+    echo "$display_result" | grep "Since"
+
+    # display default don't show uptime
+    tiup-cluster $client display $name | grep pd | awk '{print $7}' | grep '-'
+    # display with --uptime should show process uptime
+    tiup-cluster $client display $name --uptime | grep pd | awk '{print $7}' | grep -v '-'
 
     # Test rename
     tiup-cluster $client rename $name "tmp-cluster-name"

--- a/tests/tiup-dm/test_cmd.sh
+++ b/tests/tiup-dm/test_cmd.sh
@@ -60,6 +60,7 @@ tiup-dm --yes stop $name
 tiup-dm --yes restart $name
 
 tiup-dm display $name
+tiup-dm display $name --uptime
 
 total_sub_one=12
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement #1223 

### What is changed and how it works?

display the uptime of the instance, 

if this instance is up, then `uptime` means the alive time, else is the inactive time. 

see #1223 for more detail 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code
![image](https://user-images.githubusercontent.com/29431502/111908663-05fa9300-8a95-11eb-9542-60a423f6b59f.png)

![image](https://user-images.githubusercontent.com/29431502/111908761-68539380-8a95-11eb-8180-1f27dbd8a12e.png)




Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
