### PR TITLE
repository/progress: Format progress

### DIFF
--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -383,7 +383,7 @@ func download(targetDir, tmpDir string, repo *V1Repository, item *v1manifest.Ver
 	// Skip installed file if exists file valid
 	if utils.IsExist(dstFile) {
 		if err := validate(targetDir); err == nil {
-			fmt.Println("Skip exists file:", filepath.Join(targetDir, item.URL))
+			fmt.Println("Skipping existing file:", filepath.Join(targetDir, item.URL))
 			return nil
 		}
 	}

--- a/pkg/repository/progress.go
+++ b/pkg/repository/progress.go
@@ -42,7 +42,7 @@ func (p *ProgressBar) Start(url string, size int64) {
 	p.size = size
 	p.bar = pb.Start64(size)
 	p.bar.Set(pb.Bytes, true)
-	p.bar.SetTemplateString(fmt.Sprintf(`download %s {{counters . }} {{percent . }} {{speed . }}`, url))
+	p.bar.SetTemplateString(fmt.Sprintf(`download %s {{counters . }} {{percent . }} {{speed . "%%s/s" "? MiB/s"}}`, url))
 }
 
 // SetCurrent implement the DownloadProgress interface


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

This fixes #451

Instead of `1.23 MiB p/s` it now shows `1.23 MiB/s`.

### What is changed and how it works?

This sets a format string for the speed element of the ProgressBar. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Run `tiup mirror clone ...` and inspect output.


Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
