### PR TITLE
cluster: fix wrong indent in display

### DIFF
--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -119,7 +119,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 
 		// display TLS info
 		if topo.BaseTopo().GlobalOptions.TLSEnabled {
-			fmt.Printf("TLS encryption:  	%s\n", cyan.Sprint("enabled"))
+			fmt.Printf("TLS encryption:     %s\n", cyan.Sprint("enabled"))
 			fmt.Printf("CA certificate:     %s\n", cyan.Sprint(
 				m.specManager.Path(name, spec.TLSCertKeyDir, spec.TLSCACert),
 			))


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The indent of `TLS encryption: enabled` line in display output is incorrect

### What is changed and how it works?
Replace the tab with whitespace

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: fix wrong indent in display for TLS enabled clusters
```
