### PR TITLE
cluster: add JSON output option for display

### DIFF
--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -84,6 +84,7 @@ func newDisplayCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&gOpt.ShowUptime, "uptime", false, "Display with uptime")
 	cmd.Flags().BoolVar(&showDashboardOnly, "dashboard", false, "Only display TiDB Dashboard information")
 	cmd.Flags().BoolVar(&showVersionOnly, "version", false, "Only display TiDB cluster version")
+	cmd.Flags().BoolVar(&gOpt.JSON, "json", false, "Output in JSON format when applicable")
 
 	return cmd
 }

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -43,7 +43,9 @@ type Options struct {
 
 	// Show uptime or not
 	ShowUptime bool
-	Operation  Operation
+
+	JSON      bool
+	Operation Operation
 }
 
 // Operation represents the type of cluster operation


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

This adds JSON output for the `tiup cluster display` command. This makes it easier to parse the output and use it in other programs.

https://github.com/pingcap/tiup/issues/1355

### What is changed and how it works?

This puts the info in a struct and uses encoding/json to format this as JSON


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

`tiup cluster display mycluster`
`tiup cluster display --json mycluster`

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Support JSON output for the `tiup cluster display` command
```
