### PR TITLE
Fix the issue that prune command will regen config for removed nodes

### DIFF
--- a/pkg/cluster/manager/destroy.go
+++ b/pkg/cluster/manager/destroy.go
@@ -119,10 +119,16 @@ func (m *Manager) DestroyTombstone(
 
 	b := m.sshTaskBuilder(name, topo, base.User, gOpt)
 
-	var nodes []string
-	b.
+	ctx := ctxt.New(context.Background())
+	nodes, err := operator.DestroyTombstone(ctx, cluster, true /* returnNodesOnly */, gOpt, tlsCfg)
+	if err != nil {
+		return err
+	}
+	regenConfigTasks, _ := buildRegenConfigTasks(m, name, topo, base, nodes, true)
+
+	t := b.
 		Func("FindTomestoneNodes", func(ctx context.Context) (err error) {
-			nodes, err = operator.DestroyTombstone(ctx, cluster, true /* returnNodesOnly */, gOpt, tlsCfg)
+
 			if !skipConfirm {
 				err = cliutil.PromptForConfirmOrAbortError(
 					color.HiYellowString(fmt.Sprintf("Will destroy these nodes: %v\nDo you confirm this action? [y/N]:", nodes)),
@@ -136,14 +142,12 @@ func (m *Manager) DestroyTombstone(
 		}).
 		ClusterOperate(cluster, operator.DestroyTombstoneOperation, gOpt, tlsCfg).
 		UpdateMeta(name, clusterMeta, nodes).
-		UpdateTopology(name, m.specManager.Path(name), clusterMeta, nodes)
-
-	regenConfigTasks, _ := buildRegenConfigTasks(m, name, topo, base, nodes, true)
-	t := b.
+		UpdateTopology(name, m.specManager.Path(name), clusterMeta, nodes).
 		ParallelStep("+ Refresh instance configs", true, regenConfigTasks...).
 		Parallel(true, buildReloadPromTasks(metadata.GetTopology())...).
 		Build()
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+
+	if err := t.Execute(ctx); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tiup/issues/1236

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
