### PR TITLE
mirror: add `tiup mirror show` command to print current mirror address

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -66,6 +66,7 @@ of components or the repository itself.`,
 		newMirrorCloneCmd(),
 		newMirrorMergeCmd(),
 		newMirrorPublishCmd(),
+		newMirrorShowCmd(),
 		newMirrorSetCmd(),
 		newMirrorModifyCmd(),
 		newMirrorGrantCmd(),
@@ -135,6 +136,21 @@ func newMirrorSignCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&privPath, "key", "k", "", "Specify the private key path")
 	cmd.Flags().IntVarP(&timeout, "timeout", "", timeout, "Specify the timeout when access the network")
+
+	return cmd
+}
+
+// the `mirror show` sub command
+func newMirrorShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show mirror address",
+		Long:  `Show current mirror address`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println(environment.Mirror())
+			return nil
+		},
+	}
 
 	return cmd
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, there has no explicit command to get the current mirror address.

(An non-explicit way: `cat ~/.tiup/tiup.toml` and it is non-documented)

### What is changed and how it works?

Add an explicit command to show the current mirror address.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```
> ./tiup mirror show
https://tiup-mirrors.pingcap.com/

> ./tiup mirror set /Volumes/T7/local-tiup-mirror 
Successfully set mirror to /Volumes/T7/local-tiup-mirror

> ./tiup mirror show
/Volumes/T7/local-tiup-mirror
```

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
- Add `tiup mirror show` command to display the current mirror address
```
