### PR TITLE
playground: add --comments option to the mysql client connection tips

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -873,7 +873,8 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 		fmt.Println(color.GreenString("CLUSTER START SUCCESSFULLY, Enjoy it ^-^"))
 		for _, dbAddr := range succ {
 			ss := strings.Split(dbAddr, ":")
-			fmt.Println(color.GreenString("To connect TiDB: mysql --host %s --port %s -u root -p (no password)", ss[0], ss[1]))
+			connectMsg := "To connect TiDB: mysql --host %s --port %s -u root -p (no password) --comments"
+			fmt.Println(color.GreenString(connectMsg, ss[0], ss[1]))
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/pingcap/tidb/issues/24176#issuecomment-823865522

### What is changed and how it works?

Add the `--comments` option to the mysql client connection tips.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

NA

Side effects

NA

Related changes

NA

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
