### PR TITLE
Send 'Staring component...' output to stderr

### DIFF
--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -156,7 +156,7 @@ func PrepareCommand(p *PrepareCommandParams) (*exec.Cmd, error) {
 			return nil, err
 		}
 		if semver.Compare(selectVer.String(), latestV.String()) < 0 {
-			fmt.Println(color.YellowString(`Found %[1]s newer version:
+			fmt.Fprintln(os.Stderr, color.YellowString(`Found %[1]s newer version:
 
     The latest version:         %[2]s
     Local installed version:    %[3]s
@@ -275,7 +275,7 @@ func launchComponent(ctx context.Context, component string, version utils.Versio
 		Cmd:         c,
 	}
 
-	fmt.Printf("Starting component `%s`: %s\n", component, strings.Join(append([]string{p.Exec}, p.Args...), " "))
+	fmt.Fprintf(os.Stderr, "Starting component `%s`: %s\n", component, strings.Join(append([]string{p.Exec}, p.Args...), " "))
 	err = p.Cmd.Start()
 	if p.Cmd.Process != nil {
 		p.Pid = p.Cmd.Process.Pid


### PR DESCRIPTION

### What is changed and how it works?

Some components output JSON or YAML. When the "Starting component..." message is mixed with this
the output needs to be cleaned up before it can be used.

Examples of this are:

```
tiup ctl:v5.0.0 tidb --host 192.168.122.50 schema in mysql | jq
```

```
tiup cluster template > template.yaml
```

This commit changes the output o the "Starting component..." to be send to stderr instead.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Run the command with `> /dev/null`, you should now only see the `Starting component...` line.

Related changes

 - Need to cherry-pick to the release branch

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
