### PR TITLE
Added and tweaked the method of reporting makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: components server targets
 .DEFAULT_GOAL := default
 
+LANG=C
 MAKEOVERRIDES =
 targets:
 	@printf "%-30s %s\n" "Target" "Description"
@@ -162,4 +163,3 @@ tools/bin/revive: tools/check/go.mod
 tools/bin/golangci-lint:
 	@# Target: pull in specific version of golangci-lint (v1.38.0)
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.38.0
-

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
-.PHONY: cmd components server
+.PHONY: components server targets
 .DEFAULT_GOAL := default
+
+MAKEOVERRIDES =
+targets:
+	@printf "%-30s %s\n" "Target" "Description"
+	@printf "%-30s %s\n" "------" "-----------"
+	@make -pqR : 2>/dev/null \
+	| awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' \
+	| egrep -v -e '^[^[:alnum:]]' -e '^$@$$' \
+	| sort \
+	| xargs -I _ sh -c 'printf "%-30s " _; make _ -nB | (grep "^# Target:" || echo "") | tail -1 | sed "s/^# Target: //g"'
 
 REPO    := github.com/pingcap/tiup
 
@@ -27,99 +37,129 @@ FAILPOINT_ENABLE  := $$(tools/bin/failpoint-ctl enable)
 FAILPOINT_DISABLE := $$(tools/bin/failpoint-ctl disable)
 
 default: check build
+	@# Target: run the checks and then build.
 
 include ./tests/Makefile
 
 # Build TiUP and all components
 build: tiup components
+	@# Target: build tiup and all it's components
 
 components: playground client cluster dm bench server
+	@# Target: build the playground, client, cluster, dm, bench and server components
 
 tiup:
+	@# Target: build the tiup driver
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup
 
 playground:
+	@# Target: build tiup-playground component
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup-playground ./components/playground
 
 client:
+	@# Target: build the tiup-client component
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup-client ./components/client
 
 cluster:
+	@# Target: build the tiup-cluster component
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup-cluster ./components/cluster
 
 dm:
+	@# Target: build the tiup-dm component
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup-dm ./components/dm
 
 bench:
+	@# Target: build the tiup-bench component
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup-bench ./components/bench
 
 doc:
+	@# Target: build the tiup-doc component
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup-doc ./components/doc
 
 errdoc:
+	@# Target: build the tiup-errdoc component
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup-errdoc ./components/errdoc
 
 ctl:
+	@# Target: build the tiup-ctl component
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup-ctl ./components/ctl
 
 server:
+	@# Target: build the tiup-server component
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup-server ./server
 
 check: fmt lint tidy check-static vet
+	@# Target: run all checkers. (fmt, lint, tidy, check-static and vet)
 
 check-static: tools/bin/golangci-lint
+	@# Target: run the golangci-lint static check tool
 	tools/bin/golangci-lint run --config tools/check/golangci.yaml ./... --deadline=3m --fix
 
 lint: tools/bin/revive
+	@# Target: run the lint checker revive
 	@echo "linting"
 	./tools/check/check-lint.sh
 	@tools/bin/revive -formatter friendly -config tools/check/revive.toml $(FILES)
 
 vet:
+	@# Target: run the go vet tool
 	$(GO) vet ./...
 
 tidy:
+	@# Target: run tidy check
 	@echo "go mod tidy"
 	./tools/check/check-tidy.sh
 
 clean:
+	@# Target: run the build cleanup steps
 	@rm -rf bin
 	@rm -rf cover
 	@rm -rf tests/*/{bin/*.test,logs,cover/*.out}
 
 test: failpoint-enable run-tests failpoint-disable
+	@# Target: run tests with failpoint enabled
 
 # TODO: refactor integration tests base on v1 manifest
 # run-tests: unit-test integration_test
 run-tests: unit-test
+	@# Target: run the unit tests
 
 # Run tests
 unit-test:
+	@# Target: run the code coverage test phase
 	mkdir -p cover
 	TIUP_HOME=$(shell pwd)/tests/tiup $(GOTEST) ./... -covermode=count -coverprofile cover/cov.unit-test.out
 
 race: failpoint-enable
+	@# Target: run race check with failpoint enabled
 	TIUP_HOME=$(shell pwd)/tests/tiup $(GOTEST) -race ./...  || { $(FAILPOINT_DISABLE); exit 1; }
 	@$(FAILPOINT_DISABLE)
 
 failpoint-enable: tools/bin/failpoint-ctl
+	@# Target: enable failpoint
 	@$(FAILPOINT_ENABLE)
 
 failpoint-disable: tools/bin/failpoint-ctl
+	@# Target: disable failpoint
 	@$(FAILPOINT_DISABLE)
 
 tools/bin/failpoint-ctl: go.mod
+	@# Target: build the failpoint-ctl utility
 	$(GO) build -o $@ github.com/pingcap/failpoint/failpoint-ctl
 
 fmt:
+	@# Target: run the go formatter utility
 	@echo "gofmt (simplify)"
 	@gofmt -s -l -w $(FILES) 2>&1
 	@echo "goimports (if installed)"
 	$(shell goimports -w $(FILES) 2>/dev/null)
 
 tools/bin/revive: tools/check/go.mod
+	@# Target: build revive utility
 	cd tools/check; \
 	$(GO) build -o ../bin/revive github.com/mgechev/revive
 
 tools/bin/golangci-lint:
+	@# Target: pull in specific version of golangci-lint (v1.38.0)
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.38.0
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,8 @@
 build_integration_test: build_tiup_playground_test build_tiup_cluster_test build_tiup_dm_test
+	@# Target: run the playground, cluster, and dm integration tests.
 
 build_tiup_playground_test: failpoint-enable
+	@# Target: run the tiup-playground tests
 	$(GOTEST) -c -cover -covermode=count \
 		-coverpkg=github.com/pingcap/tiup/... \
 		-o tests/tiup-playground/bin/tiup-playground.test \
@@ -8,6 +10,7 @@ build_tiup_playground_test: failpoint-enable
 	@$(FAILPOINT_DISABLE)
 
 build_tiup_cluster_test: failpoint-enable
+	@# Target: run the tiup-cluster tests
 	$(GOTEST) -c -cover -covermode=count \
 		-coverpkg=github.com/pingcap/tiup/... \
 		-o tests/tiup-cluster/bin/tiup-cluster.test \
@@ -15,6 +18,7 @@ build_tiup_cluster_test: failpoint-enable
 	@$(FAILPOINT_DISABLE)
 
 build_tiup_dm_test: failpoint-enable
+	@# Target: run the tiup-dm tests
 	$(GOTEST) -c -cover -covermode=count \
 		-coverpkg=github.com/pingcap/tiup/... \
 		-o tests/tiup-dm/bin/tiup-dm.test \
@@ -22,6 +26,7 @@ build_tiup_dm_test: failpoint-enable
 	@$(FAILPOINT_DISABLE)
 
 build_tiup_test: failpoint-enable
+	@# Target: run the tiup tests
 	$(GOTEST) -c -cover -covermode=count \
 		-coverpkg=github.com/pingcap/tiup/... \
 		-o tests/tiup/bin/tiup.test \


### PR DESCRIPTION
Added a target into the make file to be able to report available targets within the makefile. This was a tweak of something I saw on - https://stackoverflow.com/questions/4219255/how-do-you-get-the-list-of-targets-in-a-makefile

This help us by documenting known targets.
