### PR TITLE
cluster: fix tikv not upgraded on error increasing schedule limit

### DIFF
--- a/pkg/cluster/operation/upgrade.go
+++ b/pkg/cluster/operation/upgrade.go
@@ -67,19 +67,19 @@ func Upgrade(
 				// the config modifing error should be able to be safely ignored, as it will
 				// be processed with current settings anyway.
 				log.Warnf("failed increasing schedule limit: %s, ignore", err)
-				continue
+			} else {
+				defer func() {
+					upgErr := decreaseScheduleLimit(pdClient, origLeaderScheduleLimit, origRegionScheduleLimit)
+					if upgErr != nil {
+						log.Warnf(
+							"failed decreasing schedule limit (original values should be: %s, %s), please check if their current values are reasonable: %s",
+							fmt.Sprintf("leader-schedule-limit=%d", origLeaderScheduleLimit),
+							fmt.Sprintf("region-schedule-limit=%d", origRegionScheduleLimit),
+							upgErr,
+						)
+					}
+				}()
 			}
-			defer func() {
-				upgErr := decreaseScheduleLimit(pdClient, origLeaderScheduleLimit, origRegionScheduleLimit)
-				if upgErr != nil {
-					log.Warnf(
-						"failed decreasing schedule limit (original values should be: %s, %s), please check if their current values are reasonable: %s",
-						fmt.Sprintf("leader-schedule-limit=%d", origLeaderScheduleLimit),
-						fmt.Sprintf("region-schedule-limit=%d", origRegionScheduleLimit),
-						upgErr,
-					)
-				}
-			}()
 		default:
 			// do nothing, kept for future usage with other components
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The upgrade process of TiKV nodes may be skipped unexpectedly if increasing schedule limit failed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: fix tikv not upgraded on error increasing schedule limit
```
