### PR TITLE
Don't check labels when user enable placement-rule

### DIFF
--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -692,18 +692,18 @@ func (pc *PDClient) GetReplicateConfig() ([]byte, error) {
 }
 
 // GetLocationLabels gets the replication.location-labels config from pd server
-func (pc *PDClient) GetLocationLabels() ([]string, error) {
+func (pc *PDClient) GetLocationLabels() ([]string, bool, error) {
 	config, err := pc.GetReplicateConfig()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	rc := PDReplicationConfig{}
 	if err := json.Unmarshal(config, &rc); err != nil {
-		return nil, perrs.Annotatef(err, "unmarshal replication config: %s", string(config))
+		return nil, false, perrs.Annotatef(err, "unmarshal replication config: %s", string(config))
 	}
 
-	return rc.LocationLabels, nil
+	return rc.LocationLabels, rc.EnablePlacementRules, nil
 }
 
 // GetTiKVLabels implements TiKVLabelProvider

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -203,10 +203,13 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 	if t, ok := topo.(*spec.Specification); ok {
 		// Check if TiKV's label set correctly
 		pdClient := api.NewPDClient(masterActive, 10*time.Second, tlsCfg)
-		if lbs, err := pdClient.GetLocationLabels(); err != nil {
+
+		if lbs, placementRule, err := pdClient.GetLocationLabels(); err != nil {
 			log.Debugf("get location labels from pd failed: %v", err)
-		} else if err := spec.CheckTiKVLabels(lbs, pdClient); err != nil {
-			color.Yellow("\nWARN: there is something wrong with TiKV labels, which may cause data losing:\n%v", err)
+		} else if !placementRule {
+			if err := spec.CheckTiKVLabels(lbs, pdClient); err != nil {
+				color.Yellow("\nWARN: there is something wrong with TiKV labels, which may cause data losing:\n%v", err)
+			}
 		}
 
 		// Check if there is some instance in tombstone state

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -97,12 +97,14 @@ func (m *Manager) ScaleOut(
 			return err
 		}
 		pdClient := api.NewPDClient(pdList, 10*time.Second, tlsCfg)
-		lbs, err := pdClient.GetLocationLabels()
+		lbs, placementRule, err := pdClient.GetLocationLabels()
 		if err != nil {
 			return err
 		}
-		if err := spec.CheckTiKVLabels(lbs, mergedTopo.(*spec.Specification)); err != nil {
-			return perrs.Errorf("check TiKV label failed, please fix that before continue:\n%s", err)
+		if !placementRule {
+			if err := spec.CheckTiKVLabels(lbs, mergedTopo.(*spec.Specification)); err != nil {
+				return perrs.Errorf("check TiKV label failed, please fix that before continue:\n%s", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
From https://docs.pingcap.com/tidb/stable/configure-placement-rules:

> After enabling Placement Rules, the previously configured max-replicas and location-labels no longer take effect. To adjust the replica policy, use the interface related to Placement Rules.

Fix https://github.com/pingcap/tiup/issues/1371

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
