### PR TITLE
cluster: make two configs in cdc spec editable

### DIFF
--- a/pkg/cluster/spec/cdc.go
+++ b/pkg/cluster/spec/cdc.go
@@ -37,8 +37,8 @@ type CDCSpec struct {
 	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
 	LogDir          string                 `yaml:"log_dir,omitempty"`
 	Offline         bool                   `yaml:"offline,omitempty"`
-	GCTTL           int64                  `yaml:"gc-ttl,omitempty"`
-	TZ              string                 `yaml:"tz,omitempty"`
+	GCTTL           int64                  `yaml:"gc-ttl,omitempty" validate:"gc-ttl:editable"`
+	TZ              string                 `yaml:"tz,omitempty" validate:"tz:editable"`
 	NumaNode        string                 `yaml:"numa_node,omitempty" validate:"numa_node:editable"`
 	Config          map[string]interface{} `yaml:"config,omitempty" validate:"config:ignore"`
 	ResourceControl meta.ResourceControl   `yaml:"resource_control,omitempty" validate:"resource_control:editable"`


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`gc-ttl` and `tz` should be editable in the command line parameters of cdc server

### What is changed and how it works?

add `vaildate:xx:editable` to these two parameters

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release notes:
```release-note
Make `tc-ttl` and `tz` editable in cdc server spec
```
