### PR TITLE
cluster: Type -> Rule in confirmTopology

### DIFF
--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -87,7 +87,7 @@ func (m *Manager) confirmTopology(name, version string, topo spec.Topology, patc
 
 	clusterTable := [][]string{
 		// Header
-		{"Type", "Host", "Ports", "OS/Arch", "Directories"},
+		{"Rule", "Host", "Ports", "OS/Arch", "Directories"},
 	}
 
 	topo.IterInstance(func(instance spec.Instance) {

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -87,7 +87,7 @@ func (m *Manager) confirmTopology(name, version string, topo spec.Topology, patc
 
 	clusterTable := [][]string{
 		// Header
-		{"Rule", "Host", "Ports", "OS/Arch", "Directories"},
+		{"Role", "Host", "Ports", "OS/Arch", "Directories"},
 	}
 
 	topo.IterInstance(func(instance spec.Instance) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

IN `tiup cluster display` the topology's header is like below:

![image](https://user-images.githubusercontent.com/29431502/112711903-ea651180-8f06-11eb-8508-e168c6b6acfb.png)


But in `tiup cluster scale-out` the topology's header is like below:

![image](https://user-images.githubusercontent.com/29431502/112711931-12547500-8f07-11eb-9f6e-bdaf1e4e3932.png)

Let's be consistent


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
