### PR TITLE
Revert "Fix tiflash not start with newest nightly PD (#902)"

### DIFF
--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -152,7 +152,7 @@ func (inst *TiFlashInstance) Start(ctx context.Context, version utils.Version) e
 		if err != nil {
 			return err
 		}
-		if version, err = env.GetComponentInstalledVersion("tiflash", version); err != nil {
+		if version, err = env.DownloadComponentIfMissing("tiflash", version); err != nil {
 			return err
 		}
 		// version may be empty, we will use the latest stable version later in Start cmd.

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -76,8 +76,7 @@ type scheduleConfig struct {
 }
 
 type replicateMaxReplicaConfig struct {
-	MaxReplicas          int    `json:"max-replicas"`
-	EnablePlacementRules string `json:"enable-placement-rules"`
+	MaxReplicas int `json:"max-replicas"`
 }
 
 type replicateEnablePlacementRulesConfig struct {
@@ -123,8 +122,7 @@ func (inst *TiFlashInstance) Start(ctx context.Context, version utils.Version) e
 	}
 	// Update maxReplicas before placement rules so that it would not be overwritten
 	maxReplicas, err := json.Marshal(replicateMaxReplicaConfig{
-		MaxReplicas:          1,
-		EnablePlacementRules: "false",
+		MaxReplicas: 1,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This reverts commit 402079dbc40bc7397d4b136eccacee833c81d898.

We should reverts #902 because it introduced an issue:
https://github.com/pingcap/tiup/issues/1279

BTW, PD itself fixes #888 in https://github.com/tikv/pd/pull/3163
So we don't need #902 anymore with recently released PD.

However, after revert #902, ***TiFlash with old PD (before #3163) may not work with tiup-playground***

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
