### PR TITLE
repository: set user agent for mirror requests

### DIFF
--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tiup/pkg/utils/mock"
 	"github.com/pingcap/tiup/pkg/utils/rand"
 	"github.com/pingcap/tiup/pkg/verbose"
+	"github.com/pingcap/tiup/pkg/version"
 )
 
 const (
@@ -293,6 +294,7 @@ func (l *httpMirror) download(url string, to string, maxSize int64) (io.ReadClos
 	}(time.Now())
 
 	client := grab.NewClient()
+	client.UserAgent = fmt.Sprintf("tiup/%s", version.NewTiUPVersion().SemVer())
 	req, err := grab.NewRequest(to, url)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Set user-agent for HTTP requests make by repository, the default is `grab` now.

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
repository: set user agent for mirror requests
```
