### PR TITLE
fix: grant cap_net_raw to blackbox_exporter

### DIFF
--- a/embed/templates/systemd/system.service.tpl
+++ b/embed/templates/systemd/system.service.tpl
@@ -21,6 +21,9 @@ LimitCORE={{.LimitCORE}}
 LimitNOFILE=1000000
 LimitSTACK=10485760
 
+{{- if .GrantCapNetRaw}}
+AmbientCapabilities=CAP_NET_RAW
+{{- end}}
 User={{.User}}
 ExecStart={{.DeployDir}}/scripts/run_{{.ServiceName}}.sh
 {{- if eq .ServiceName "prometheus"}}

--- a/pkg/cluster/task/monitored_config.go
+++ b/pkg/cluster/task/monitored_config.go
@@ -105,6 +105,11 @@ func (m *MonitoredConfig) syncMonitoredSystemConfig(ctx context.Context, exec ct
 		WithIOReadBandwidthMax(resource.IOReadBandwidthMax).
 		WithIOWriteBandwidthMax(resource.IOWriteBandwidthMax)
 
+	// blackbox_exporter needs cap_net_raw to send ICMP ping packets
+	if comp == spec.ComponentBlackboxExporter {
+		systemCfg.GrantCapNetRaw = true
+	}
+
 	if err := systemCfg.ConfigToFile(sysCfg); err != nil {
 		return err
 	}

--- a/pkg/cluster/template/systemd/system.go
+++ b/pkg/cluster/template/systemd/system.go
@@ -33,6 +33,7 @@ type Config struct {
 	LimitCORE           string
 	DeployDir           string
 	DisableSendSigkill  bool
+	GrantCapNetRaw      bool
 	// Takes one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always.
 	// The Template set as always if this is not setted.
 	Restart string


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #1249

### What is changed and how it works?
- add `AmbientCapabilities=CAP_NET_RAW` with condition `GrantCapNetRaw` in the template
- set `GrantCapNetRaw` to `true` when `componentName == spec.ComponentBlackboxExporter`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Manually test with `tiup cluster deploy`.

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
