### PR TITLE
cluster: fix and optimize os version check

### DIFF
--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -159,21 +159,23 @@ func checkOSInfo(opt *CheckOptions, osInfo *sysinfo.OS) *CheckResult {
 		}
 	case "debian":
 		// debian support is not fully tested, but we suppose it should work
-		result.Err = fmt.Errorf("debian support is not fully tested, be careful")
+		msg := "debian support is not fully tested, be careful"
+		result.Err = fmt.Errorf("%s (%s)", result.Msg, msg)
 		result.Warn = true
 		if ver, _ := strconv.Atoi(osInfo.Version); ver < 9 {
 			result.Err = fmt.Errorf("%s %s not supported, use version 9 or higher (%s)",
-				osInfo.Name, osInfo.Release, result.Err)
+				osInfo.Name, osInfo.Release, msg)
 			result.Warn = false
 			return result
 		}
 	case "ubuntu":
 		// ubuntu support is not fully tested, but we suppose it should work
-		result.Err = fmt.Errorf("ubuntu support is not fully tested, be careful")
+		msg := "ubuntu support is not fully tested, be careful"
+		result.Err = fmt.Errorf("%s (%s)", result.Msg, msg)
 		result.Warn = true
 		if ver, _ := strconv.ParseFloat(osInfo.Version, 64); ver < 18.04 {
 			result.Err = fmt.Errorf("%s %s not supported, use version 18.04 or higher (%s)",
-				osInfo.Name, osInfo.Release, result.Err)
+				osInfo.Name, osInfo.Release, msg)
 			result.Warn = false
 			return result
 		}

--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -150,15 +150,33 @@ func checkOSInfo(opt *CheckOptions, osInfo *sysinfo.OS) *CheckResult {
 
 	// check OS vendor
 	switch osInfo.Vendor {
-	case "centos", "redhat":
+	case "centos", "redhat", "rhel":
 		// check version
 		if ver, _ := strconv.Atoi(osInfo.Version); ver < 7 {
 			result.Err = fmt.Errorf("%s %s not supported, use version 7 or higher",
 				osInfo.Name, osInfo.Release)
 			return result
 		}
-	case "debian", "ubuntu":
-		// check version
+	case "debian":
+		// debian support is not fully tested, but we suppose it should work
+		result.Err = fmt.Errorf("debian support is not fully tested, be careful")
+		result.Warn = true
+		if ver, _ := strconv.Atoi(osInfo.Version); ver < 9 {
+			result.Err = fmt.Errorf("%s %s not supported, use version 9 or higher (%s)",
+				osInfo.Name, osInfo.Release, result.Err)
+			result.Warn = false
+			return result
+		}
+	case "ubuntu":
+		// ubuntu support is not fully tested, but we suppose it should work
+		result.Err = fmt.Errorf("ubuntu support is not fully tested, be careful")
+		result.Warn = true
+		if ver, _ := strconv.ParseFloat(osInfo.Version, 64); ver < 18.04 {
+			result.Err = fmt.Errorf("%s %s not supported, use version 18.04 or higher (%s)",
+				osInfo.Name, osInfo.Release, result.Err)
+			result.Warn = false
+			return result
+		}
 	default:
 		result.Err = fmt.Errorf("os vendor %s not supported", osInfo.Vendor)
 		return result


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1332 and add warning to Debian/Ubuntu users.

Our components should be working on recent Debian and Ubuntu systems, we have some development servers running Debian and Ubuntu systems and are working well, but we don't yet have them fully tested, our full test suits are only run on CentOS 7 as of now.

### What is changed and how it works?
- Fix version check for some RHEL systems
- Add warnings for Debian and Ubuntu systems
- Check versions of Debian and Ubuntu systems and report error for very old releases

The change does not matters that much as the `check` process is optional for users trying to deploy a cluster.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: fix and optimize os version check
```
