### PR TITLE
install.sh: check depends before downloading package

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,11 +43,11 @@ install_binary() {
 check_depends() {
     pass=0
     command -v curl >/dev/null || {
-        echo "Dependency check failed: please install 'curl' before installing."
-	pass=1
+        echo "Dependency check failed: please install 'curl' before proceeding."
+        pass=1
     }
     command -v tar >/dev/null || {
-        echo "Dependency check failed: please install 'tar' before installing."
+        echo "Dependency check failed: please install 'tar' before proceeding."
         pass=1
     }
     return $pass

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,23 @@ install_binary() {
     return 0
 }
 
+check_depends() {
+    pass=0
+    command -v curl >/dev/null || {
+        echo "Dependency check failed: please install 'curl' before installing."
+	pass=1
+    }
+    command -v tar >/dev/null || {
+        echo "Dependency check failed: please install 'tar' before installing."
+        pass=1
+    }
+    return $pass
+}
+
+if ! check_depends; then
+    exit 1
+fi
+
 if ! install_binary; then
     echo "Failed to download and/or extract tiup archive."
     exit 1

--- a/pkg/cluster/template/install/local_install.sh.go
+++ b/pkg/cluster/template/install/local_install.sh.go
@@ -46,11 +46,6 @@ if [ -z "$arch" ]; then
     exit 1
 fi
 
-if [ "$os-$arch" == "darwin-arm64" ]; then
-    echo "Architecture darwin-arm64 not supported." >&2
-    exit 1
-fi
-
 if [ -z "$TIUP_HOME" ]; then
     TIUP_HOME=$HOME/.tiup
 fi
@@ -67,6 +62,19 @@ install_binary() {
   rm -rf $TIUP_HOME/manifests
   return 0
 }
+
+check_depends() {
+    pass=0
+    command -v tar >/dev/null || {
+        echo "Dependency check failed: please install 'tar' before proceeding."
+        pass=1
+    }
+    return $pass
+}
+
+if ! check_depends; then
+    exit 1
+fi
 
 if ! install_binary; then
     echo "Failed to download and/or extract tiup archive."


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1287 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
install.sh: check depends before downloading package
```
