### PR TITLE
repository: optimize error handing if root.json fails to load

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,14 +14,18 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/fatih/color"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/localdata"
+	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/pingcap/tiup/pkg/repository"
+	"github.com/pingcap/tiup/pkg/repository/v1manifest"
 	"github.com/pingcap/tiup/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -69,6 +73,9 @@ the latest stable version will be downloaded from the repository.`,
 			default:
 				e, err := environment.InitEnv(repoOpts)
 				if err != nil {
+					if errors.Is(perrs.Cause(err), v1manifest.ErrLoadManifest) {
+						log.Warnf("Please check for root manifest file, you may download one from the repository mirror, or try `tiup mirror set` to force reset it.")
+					}
 					return err
 				}
 				environment.SetGlobalEnv(e)

--- a/pkg/repository/v1manifest/local_manifests.go
+++ b/pkg/repository/v1manifest/local_manifests.go
@@ -206,7 +206,10 @@ func (ms *FsManifests) load(filename string) (string, error) {
 				}
 				bytes, err := os.ReadFile(initRoot)
 				if err != nil {
-					return "", errors.Errorf("cannot open the initial root.json at %s", initRoot)
+					return "", &LoadManifestError{
+						manifest: "root.json",
+						err:      err,
+					}
 				}
 				return string(bytes), nil
 			}

--- a/pkg/repository/v1manifest/types.go
+++ b/pkg/repository/v1manifest/types.go
@@ -15,6 +15,8 @@ package v1manifest
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 )
 
@@ -268,4 +270,35 @@ func (manifest *Component) VersionListWithYanked(platform string) map[string]Ver
 	}
 
 	return vs
+}
+
+// ErrLoadManifest is an empty object of LoadManifestError, useful for type check
+var ErrLoadManifest = &LoadManifestError{}
+
+// LoadManifestError is the error type used when loading manifest failes
+type LoadManifestError struct {
+	manifest string // manifest name
+	err      error  // wrapped error
+}
+
+// Error implements the error interface
+func (e *LoadManifestError) Error() string {
+	return fmt.Sprintf(
+		"error loading manifest %s: %s",
+		e.manifest, e.err,
+	)
+}
+
+// Unwrap implements the error interface
+func (e *LoadManifestError) Unwrap() error { return e.err }
+
+// Is implements the error interface
+func (e *LoadManifestError) Is(target error) bool {
+	t, ok := target.(*LoadManifestError)
+	if !ok {
+		return false
+	}
+
+	return (e.manifest == t.manifest || t.manifest == "") &&
+		(errors.Is(e.err, t) || t.err == nil)
 }

--- a/pkg/repository/v1manifest/types_test.go
+++ b/pkg/repository/v1manifest/types_test.go
@@ -14,6 +14,8 @@
 package v1manifest
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/alecthomas/assert"
@@ -82,4 +84,38 @@ func TestVersionList(t *testing.T) {
 
 	versions = manifest.VersionList("windows/amd64")
 	assert.Equal(t, len(versions), 0)
+}
+
+func TestLoadManifestError(t *testing.T) {
+	err0 := &LoadManifestError{
+		manifest: "root.json",
+		err:      fmt.Errorf("dummy error"),
+	}
+	// identical errors are equal
+	assert.True(t, errors.Is(err0, err0))
+	assert.True(t, errors.Is(ErrLoadManifest, ErrLoadManifest))
+	assert.True(t, errors.Is(ErrLoadManifest, &LoadManifestError{}))
+	assert.True(t, errors.Is(&LoadManifestError{}, ErrLoadManifest))
+	// not equal for different error types
+	assert.False(t, errors.Is(err0, errors.New("")))
+	// default Value matches any error
+	assert.True(t, errors.Is(err0, ErrLoadManifest))
+	// error with values are not matching default ones
+	assert.False(t, errors.Is(ErrLoadManifest, err0))
+
+	err1 := &LoadManifestError{
+		manifest: "root.json",
+		err:      fmt.Errorf("dummy error 2"),
+	}
+	assert.True(t, errors.Is(err1, ErrLoadManifest))
+	// errors with different errors are different
+	assert.False(t, errors.Is(err0, err1))
+	assert.False(t, errors.Is(err1, err0))
+
+	err2 := &LoadManifestError{
+		manifest: "root.json",
+	}
+	// nil errors can be match with any error, but not vise vera
+	assert.True(t, errors.Is(err1, err2))
+	assert.False(t, errors.Is(err2, err1))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This implements the code part of #1300, document updates may still be needed.

### What is changed and how it works?
Keep the original error from std libraries, and display an extra warning message if the error is failed loading `root.json` manifest, and provide an instruction for workaround (`tiup mirror set`).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
optimize error messages when `root.json` manifest file fails to load.
```
