### PR TITLE
Fix the issue that it may panic when user try to list expired component

### DIFF
--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -450,7 +450,11 @@ func (r *V1Repository) updateComponentManifest(id string, withYanked bool) (*v1m
 
 	if oldVersion != 0 && oldVersion == fileVersion.Version {
 		// We're up to date, load the old manifest from disk.
-		return r.local.LoadComponentManifest(&item, filename)
+		comp, err := r.local.LoadComponentManifest(&item, filename)
+		if comp == nil && err == nil {
+			err = fmt.Errorf("component %s not exist", id)
+		}
+		return comp, err
 	}
 
 	var component v1manifest.Component


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When a user try to list a component that's expired with the command `tiup list <component>`, it may panic if the component manifest has already been downloaded before.

```
tiup list doc
doc
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x4977c1a]

goroutine 1 [running]:
github.com/pingcap/tiup/cmd.showComponentVersions(0xc00011d470, 0x7ffeefbff702, 0x3, 0x0, 0x0, 0x0, 0x44856c0)
        /Users/joshua/Desktop/Code/tiup/cmd/list.go:202 +0x2ba
github.com/pingcap/tiup/cmd.newListCmd.func1(0xc000232500, 0xc00011c1f0, 0x1, 0x1, 0x0, 0x0)
        /Users/joshua/Desktop/Code/tiup/cmd/list.go:63 +0xb7
github.com/spf13/cobra.(*Command).execute(0xc000232500, 0xc00011c1c0, 0x1, 0x1, 0xc000232500, 0xc00011c1c0)
        /Users/joshua/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc000232000, 0xbd7a4b, 0x526ed00, 0xc000541f78)
        /Users/joshua/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/joshua/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
github.com/pingcap/tiup/cmd.Execute()
        /Users/joshua/Desktop/Code/tiup/cmd/root.go:198 +0x67
main.main()
        /Users/joshua/Desktop/Code/tiup/main.go:21 +0x25
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
