### PR TITLE
tiup: fix -v/--version argument

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,9 +33,10 @@ func init() {
 	cobra.EnableCommandSorting = false
 
 	var (
-		binary  string
-		binPath string
-		tag     string
+		binary       string
+		binPath      string
+		tag          string
+		printVersion bool // not using cobra.Command.Version to make it possible to show component versions
 	)
 
 	rootCmd = &cobra.Command{
@@ -48,13 +49,15 @@ locally will be used. If the specified component does not have any version insta
 the latest stable version will be downloaded from the repository.`,
 
 		SilenceErrors:      true,
-		Version:            version.NewTiUPVersion().String(),
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		Args: func(cmd *cobra.Command, args []string) error {
 			// Support `tiup <component>`
 			return nil
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if printVersion && len(args) == 0 {
+				return nil
+			}
 			e, err := environment.InitEnv(repoOpts)
 			if err != nil {
 				return err
@@ -63,6 +66,10 @@ the latest stable version will be downloaded from the repository.`,
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if printVersion && len(args) == 0 {
+				fmt.Println(version.NewTiUPVersion().String())
+				return nil
+			}
 			env := environment.GlobalEnv()
 			if binary != "" {
 				component, ver := environment.ParseCompVersion(binary)
@@ -114,6 +121,7 @@ the latest stable version will be downloaded from the repository.`,
 	// $ tiup dumpling -h ${host}.
 	// We try to leave the handling of `-h` flag to the component.
 	rootCmd.PersistentFlags().Bool("help", false, "Help for this command")
+	rootCmd.Flags().BoolVarP(&printVersion, "version", "v", false, "Print the version of tiup")
 
 	rootCmd.AddCommand(
 		newInstallCmd(),

--- a/pkg/cluster/manager/destroy.go
+++ b/pkg/cluster/manager/destroy.go
@@ -128,7 +128,6 @@ func (m *Manager) DestroyTombstone(
 
 	t := b.
 		Func("FindTomestoneNodes", func(ctx context.Context) (err error) {
-
 			if !skipConfirm {
 				err = cliutil.PromptForConfirmOrAbortError(
 					color.HiYellowString(fmt.Sprintf("Will destroy these nodes: %v\nDo you confirm this action? [y/N]:", nodes)),


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Not able to show components' version as the `-v/--version` was always been processed by `tiup`. It was introduced in #1158 

### What is changed and how it works?
Not using cobra's builtin `Version` field, but define a custom version argument in `tiup`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
