### PR TITLE
playground: support semver constraint

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -341,7 +341,7 @@ func newMirrorRotateCmd() *cobra.Command {
 }
 
 func editLatestRootManifest() (*v1manifest.Root, error) {
-	root, err := environment.GlobalEnv().V1Repository().FetchRootManfiest()
+	root, err := environment.GlobalEnv().V1Repository().FetchRootManifest()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -635,8 +636,8 @@ func (r *V1Repository) loadRoot() (*v1manifest.Root, error) {
 	return root, nil
 }
 
-// FetchRootManfiest fetch the root manifest.
-func (r *V1Repository) FetchRootManfiest() (root *v1manifest.Root, err error) {
+// FetchRootManifest fetch the root manifest.
+func (r *V1Repository) FetchRootManifest() (root *v1manifest.Root, err error) {
 	err = r.ensureManifests()
 	if err != nil {
 		return nil, err
@@ -738,6 +739,58 @@ func (r *V1Repository) ComponentVersion(id, ver string, includeYanked bool) (*v1
 		return nil, errors.Annotatef(ErrUnknownVersion, "version %s on %s for component %s not found", ver, r.PlatformString(), id)
 	}
 	return vi, nil
+}
+
+// ResolveComponentVersion resolves the latest version of a component that satisfies the constraint
+func (r *V1Repository) ResolveComponentVersion(id, constraint string) (utils.Version, error) {
+	manifest, err := r.FetchComponentManifest(id, false)
+	if err != nil {
+		return "", err
+	}
+	var ver string
+	switch constraint {
+	case "", utils.LatestVersionAlias:
+		v, _, err := r.LatestStableVersion(id, false)
+		if err != nil {
+			return "", err
+		}
+		ver = v.String()
+	case utils.NightlyVersionAlias:
+		if !manifest.HasNightly(r.PlatformString()) {
+			return "", errors.Annotatef(ErrUnknownVersion, "component %s does not have nightly on %s", id, r.PlatformString())
+		}
+		ver = manifest.Nightly
+	default:
+		cons, err := utils.NewConstraint(constraint)
+		if err != nil {
+			return "", err
+		}
+		versions := manifest.VersionList(r.PlatformString())
+		verList := make([]string, 0, len(versions))
+		for v := range versions {
+			if v == manifest.Nightly {
+				continue
+			}
+			verList = append(verList, v)
+		}
+		sort.Slice(verList, func(p, q int) bool {
+			return semver.Compare(verList[p], verList[q]) > 0
+		})
+		for _, v := range verList {
+			if cons.Check(v) {
+				ver = v
+				break
+			}
+		}
+	}
+	if ver == "" {
+		return "", fmt.Errorf(`no version on %s for component %s satisfies constraint "%s"`, r.PlatformString(), id, constraint)
+	}
+	vi := manifest.VersionItem(r.PlatformString(), ver, false)
+	if vi == nil {
+		return "", errors.Annotatef(ErrUnknownVersion, "version %s on %s for component %s not found", ver, r.PlatformString(), id)
+	}
+	return utils.Version(ver), nil
 }
 
 // LatestNightlyVersion returns the latest nightly version of specific component

--- a/pkg/utils/regexp.go
+++ b/pkg/utils/regexp.go
@@ -2,6 +2,7 @@ package utils
 
 import "regexp"
 
+// MatchGroups turns a slice of matched string to a map according to capture group name
 func MatchGroups(r *regexp.Regexp, str string) map[string]string {
 	matched := r.FindStringSubmatch(str)
 	results := make(map[string]string)

--- a/pkg/utils/regexp.go
+++ b/pkg/utils/regexp.go
@@ -1,0 +1,13 @@
+package utils
+
+import "regexp"
+
+func MatchGroups(r *regexp.Regexp, str string) map[string]string {
+	matched := r.FindStringSubmatch(str)
+	results := make(map[string]string)
+	names := r.SubexpNames()
+	for i, value := range matched {
+		results[names[i]] = value
+	}
+	return results
+}

--- a/pkg/utils/regexp_test.go
+++ b/pkg/utils/regexp_test.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	. "github.com/pingcap/check"
+	"regexp"
+)
+
+var _ = Suite(&TestRegexpSuite{})
+
+type TestRegexpSuite struct{}
+
+func (s *TestRegexpSuite) TestMatchGroups(c *C) {
+	cases := []struct {
+		re       string
+		str      string
+		expected map[string]string
+	}{
+		{
+			re:  `^(?P<first>[a-zA-Z]*)(?P<second>[0-9]*)$`,
+			str: "abc123",
+			expected: map[string]string{
+				"":       "abc123",
+				"first":  "abc",
+				"second": "123",
+			},
+		},
+	}
+
+	for _, cas := range cases {
+		c.Assert(
+			MatchGroups(regexp.MustCompile(cas.re), cas.str),
+			DeepEquals, cas.expected)
+	}
+}

--- a/pkg/utils/semver.go
+++ b/pkg/utils/semver.go
@@ -177,7 +177,7 @@ func NewConstraint(raw string) (*Constraint, error) {
 			c.max.Patch = 0
 		}
 	} else if l := len(c.max.Prerelease); l > 0 {
-		c.max.Prerelease[l-1] = c.max.Prerelease[l-1] + " "
+		c.max.Prerelease[l-1] += " "
 	} else {
 		c.max.Patch++
 	}

--- a/pkg/utils/semver.go
+++ b/pkg/utils/semver.go
@@ -15,9 +15,13 @@ package utils
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/mod/semver"
+
+	"github.com/pingcap/errors"
 )
 
 // NightlyVersionAlias represents latest build of master branch.
@@ -73,4 +77,193 @@ func (v Version) IsNightly() bool {
 // String implements the fmt.Stringer interface
 func (v Version) String() string {
 	return string(v)
+}
+
+type ver struct {
+	Major, Minor, Patch int
+	Prerelease          []string
+}
+
+func (v *ver) Compare(other *ver) int {
+	if d := compareSegment(v.Major, other.Major); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.Minor, other.Minor); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.Patch, other.Patch); d != 0 {
+		return d
+	}
+
+	return comparePrerelease(v.Prerelease, other.Prerelease)
+}
+
+type Constraint struct {
+	// [min, max)
+	min ver // min ver
+	max ver // max ver
+}
+
+var (
+	constraintRegex = regexp.MustCompile(
+		`^(?P<constraint>[~^])?v?(?P<major>0|[1-9]\d*)(?:\.(?P<minor>0|[1-9]\d*|[x*]))?(?:\.(?P<patch>0|[1-9]\d*|[x*]))?(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<build>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`,
+	)
+
+	versionRegexp = regexp.MustCompile(
+		`^v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<build>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`,
+	)
+)
+
+// NewConstraint creates a constraint to check whether a semver is valid.
+// Only support ^ and ~ and x|X|*
+func NewConstraint(raw string) (*Constraint, error) {
+	result := MatchGroups(constraintRegex, strings.ToLower(strings.TrimSpace(raw)))
+	if len(result) == 0 {
+		return nil, errors.New("fail to parse version constraint")
+	}
+	c := &Constraint{}
+	defer func() {
+		if len(c.max.Prerelease) == 0 {
+			c.max.Prerelease = []string{"0"}
+		}
+	}()
+
+	c.min.Major = MustAtoI(result["major"])
+	c.max.Major = c.min.Major
+
+	if minor := result["minor"]; minor == "x" || minor == "*" {
+		c.max.Major = c.min.Major + 1
+		return c, nil
+	} else if minor != "" {
+		c.min.Minor = MustAtoI(result["minor"])
+		c.max.Minor = c.min.Minor
+	}
+
+	if patch := result["patch"]; patch == "x" || patch == "*" {
+		c.max.Minor = c.min.Minor + 1
+		return c, nil
+	} else if patch != "" {
+		c.min.Patch = MustAtoI(result["patch"])
+		c.max.Patch = c.min.Patch
+	}
+
+	if prerelease := result["prerelease"]; prerelease != "" {
+		c.min.Prerelease = strings.Split(prerelease, ".")
+	} else {
+		c.min.Prerelease = []string{}
+	}
+
+	c.max.Prerelease = append([]string(nil), c.min.Prerelease...)
+
+	if constraint := result["constraint"]; constraint == "~" {
+		// ~x.y.z -> >=x.y.z <x.(y+1).0
+		c.max.Minor++
+		c.max.Patch = 0
+	} else if constraint == "^" {
+		if c.min.Major == 0 {
+			if c.min.Minor == 0 {
+				// ^0.0.z -> =0.0.z
+				c.max.Patch++
+			} else {
+				// ^0.y.z -> >=0.y.z <0.(y+1).0
+				c.max.Minor++
+				c.max.Patch = 0
+			}
+		} else {
+			// ^x.y.z -> >=x.y.z <(x+1).0.0
+			c.max.Major++
+			c.max.Minor = 0
+			c.max.Patch = 0
+		}
+	} else if l := len(c.max.Prerelease); l > 0 {
+		c.max.Prerelease[l-1] = c.max.Prerelease[l-1] + " "
+	} else {
+		c.max.Patch++
+	}
+
+	return c, nil
+}
+
+func (c *Constraint) Check(v string) bool {
+	result := MatchGroups(versionRegexp, strings.ToLower(strings.TrimSpace(v)))
+	if len(result) == 0 {
+		return false
+	}
+
+	major := MustAtoI(result["major"])
+	minor := MustAtoI(result["minor"])
+	patch := MustAtoI(result["patch"])
+	version := &ver{
+		Major:      major,
+		Minor:      minor,
+		Patch:      patch,
+		Prerelease: []string{},
+	}
+	if pre := result["prerelease"]; pre != "" {
+		version.Prerelease = strings.Split(pre, ".")
+	}
+	return c.min.Compare(version) <= 0 && c.max.Compare(version) > 0
+}
+
+func compareSegment(v, o int) int {
+	if v < o {
+		return -1
+	}
+	if v > o {
+		return 1
+	}
+	return 0
+}
+
+// 1, -1, 0 means A>B, A<B, A=B
+func comparePrerelease(preA, preB []string) int {
+	lenA := len(preA)
+	lenB := len(preB)
+	if lenA == 0 && lenB == 0 {
+		return 0
+	}
+	if lenA == 0 {
+		return 1
+	}
+	if lenB == 0 {
+		return -1
+	}
+	for i, tempA := range preA {
+		if i == lenB {
+			// alpha < alpha.1
+			return 1
+		}
+		if d := compareAlphaNum(tempA, preB[i]); d != 0 {
+			return d
+		}
+	}
+	if lenB > len(preA) {
+		return -1
+	}
+	return 0
+}
+
+func compareAlphaNum(a, b string) int {
+	if a == b {
+		return 0
+	}
+	iA, errA := strconv.Atoi(a)
+	iB, errB := strconv.Atoi(b)
+	if errA != nil && errB != nil {
+		if a > b {
+			return 1
+		}
+		return -1
+	}
+	// Numeric identifiers always have lower precedence than non-numeric identifiers.
+	if errA != nil {
+		return 1
+	}
+	if errB != nil {
+		return -1
+	}
+	if iA > iB {
+		return 1
+	}
+	return -1
 }

--- a/pkg/utils/semver.go
+++ b/pkg/utils/semver.go
@@ -98,6 +98,7 @@ func (v *ver) Compare(other *ver) int {
 	return comparePrerelease(v.Prerelease, other.Prerelease)
 }
 
+// Constraint for semver
 type Constraint struct {
 	// [min, max)
 	min ver // min ver
@@ -184,6 +185,7 @@ func NewConstraint(raw string) (*Constraint, error) {
 	return c, nil
 }
 
+// Check checks whether a version is satisfies the constraint
 func (c *Constraint) Check(v string) bool {
 	result := MatchGroups(versionRegexp, strings.ToLower(strings.TrimSpace(v)))
 	if len(result) == 0 {

--- a/pkg/utils/semver_test.go
+++ b/pkg/utils/semver_test.go
@@ -33,3 +33,53 @@ func (s *TestSemverSuite) TestVersion(c *C) {
 	c.Assert(Version("nightly").IsNightly(), IsTrue)
 	c.Assert(Version("v1.2.3").String(), Equals, "v1.2.3")
 }
+
+func (s *TestSemverSuite) TestConstraint(c *C) {
+	cases := []struct {
+		constraint string
+		version    string
+		match      bool
+	}{
+		{"^4", "4.1.0", true},
+		{"4", "4.0.0", true},
+		{"4.0", "4.0.0", true},
+		{"~4.0", "4.0.5", true},
+		{"4.1.x", "4.1.0", true},
+		{"4.1.x", "4.1.5", true},
+		{"4.x.0", "4.5.0", true},
+		{"4.x.0", "4.5.2", true},
+		{"4.x.x", "4.5.2", true},
+		{"4.3.2-0", "4.3.2", false},
+		{"^1.1.0", "1.1.1", true},
+		{"~1.1.0", "1.1.1", true},
+		{"~1.1.0", "1.2.0", false},
+		{"^1.x.x", "1.1.1", true},
+		{"^2.x.x", "1.1.1", false},
+		{"^1.x.x", "2.1.1", false},
+		{"^1.x.x", "1.1.1-beta1", true},
+		{"^1.1.2-alpha", "1.2.1-beta.1", true},
+		{"^1.2.x", "1.2.1-beta.1", true},
+		{"~1.1.1-beta", "1.1.1-alpha", false},
+		{"~1.1.1-beta", "1.1.1-beta.1", true},
+		{"~1.1.1-beta", "1.1.1", true},
+		{"~1.2.3", "1.2.5", true},
+		{"~1.2.3", "1.2.2", false},
+		{"~1.2.3", "1.3.2", false},
+		{"~1.1.*", "1.2.3", false},
+		{"~1.3.0", "2.4.5", false},
+		{"^4.0", "5.0.0-rc", false},
+		{"^4.0-rc", "5.0.0-rc", false},
+		{"4.0.0-rc", "4.0.0-rc", true},
+		{"~4.0.0-rc", "4.0.0-rc.1", true},
+		{"^4", "v5.0.0-20210408", false},
+		{"^4.*.*", "5.0.0-0", false},
+		{"5.*.*", "5.0.0-0", false},
+		{"^4.0.0-1", "4.0.0-1", true},
+		{"4.0.0-1", "4.0.0-1", true},
+	}
+	for _, cas := range cases {
+		cons, err := NewConstraint(cas.constraint)
+		c.Assert(err, IsNil)
+		c.Assert(cons.Check(cas.version), Equals, cas.match)
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -41,6 +41,7 @@ func IsFlagSetByUser(flagSet *pflag.FlagSet, flagName string) bool {
 	return setByUser
 }
 
+// MustAtoI calls strconv.Atoi and ignores error
 func MustAtoI(a string) int {
 	v, _ := strconv.Atoi(a)
 	return v

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -40,3 +40,8 @@ func IsFlagSetByUser(flagSet *pflag.FlagSet, flagName string) bool {
 	})
 	return setByUser
 }
+
+func MustAtoI(a string) int {
+	v, _ := strconv.Atoi(a)
+	return v
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Playground is used to quickly start up a local tidb cluster for developing or testing. If it supports version constraint, it will be more convenient. For example, it can replace the combination of `tiup list` and `tiup playground` for starting up a cluster of the latest version of a major version.

### What is changed and how it works?

implement basic semver constraint `*` `x` `^` `~` just like how https://semver.npmjs.com/ calculates, and support short form of version

In all versions that satisfies version constraint, playground will find the latest one to start up.

*`v` can be omitted*

e.g.

`5` = `5.0` =  `5.0.0`

`5.*` = `5.x` = `5.*.*` = `5.x.x` = `^5` = `^5.0` = `^5.0.0`

`5.0.x` = `5.0.*` = `~5` = `~5.0` = `~5.0.0`

prereleases always be ignored unless use constraint like `^5.0.0-rc` or `~5.0.0-rc` or `5.0.0-rc`

preview:

![image](https://user-images.githubusercontent.com/5772358/115663324-eb0c8e80-a372-11eb-84cd-aeb7532617f5.png)

![image](https://user-images.githubusercontent.com/5772358/115663473-227b3b00-a373-11eb-878a-b7963debe6c4.png)

![image](https://user-images.githubusercontent.com/5772358/115663907-c06f0580-a373-11eb-802f-df1ce5685c5a.png)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Side effects

Related changes

 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Support semver constraint for Playground component
```
