### PR TITLE
cluster: make port check error message more clear to users.

### DIFF
--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -532,7 +532,7 @@ func (s *Specification) portInvalidDetect() error {
 				port := int(compSpec.Field(i).Int())
 				if port <= 0 || port >= 65535 {
 					portField := strings.Split(compSpec.Type().Field(i).Tag.Get("yaml"), ",")[0]
-					return errors.Errorf("`%s` of %s=%d is invalid", cfg, portField, port)
+					return errors.Errorf("`%s` of %s=%d is invalid, port should be in the range [0, 65535]", cfg, portField, port)
 				}
 			}
 		}

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -929,7 +929,7 @@ global:
   ssh_port: 65536
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "`global` of ssh_port=65536 is invalid")
+	c.Assert(err.Error(), Equals, "`global` of ssh_port=65536 is invalid, port should be in the range [0, 65535]")
 
 	err = yaml.Unmarshal([]byte(`
 global:
@@ -939,14 +939,14 @@ tidb_servers:
     port: -1
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "`tidb_servers` of port=-1 is invalid")
+	c.Assert(err.Error(), Equals, "`tidb_servers` of port=-1 is invalid, port should be in the range [0, 65535]")
 
 	err = yaml.Unmarshal([]byte(`
 monitored:
     node_exporter_port: 102400
 `), &topo)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "`monitored` of node_exporter_port=102400 is invalid")
+	c.Assert(err.Error(), Equals, "`monitored` of node_exporter_port=102400 is invalid, port should be in the range [0, 65535]")
 }
 
 func (s *metaSuiteTopo) TestInvalidUserGroup(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

* make error message for port range more clear to users, can help them to solve problems more quickly.

### What is changed and how it works?

* modify port range error message 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->

NONE