### PR TITLE
cluster: speed up start/enable monitor instances

### DIFF
--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -381,9 +381,8 @@ func systemctl(ctx context.Context, executor ctxt.Executor, service string, acti
 		if bytes.Contains(stderr, []byte(" not loaded.")) {
 			log.Warnf(string(stderr))
 			return nil // reset the error to avoid exiting
-		} else {
-			log.Errorf(string(stderr))
 		}
+		log.Errorf(string(stderr))
 	}
 	return err
 }

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -90,15 +90,17 @@ func Start(
 		if err != nil {
 			return errors.Annotatef(err, "failed to start %s", comp.Name())
 		}
-		if monitoredOptions == nil {
-			continue
-		}
-		for _, inst := range insts {
-			if !uniqueHosts.Exist(inst.GetHost()) {
-				uniqueHosts.Insert(inst.GetHost())
-				if err := StartMonitored(ctx, inst, monitoredOptions, options.OptTimeout); err != nil {
-					return err
-				}
+		uniqueHosts.Join(insts...)
+	}
+
+	if monitoredOptions == nil {
+		return nil
+	}
+	for _, inst := range insts {
+		if !uniqueHosts.Exist(inst.GetHost()) {
+			uniqueHosts.Insert(inst.GetHost())
+			if err := StartMonitored(ctx, inst, monitoredOptions, options.OptTimeout); err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -276,9 +276,9 @@ func RestartComponent(ctx context.Context, instances []spec.Instance, timeout ui
 func enableInstance(ctx context.Context, ins spec.Instance, timeout uint64, isEnable bool) error {
 	e := ctxt.GetInner(ctx).Get(ins.GetHost())
 	if isEnable {
-		log.Infof("\tEnabling instance %s %s:%d", ins.ComponentName(), ins.GetHost(), ins.GetPort())
+		log.Infof("\tEnabling instance %s %s", ins.ComponentName(), ins.ID())
 	} else {
-		log.Infof("\tDisabling instance %s %s:%d", ins.ComponentName(), ins.GetHost(), ins.GetPort())
+		log.Infof("\tDisabling instance %s %s", ins.ComponentName(), ins.ID())
 	}
 
 	action := "disable"
@@ -402,10 +402,20 @@ func EnableMonitored(ctx context.Context, hosts []string, options *spec.Monitore
 			host := host
 			nctx := checkpoint.NewContext(ctx)
 			errg.Go(func() error {
+				if isEnable {
+					log.Infof("\tEnabling instance %s", host)
+				} else {
+					log.Infof("\tDisabling instance %s", host)
+				}
 				e := ctxt.GetInner(nctx).Get(host)
 				service := fmt.Sprintf("%s-%d.service", comp, ports[comp])
 				if err := systemctl(nctx, e, service, action, timeout); err != nil {
 					return toFailedActionError(err, action, host, service, "")
+				}
+				if isEnable {
+					log.Infof("\tEnable instance %s success", host)
+				} else {
+					log.Infof("\tDisable instance %s success", host)
 				}
 				return nil
 			})

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -263,9 +263,9 @@ func systemctlMonitor(ctx context.Context, hosts []string, options *spec.Monitor
 				var err error
 				switch action {
 				case "start":
-					err = spec.PortStarted(ctx, e, ports[comp], timeout)
+					err = spec.PortStarted(nctx, e, ports[comp], timeout)
 				case "stop":
-					err = spec.PortStopped(ctx, e, ports[comp], timeout)
+					err = spec.PortStopped(nctx, e, ports[comp], timeout)
 				}
 
 				if err != nil {

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -90,17 +90,15 @@ func Start(
 		if err != nil {
 			return errors.Annotatef(err, "failed to start %s", comp.Name())
 		}
-		uniqueHosts.Join(insts...)
-	}
-
-	if monitoredOptions == nil {
-		return nil
-	}
-	for _, inst := range insts {
-		if !uniqueHosts.Exist(inst.GetHost()) {
-			uniqueHosts.Insert(inst.GetHost())
-			if err := StartMonitored(ctx, inst, monitoredOptions, options.OptTimeout); err != nil {
-				return err
+		if monitoredOptions == nil {
+			continue
+		}
+		for _, inst := range insts {
+			if !uniqueHosts.Exist(inst.GetHost()) {
+				uniqueHosts.Insert(inst.GetHost())
+				if err := StartMonitored(ctx, inst, monitoredOptions, options.OptTimeout); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -111,7 +111,7 @@ func StopAndDestroyInstance(ctx context.Context, cluster spec.Topology, instance
 		monitoredOptions := cluster.GetMonitoredOptions()
 
 		if monitoredOptions != nil {
-			if err := StopMonitored(ctx, instance.GetHost(), monitoredOptions, options.OptTimeout); err != nil {
+			if err := StopMonitored(ctx, []string{instance.GetHost()}, monitoredOptions, options.OptTimeout); err != nil {
 				if !ignoreErr {
 					return errors.Annotatef(err, "failed to stop monitor")
 				}

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -111,7 +111,7 @@ func StopAndDestroyInstance(ctx context.Context, cluster spec.Topology, instance
 		monitoredOptions := cluster.GetMonitoredOptions()
 
 		if monitoredOptions != nil {
-			if err := StopMonitored(ctx, instance, monitoredOptions, options.OptTimeout); err != nil {
+			if err := StopMonitored(ctx, instance.GetHost(), monitoredOptions, options.OptTimeout); err != nil {
 				if !ignoreErr {
 					return errors.Annotatef(err, "failed to stop monitor")
 				}

--- a/pkg/cluster/spec/pump.go
+++ b/pkg/cluster/spec/pump.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
@@ -149,7 +148,7 @@ func (i *PumpInstance) InitConfig(
 
 	enableTLS := topo.GlobalOptions.TLSEnabled
 	spec := i.InstanceSpec.(*PumpSpec)
-	nodeID := i.GetHost() + ":" + strconv.Itoa(i.GetPort())
+	nodeID := i.ID()
 	// keep origin node id if is imported
 	if i.IsImported() {
 		nodeID = ""


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In the current implementation, node_exporter and blackbox_exporter may be invoked multiple times serially during a single `tiup cluster {start|stop|enable}` processing. 
Instead，those monitor components will be concurrently executed after all components are executed.

The process time of `tiup cluster enable` compared to old's  as follows:

```bash
# old 
Enabled cluster `c1` successfully

real    0m13.318s
user    0m2.228s
sys     0m0.319s

# new 
Enabled cluster `c1` successfully

real    0m5.687s
user    0m2.176s
sys     0m0.244s
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
