### PR TITLE
enable but inact memory profiling

### DIFF
--- a/components/playground/instance/process.go
+++ b/components/playground/instance/process.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -84,8 +85,8 @@ func (p *process) Cmd() *exec.Cmd {
 	return p.cmd
 }
 
-// NewComponentProcess create a Process instance.
-func NewComponentProcess(ctx context.Context, dir, binPath, component string, version utils.Version, arg ...string) (Process, error) {
+// NewComponentProcessWithEnvs create a Process instance with given environment variables.
+func NewComponentProcessWithEnvs(ctx context.Context, dir, binPath, component string, version utils.Version, envs map[string]string, arg ...string) (Process, error) {
 	if dir == "" {
 		panic("dir must be set")
 	}
@@ -95,20 +96,31 @@ func NewComponentProcess(ctx context.Context, dir, binPath, component string, ve
 
 	env := environment.GlobalEnv()
 	params := &tiupexec.PrepareCommandParams{
-		Ctx:         ctx,
-		Component:   component,
-		Version:     version,
-		BinPath:     binPath,
-		InstanceDir: dir,
-		WD:          dir,
-		Args:        arg,
-		SysProcAttr: SysProcAttr,
-		Env:         env,
+		Ctx:          ctx,
+		Component:    component,
+		Version:      version,
+		BinPath:      binPath,
+		InstanceDir:  dir,
+		WD:           dir,
+		Args:         arg,
+		EnvVariables: make([]string, 0),
+		SysProcAttr:  SysProcAttr,
+		Env:          env,
 	}
+	for k, v := range envs {
+		pair := fmt.Sprintf("%s=%s", k, v)
+		params.EnvVariables = append(params.EnvVariables, pair)
+	}
+
 	cmd, err := tiupexec.PrepareCommand(params)
 	if err != nil {
 		return nil, err
 	}
 
 	return &process{cmd: cmd}, nil
+}
+
+// NewComponentProcess create a Process instance.
+func NewComponentProcess(ctx context.Context, dir, binPath, component string, version utils.Version, arg ...string) (Process, error) {
+	return NewComponentProcessWithEnvs(ctx, dir, binPath, component, version, nil, arg...)
 }

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -71,7 +71,9 @@ func (inst *TiKVInstance) Start(ctx context.Context, version utils.Version) erro
 	}
 
 	var err error
-	if inst.Process, err = NewComponentProcess(ctx, inst.Dir, inst.BinPath, "tikv", version, args...); err != nil {
+	envs := make(map[string]string)
+	envs["MALLOC_CONF"] = "prof:true,prof_active:true,prof.active:false"
+	if inst.Process, err = NewComponentProcessWithEnvs(ctx, inst.Dir, inst.BinPath, "tikv", version, envs, args...); err != nil {
 		return err
 	}
 	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))

--- a/embed/templates/scripts/run_tikv.sh.tpl
+++ b/embed/templates/scripts/run_tikv.sh.tpl
@@ -20,6 +20,8 @@ echo $stat
   {{- end}}
 {{- end}}
 
+export MALLOC_CONF="prof:true,prof_active:true,prof.active:false"
+
 {{- if .NumaNode}}
 exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/tikv-server \
 {{- else}}

--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -127,17 +127,18 @@ func base62Tag() string {
 
 // PrepareCommandParams for PrepareCommand.
 type PrepareCommandParams struct {
-	Ctx         context.Context
-	Component   string
-	Version     utils.Version
-	BinPath     string
-	Tag         string
-	InstanceDir string
-	WD          string
-	Args        []string
-	SysProcAttr *syscall.SysProcAttr
-	Env         *environment.Environment
-	CheckUpdate bool
+	Ctx          context.Context
+	Component    string
+	Version      utils.Version
+	BinPath      string
+	Tag          string
+	InstanceDir  string
+	WD           string
+	Args         []string
+	EnvVariables []string
+	SysProcAttr  *syscall.SysProcAttr
+	Env          *environment.Environment
+	CheckUpdate  bool
 }
 
 // PrepareCommand will download necessary component and returns a *exec.Cmd
@@ -222,6 +223,7 @@ func PrepareCommand(p *PrepareCommandParams) (*exec.Cmd, error) {
 		fmt.Sprintf("%s=%s", localdata.EnvTag, p.Tag),
 	}
 	envs = append(envs, os.Environ()...)
+	envs = append(envs, p.EnvVariables...)
 
 	// init the command
 	c := exec.CommandContext(p.Ctx, binPath, p.Args...)


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1270 and https://github.com/tikv/tikv/issues/9538.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   1. Start a TiKV cluster with the environment variable set.
   2. wget "http://172.16.4.78:50013/debug/pprof/heap?seconds=1" to dump a memory profiling

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

Release notes:

```release-note
NONE
```
