### PR TITLE
fix: workaround for nightly versions in checkConfig()

### DIFF
--- a/pkg/cluster/spec/server_config.go
+++ b/pkg/cluster/spec/server_config.go
@@ -264,9 +264,14 @@ func checkConfig(ctx context.Context, e ctxt.Executor, componentName, clusterVer
 			return perrs.Annotate(ErrorCheckConfig, err.Error())
 		}
 
+		clsVer := utils.Version(clusterVersion)
 		ver := clusterVersion
+		if clsVer.IsNightly() {
+			ver = utils.NightlyVersionAlias
+		}
+		// FIXME: workaround for nightly versions, need refactor
 		if bindVersion != nil {
-			ver = bindVersion(componentName, clusterVersion)
+			ver = bindVersion(componentName, ver)
 		}
 
 		entry, err := repo.ComponentBinEntry(componentName, ver)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If a cluster is deployed with the real version of nightly of that day, e.g.: `v5.0.0-nightly-20210405` instead of `nightly`, and when there is a new nightly version overwrites that value (and as we don't keep old nightly versions, the `v5.0.0-nightly-20210405` then no longer available in the repo), a `reload` operation will fail with `unknown version` error.

If the cluster was deployed with `nightly` as version, all seems working correctly.

### What is changed and how it works?
Check if the cluster version is a nightly version, and use `nightly` as version to query binary paths in repo for the component.

This may, in theory, encounter issues when the deployed nightly version was so far behind the real latest nightly version, the the entry point path of component has changed since it was deployed and last upgraded.

**Note** that this should be considered as a workaround only, and we may need to refactor the `checkConfig()` for better nightly version handling.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: workaround for config checks of manually deployed nightly versions
```
