### PR TITLE
cluster: start pd,dm-master in sequentially

### DIFF
--- a/pkg/cluster/manager/builder.go
+++ b/pkg/cluster/manager/builder.go
@@ -306,7 +306,7 @@ func buildScaleOutTask(
 			return m.specManager.SaveMeta(name, metadata)
 		}).
 		Func("StartCluster", func(ctx context.Context) error {
-			return operator.Start(ctx, newPart, operator.Options{OptTimeout: gOpt.OptTimeout}, tlsCfg)
+			return operator.Start(ctx, newPart, operator.Options{OptTimeout: gOpt.OptTimeout, Operation: operator.ScaleOutOperation}, tlsCfg)
 		}).
 		Parallel(false, refreshConfigTasks...).
 		Parallel(false, buildReloadPromTasks(metadata.GetTopology())...)

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -464,7 +464,7 @@ func StartComponent(ctx context.Context, instances []spec.Instance, options Opti
 	// eg: PD has more strict restrictions on the capacity expansion process,
 	// that is, there should be only one node in the peer-join stage at most
 	// ref https://github.com/tikv/pd/blob/d38b36714ccee70480c39e07126e3456b5fb292d/server/join/join.go#L179-L191
-	if name == spec.ComponentPD || name == spec.ComponentDMMaster {
+	if options.Operation == ScaleOutOperation && (name == spec.ComponentPD || name == spec.ComponentDMMaster) {
 		return serialStartInstances(ctx, instances, options, tlsCfg)
 	}
 

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -43,6 +43,7 @@ type Options struct {
 
 	// Show uptime or not
 	ShowUptime bool
+	Operation  Operation
 }
 
 // Operation represents the type of cluster operation


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement #1187 

### What is changed and how it works?

Start instances in serial for Raft related components
eg: PD has more strict restrictions on the capacity expansion process, that is, there should be only one node in the peer-join stage at most.

Ref https://github.com/tikv/pd/blob/d38b36714ccee70480c39e07126e3456b5fb292d/server/join/join.go#L179-L191

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
