### PR TITLE
Added tiup cluster template --local

### DIFF
--- a/embed/templates/examples/local.yaml
+++ b/embed/templates/examples/local.yaml
@@ -1,0 +1,32 @@
+# For more information about the format of the tiup cluster topology file, consult
+# https://docs.pingcap.com/tidb/stable/production-deployment-using-tiup#step-3-initialize-cluster-topology-file
+
+# # Global variables are applied to all deployments and used as the default value of
+# # the deployments if a specific deployment value is missing.
+global:
+  # # The OS user who runs the tidb cluster.
+  user: "ubuntu"
+  # # SSH port of servers in the managed cluster.
+  ssh_port: 22
+  # # Storage directory for cluster deployment files, startup scripts, and configuration files.
+  deploy_dir: "/home/ubuntu/.tiup/cluster/tidb-deploy"
+  # # TiDB Cluster data storage directory
+  data_dir: "/home/ubuntu/.tiup/cluster/tidb-data"
+
+pd_servers:
+  - host: 127.0.0.1
+
+tidb_servers:
+  - host: 127.0.0.1
+
+tikv_servers:
+  - host: 127.0.0.1
+
+tiflash_servers:
+  - host: 127.0.0.1
+
+monitoring_servers:
+  - host: 127.0.0.1
+
+grafana_servers:
+  - host: 127.0.0.1


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixes #1403 

### What is changed and how it works?

Adds a new `local.yaml` topology file and `tiup cluster template --local` option to print a template that will deploy a cluster entirely to the local machine.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
I used the template output file to successfully deploy a cluster.

Code changes

n/a

Side effects

n/a

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

https://docs.pingcap.com/tidb/stable/tiup-component-cluster-template should be updated to describe the existence of this new type of template.

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Add a new `--local` option to `tiup cluster template`. This prints a simple topology template that will deploy a very basic cluster, with one instance of each component, to the user's local machine.
```
