### PR TITLE
tiup: update `mirror` command

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -831,7 +831,17 @@ func newMirrorCloneCmd() *cobra.Command {
 				return spec.TiDBComponentVersion(comp, "")
 			}
 
-			return repository.CloneMirror(repo, components, versionMapper, args[0], args[1:], options)
+			// format input versions
+			versionList := make([]string, 0)
+			for _, ver := range args[1:] {
+				v, err := utils.FmtVer(ver)
+				if err != nil {
+					return err
+				}
+				versionList = append(versionList, v)
+			}
+
+			return repository.CloneMirror(repo, components, versionMapper, args[0], versionList, options)
 		},
 	}
 

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -655,8 +655,8 @@ func newMirrorInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init <path>",
 		Short: "Initialize an empty repository",
-		Long: `Initialize an empty TiUP repository at given path. If path is not specified, the
-current working directory (".") will be used.`,
+		Long: `Initialize an empty TiUP repository at given path.
+The specified path must be an empty directory.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return cmd.Help()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,11 +58,20 @@ the latest stable version will be downloaded from the repository.`,
 			if printVersion && len(args) == 0 {
 				return nil
 			}
-			e, err := environment.InitEnv(repoOpts)
-			if err != nil {
-				return err
+			switch cmd.Name() {
+			case "init":
+				if cmd.HasParent() && cmd.Parent().Name() == "mirror" {
+					// skip environment init
+					break
+				}
+				fallthrough
+			default:
+				e, err := environment.InitEnv(repoOpts)
+				if err != nil {
+					return err
+				}
+				environment.SetGlobalEnv(e)
 			}
-			environment.SetGlobalEnv(e)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,8 @@ the latest stable version will be downloaded from the repository.`,
 				return nil
 			}
 			switch cmd.Name() {
-			case "init":
+			case "init",
+				"set":
 				if cmd.HasParent() && cmd.Parent().Name() == "mirror" {
 					// skip environment init
 					break


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Fix #1299 
- Fix #1301 
- Fix version handling in `tiup mirror clone` sub command, to support input versions both with and without leading `v`
- Add a `--reset` flag to `tiup mirror set` sub command to reset the mirror to builtin default (`https://tiup-mirrors.pingcap.com/`)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
fix bugs and improve usability of `tiup mirror` sub command.
```
