### PR TITLE
ci: bump tidb versions in test scripts

### DIFF
--- a/tests/tiup-cluster/run.sh
+++ b/tests/tiup-cluster/run.sh
@@ -11,8 +11,8 @@ export TIUP_CLUSTER_PROGRESS_REFRESH_RATE=10s
 export TIUP_CLUSTER_EXECUTE_DEFAULT_TIMEOUT=300s
 export DEBUG_CHECKPOINT=1
 
-export version=${version-v4.0.4}
-export old_version=${old_version-v3.0.16}
+export version=${version-v4.0.12}
+export old_version=${old_version-v3.0.20}
 
 # Prepare local config
 echo "preparing local config"

--- a/tests/tiup-cluster/test_cmd.sh
+++ b/tests/tiup-cluster/test_cmd.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/cmd_subtest.sh
 
-echo "test cluster for verision v4.0.9 wo/ TLS, via easy ssh"
-cmd_subtest 4.0.9 false false
+echo "test cluster for verision v4.0.12 wo/ TLS, via easy ssh"
+cmd_subtest 4.0.12 false false

--- a/tests/tiup-cluster/test_cmd_tls_native_ssh.sh
+++ b/tests/tiup-cluster/test_cmd_tls_native_ssh.sh
@@ -5,7 +5,7 @@ set -eu
 source script/cmd_subtest.sh
 export GO_FAILPOINTS='github.com/pingcap/tiup/pkg/cluster/executor/assertNativeSSH=return(true)' 
 
-echo "test cluster for verision v4.0.9 w/ TLS, via native ssh"
-cmd_subtest v4.0.9 true true
+echo "test cluster for verision v4.0.12 w/ TLS, via native ssh"
+cmd_subtest v4.0.12 true true
 
 unset GO_FAILPOINTS

--- a/tests/tiup-cluster/test_scale_core.sh
+++ b/tests/tiup-cluster/test_scale_core.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/scale_core.sh
 
-echo "test scaling of core components in cluster for verision v4.0.4 wo/ TLS, via easy ssh"
-scale_core v4.0.4 false false
+echo "test scaling of core components in cluster for verision v4.0.12 wo/ TLS, via easy ssh"
+scale_core v4.0.12 false false

--- a/tests/tiup-cluster/test_scale_core_tls.sh
+++ b/tests/tiup-cluster/test_scale_core_tls.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/scale_core.sh
 
-echo "test scaling of core components in cluster for verision v4.0.4 w/ TLS, via easy ssh"
-scale_core v4.0.4 true false
+echo "test scaling of core components in cluster for verision v4.0.12 w/ TLS, via easy ssh"
+scale_core v4.0.12 true false

--- a/tests/tiup-cluster/test_scale_tools.sh
+++ b/tests/tiup-cluster/test_scale_tools.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/scale_tools.sh
 
-echo "test scaling of tools components in cluster for verision v4.0.4, via easy ssh"
-scale_tools v4.0.4 false false
+echo "test scaling of tools components in cluster for verision v4.0.12, via easy ssh"
+scale_tools v4.0.12 false false

--- a/tests/tiup-cluster/test_scale_tools_tls.sh
+++ b/tests/tiup-cluster/test_scale_tools_tls.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/scale_tools.sh
 
-echo "test scaling of tools components in cluster for verision v4.0.4 w/ TLS, via easy ssh"
-scale_tools v4.0.4 true false
+echo "test scaling of tools components in cluster for verision v4.0.12 w/ TLS, via easy ssh"
+scale_tools v4.0.12 true false

--- a/tests/tiup-cluster/test_upgrade.sh
+++ b/tests/tiup-cluster/test_upgrade.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-version=${version-v4.0.4}
-old_version=${old_version-v3.0.16}
+version=${version-v4.0.12}
+old_version=${old_version-v3.0.20}
 name=test_upgrade
 topo=./topo/upgrade.yaml
 

--- a/tests/tiup-cluster/test_upgrade_tls.sh
+++ b/tests/tiup-cluster/test_upgrade_tls.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-version=${version-v4.0.4}
-old_version=${old_version-v3.0.16}
+version=${version-v4.0.12}
+old_version=${old_version-v3.0.20}
 name=test_upgrade_tls
 topo=./topo/upgrade_tls.yaml
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->
### What is changed and how it works?
Bump tidb versions in test scripts to the latest `v4.0.12` release.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - No code


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
