### PR TITLE
mirror clone: Improve handling of latest versions

### DIFF
--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -464,6 +464,9 @@ func combineVersions(versions *[]string,
 					if latest == "" {
 						continue
 					}
+					if selectedVersion != utils.LatestVersionAlias {
+						fmt.Printf("%s %s/%s %s not found, using %s instead.\n", manifest.ID, os, arch, selectedVersion, latest)
+					}
 					selectedVersion = latest
 				}
 				if !result.Exist(selectedVersion) {

--- a/pkg/utils/semver.go
+++ b/pkg/utils/semver.go
@@ -23,6 +23,9 @@ import (
 // NightlyVersionAlias represents latest build of master branch.
 const NightlyVersionAlias = "nightly"
 
+// LatestVersionAlias represents the latest build (excluding nightly versions).
+const LatestVersionAlias = "latest"
+
 // FmtVer converts a version string to SemVer format, if the string is not a valid
 // SemVer and fails to parse and convert it, an error is raised.
 func FmtVer(ver string) (string, error) {
@@ -30,6 +33,11 @@ func FmtVer(ver string) (string, error) {
 
 	// nightly version is an alias
 	if strings.ToLower(v) == NightlyVersionAlias {
+		return v, nil
+	}
+
+	// latest version is an alias
+	if strings.ToLower(v) == LatestVersionAlias {
 		return v, nil
 	}
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

When running `tiup mirror clone ... v5.0.0` it may download a different version of a component if there
is no v5.0.0 for that component. 

If you specify "v9999" it will cause `tiup mirror clone` to download the latest version of all components.

### What is changed and how it works?

1. Print a message when falling back on the latest version for a component
2. Allow the user to specify "latest" as version to get the latest version.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Try `tiup mirror clone /path/to/tiup-mirror --os linux --arch amd64 latest` and `tiup mirror clone /path/to/tiup-mirror --os linux --arch amd4 v5.0.0`.

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Allow specifying "latest" as version for `tiup mirror clone`
```
