### PR TITLE
Fix typo with find command

### DIFF
--- a/tools/check/check-lint.sh
+++ b/tools/check/check-lint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # check for io/ioutil
-GREP_IOUTIL=`find -name "*.go" | xargs grep -ns "io\/ioutil"`
+GREP_IOUTIL=`find . -name "*.go" | xargs grep -ns "io\/ioutil"`
 
 if [[ ! -z $GREP_IOUTIL ]]; then
     echo $GREP_IOUTIL


### PR DESCRIPTION
Fix typo for find command.

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When running make we see

```
rkazak@rkazaknb tiup % make
gofmt (simplify)
goimports (if installed)
linting
./tools/check/check-lint.sh
find: illegal option -- n
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
go mod tidy
```

### What is changed and how it works?

Added in missing '.' - local dir path.

```
rkazak@rkazaknb tiup % make        
gofmt (simplify)
goimports (if installed)
linting
./tools/check/check-lint.sh
go mod tidy
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
