### PR TITLE
Fix the issue that the global absolute log dir path not generate correctly

### DIFF
--- a/pkg/cluster/spec/parse_topology_test.go
+++ b/pkg/cluster/spec/parse_topology_test.go
@@ -175,7 +175,7 @@ tikv_servers:
 
 		c.Assert(topo.TiKVServers[1].DeployDir, check.Equals, "/home/tidb/my-deploy/tikv-20161")
 		c.Assert(topo.TiKVServers[1].DataDir, check.Equals, "/home/tidb/my-deploy/tikv-20161/data")
-		c.Assert(topo.TiKVServers[1].LogDir, check.Equals, "")
+		c.Assert(topo.TiKVServers[1].LogDir, check.Equals, "/home/tidb/my-deploy/tikv-20161/log")
 	})
 
 	// test global options, case 4
@@ -228,7 +228,7 @@ tiflash_servers:
 
 		c.Assert(topo.TiFlashServers[0].DeployDir, check.Equals, "/home/tidb/deploy/tiflash-9000")
 		c.Assert(topo.TiFlashServers[0].DataDir, check.Equals, "/path/to/my-first-data,/home/tidb/deploy/tiflash-9000/my-second-data")
-		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "")
+		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "/home/tidb/deploy/tiflash-9000/log")
 	})
 
 	// test global options, case 6
@@ -317,7 +317,7 @@ tiflash_servers:
 
 		c.Assert(topo.TiFlashServers[0].DeployDir, check.Equals, "/home/tidb/deploy/tiflash-9000")
 		c.Assert(topo.TiFlashServers[0].DataDir, check.Equals, "/ssd0/tiflash")
-		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "")
+		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "/home/tidb/deploy/tiflash-9000/log")
 	})
 
 	// test tiflash storage section defined data dir
@@ -336,7 +336,7 @@ tiflash_servers:
 
 		c.Assert(topo.TiFlashServers[0].DeployDir, check.Equals, "/home/tidb/deploy/tiflash-9000")
 		c.Assert(topo.TiFlashServers[0].DataDir, check.Equals, "/ssd0/tiflash,/ssd1/tiflash,/ssd2/tiflash")
-		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "")
+		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "/home/tidb/deploy/tiflash-9000/log")
 	})
 
 	// test tiflash storage section defined data dir, "data_dir" will be ignored
@@ -355,7 +355,7 @@ tiflash_servers:
 
 		c.Assert(topo.TiFlashServers[0].DeployDir, check.Equals, "/home/tidb/deploy/tiflash-9000")
 		c.Assert(topo.TiFlashServers[0].DataDir, check.Equals, "/ssd0/tiflash,/ssd1/tiflash,/ssd2/tiflash")
-		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "")
+		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "/home/tidb/deploy/tiflash-9000/log")
 	})
 
 	// test tiflash storage section defined data dir
@@ -377,7 +377,7 @@ tiflash_servers:
 
 		c.Assert(topo.TiFlashServers[0].DeployDir, check.Equals, "/home/tidb/deploy/tiflash-9000")
 		c.Assert(topo.TiFlashServers[0].DataDir, check.Equals, "/ssd0/tiflash,/hdd0/tiflash,/hdd1/tiflash,/hdd2/tiflash,/ssd1/tiflash,/ssd2/tiflash")
-		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "")
+		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "/home/tidb/deploy/tiflash-9000/log")
 	})
 
 	// test if there is only one path in storage.main.dir
@@ -395,7 +395,7 @@ tiflash_servers:
 
 		c.Assert(topo.TiFlashServers[0].DeployDir, check.Equals, "/home/tidb/deploy/tiflash-9000")
 		c.Assert(topo.TiFlashServers[0].DataDir, check.Equals, "/ssd0/tiflash")
-		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "")
+		c.Assert(topo.TiFlashServers[0].LogDir, check.Equals, "/home/tidb/deploy/tiflash-9000/log")
 	})
 
 	// test tiflash storage section defined data dir


### PR DESCRIPTION


Fix https://github.com/pingcap/tiup/issues/1375

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
