### PR TITLE
Fix the dir check logic on imported cluster

### DIFF
--- a/components/dm/ansible/import.go
+++ b/components/dm/ansible/import.go
@@ -330,8 +330,9 @@ func (im *Importer) ImportFromAnsibleDir(ctx context.Context) (clusterName strin
 		case "dm_master_servers":
 			for _, host := range group.Hosts {
 				srv := &spec.MasterSpec{
-					Host:    host.Vars["ansible_host"],
-					SSHPort: ansible.GetHostPort(host, cfg),
+					Host:     host.Vars["ansible_host"],
+					SSHPort:  ansible.GetHostPort(host, cfg),
+					Imported: true,
 				}
 
 				runFileName := filepath.Join(host.Vars["deploy_dir"], "scripts", "run_dm-master.sh")
@@ -380,6 +381,7 @@ func (im *Importer) ImportFromAnsibleDir(ctx context.Context) (clusterName strin
 					Host:      host.Vars["ansible_host"],
 					SSHPort:   ansible.GetHostPort(host, cfg),
 					DeployDir: firstNonEmpty(host.Vars["deploy_dir"], topo.GlobalOptions.DeployDir),
+					Imported:  true,
 				}
 
 				runFileName := filepath.Join(host.Vars["deploy_dir"], "scripts", "run_dm-worker.sh")
@@ -441,6 +443,7 @@ func (im *Importer) ImportFromAnsibleDir(ctx context.Context) (clusterName strin
 					Host:      host.Vars["ansible_host"],
 					SSHPort:   ansible.GetHostPort(host, cfg),
 					DeployDir: firstNonEmpty(host.Vars["deploy_dir"], topo.GlobalOptions.DeployDir),
+					Imported:  true,
 				}
 
 				runFileName := filepath.Join(host.Vars["deploy_dir"], "scripts", "run_prometheus.sh")
@@ -489,6 +492,7 @@ func (im *Importer) ImportFromAnsibleDir(ctx context.Context) (clusterName strin
 					Host:      host.Vars["ansible_host"],
 					SSHPort:   ansible.GetHostPort(host, cfg),
 					DeployDir: firstNonEmpty(host.Vars["deploy_dir"], topo.GlobalOptions.DeployDir),
+					Imported:  true,
 				}
 
 				runFileName := filepath.Join(host.Vars["deploy_dir"], "scripts", "run_alertmanager.sh")
@@ -546,6 +550,7 @@ func (im *Importer) ImportFromAnsibleDir(ctx context.Context) (clusterName strin
 					Port:     port,
 					Username: grafanaUser,
 					Password: grafanaPass,
+					Imported: true,
 				}
 
 				runFileName := filepath.Join(host.Vars["deploy_dir"], "scripts", "run_grafana.sh")

--- a/components/dm/ansible/import_test.go
+++ b/components/dm/ansible/import_test.go
@@ -164,6 +164,7 @@ func TestImportFromAnsible(t *testing.T) {
 		DeployDir: "",
 		LogDir:    "/home/tidb/deploy/log",
 		Config:    map[string]interface{}{"log-level": "info"},
+		Imported:  true,
 	}
 	assert.Equal(expectedMaster, master)
 
@@ -180,6 +181,7 @@ func TestImportFromAnsible(t *testing.T) {
 		DeployDir: "/home/tidb/deploy",
 		LogDir:    "/home/tidb/deploy/log",
 		Config:    map[string]interface{}{"log-level": "info"},
+		Imported:  true,
 	}
 
 	worker := topo.Workers[0]
@@ -199,6 +201,7 @@ func TestImportFromAnsible(t *testing.T) {
 		DeployDir: "",
 		DataDir:   "/home/tidb/deploy/data.alertmanager",
 		LogDir:    "/home/tidb/deploy/log",
+		Imported:  true,
 	}
 	assert.Equal(expectedAlter, aler)
 
@@ -212,6 +215,7 @@ func TestImportFromAnsible(t *testing.T) {
 		Port:      3001,
 		Username:  "foo",
 		Password:  "bar",
+		Imported:  true,
 	}
 	assert.Equal(expectedGrafana, grafana)
 
@@ -225,6 +229,7 @@ func TestImportFromAnsible(t *testing.T) {
 		DataDir:   "/home/tidb/deploy/prometheus.data.metrics",
 		LogDir:    "/home/tidb/deploy/log",
 		Port:      9090,
+		Imported:  true,
 	}
 	assert.Equal(expectedMonitor, monitor)
 

--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -187,8 +187,9 @@ func (m *Manager) Deploy(
 	iterErr = nil
 	topo.IterInstance(func(inst spec.Instance) {
 		if _, found := uniqueHosts[inst.GetHost()]; !found {
-			// check for "imported" parameter, it can not be true when scaling out
-			if inst.IsImported() {
+			// check for "imported" parameter, it can not be true when deploying and scaling out
+			// only for tidb now, need to support dm
+			if inst.IsImported() && m.sysName == "tidb" {
 				iterErr = errors.New(
 					"'imported' is set to 'true' for new instance, this is only used " +
 						"for instances imported from tidb-ansible and make no sense when " +

--- a/pkg/cluster/spec/prometheus.go
+++ b/pkg/cluster/spec/prometheus.go
@@ -372,7 +372,7 @@ func (i *MonitorInstance) initRules(ctx context.Context, e ctxt.Executor, spec *
 		"mkdir -p %[1]s/conf",
 		`find %[1]s/conf -type f -name "*.rules.yml" -delete`,
 		`find %[1]s/bin/prometheus -maxdepth 1 -type f -name "*.rules.yml" -exec cp {} %[1]s/conf/ \;`,
-		`find %[1]s/conf -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i "s/ENV_LABELS_ENV/%[2]s/g" {} \;`,
+		`find %[1]s/conf -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i -e "s/ENV_LABELS_ENV/%[2]s/g" {} \;`,
 	}
 	_, stderr, err := e.Execute(ctx, fmt.Sprintf(strings.Join(cmds, " && "), paths.Deploy, clusterName), false)
 	if err != nil {

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -223,6 +223,9 @@ func CheckClusterDirOverlap(entries []DirEntry) error {
 			}
 
 			if utils.IsSubDir(d1.dir, d2.dir) || utils.IsSubDir(d2.dir, d1.dir) {
+				if d1.instance.IsImported() && d2.instance.IsImported() {
+					continue
+				}
 				properties := map[string]string{
 					"ThisDirKind":   d1.dirKind,
 					"ThisDir":       d1.dir,


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When scaling cluster, tiup will check if there are directories that overlaps each other to avoid conflict. The directories include both imported an new deployed ones.

However, the components deployed by ansible will use the same directory for saving log, which is by designed. At this time, TiUP will report an error if the imported cluster share the same host with different components when you try to scale the cluster.

### What is changed and how it works?

If the directories conflict are both imported, skip instead of report an error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
