### PR TITLE
modify MALLOC_CONF for playground

### DIFF
--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -72,7 +72,7 @@ func (inst *TiKVInstance) Start(ctx context.Context, version utils.Version) erro
 
 	var err error
 	envs := make(map[string]string)
-	envs["MALLOC_CONF"] = "prof:true,prof_active:true,prof.active:false"
+	envs["MALLOC_CONF"] = "prof:true,prof_active:false,prof.active:false"
 	if inst.Process, err = NewComponentProcessWithEnvs(ctx, inst.Dir, inst.BinPath, "tikv", version, envs, args...); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: YangKeao <keao.yang@yahoo.com>

In #1361, I forgot to modify the same environment variable for `playground`. 

As discussed in tikv/tikv#10150, this option has brought some problems like tikv/tikv#10131 and other issues report (on asktug). And it could also cause performance regression or memory leaking (though, it seems not to be measuable).