### PR TITLE
task: implement parallel concurrency limit

### DIFF
--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -143,6 +143,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip all confirmations and assumes 'yes'")
 	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "(EXPERIMENTAL) Use the native SSH client installed on local system instead of the build-in one.")
 	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "(EXPERIMENTAL) The executor type: 'builtin', 'system', 'none'.")
+	rootCmd.PersistentFlags().IntVarP(&gOpt.Concurrency, "concurrency", "c", 5, "max number of parallel tasks allowed")
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")
 
 	rootCmd.AddCommand(

--- a/components/dm/ansible/import_test.go
+++ b/components/dm/ansible/import_test.go
@@ -142,7 +142,7 @@ func TestImportFromAnsible(t *testing.T) {
 	im, err := NewImporter(dir, "inventory.ini", executor.SSHTypeBuiltin, 0)
 	assert.Nil(err)
 	im.testExecutorGetter = &executorGetter{}
-	clusterName, meta, err := im.ImportFromAnsibleDir(ctxt.New(context.Background()))
+	clusterName, meta, err := im.ImportFromAnsibleDir(ctxt.New(context.Background(), 0))
 	assert.Nil(err, "verbose: %+v", err)
 	assert.Equal("test-cluster", clusterName)
 

--- a/components/dm/command/import.go
+++ b/components/dm/command/import.go
@@ -49,7 +49,7 @@ func newImportCmd() *cobra.Command {
 				return err
 			}
 
-			ctx := ctxt.New(context.Background())
+			ctx := ctxt.New(context.Background(), 0)
 			clusterName, meta, err := importer.ImportFromAnsibleDir(ctx)
 			if err != nil {
 				return err

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -110,6 +110,7 @@ please backup your data before process.`,
 	rootCmd.PersistentFlags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip all confirmations and assumes 'yes'")
 	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "Use the SSH client installed on local system instead of the build-in one.")
 	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "The executor type: 'builtin', 'system', 'none'")
+	rootCmd.PersistentFlags().IntVarP(&gOpt.Concurrency, "concurrency", "c", 5, "max number of parallel tasks allowed")
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")
 
 	rootCmd.AddCommand(

--- a/pkg/cluster/ansible/config.go
+++ b/pkg/cluster/ansible/config.go
@@ -95,7 +95,7 @@ func ImportConfig(name string, clsMeta *spec.ClusterMeta, sshTimeout uint64, ssh
 		Parallel(false, copyFileTasks...).
 		Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), 0)); err != nil {
 		return errors.Trace(err)
 	}
 	log.Infof("Finished copying configs.")

--- a/pkg/cluster/ansible/service.go
+++ b/pkg/cluster/ansible/service.go
@@ -36,7 +36,7 @@ var (
 // parseDirs sets values of directories of component
 func parseDirs(user string, ins spec.InstanceSpec, sshTimeout uint64, sshType executor.SSHType) (spec.InstanceSpec, error) {
 	hostName, sshPort := ins.SSH()
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), 0)
 
 	e, err := executor.New(sshType, false, executor.SSHConfig{
 		Host:    hostName,

--- a/pkg/cluster/executor/local_test.go
+++ b/pkg/cluster/executor/local_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestLocal(t *testing.T) {
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), 0)
 
 	assert := require.New(t)
 	user, err := user.Current()
@@ -72,7 +72,7 @@ func TestWrongIP(t *testing.T) {
 }
 
 func TestLocalExecuteWithQuotes(t *testing.T) {
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), 0)
 
 	assert := require.New(t)
 	user, err := user.Current()

--- a/pkg/cluster/manager/basic.go
+++ b/pkg/cluster/manager/basic.go
@@ -61,7 +61,7 @@ func (m *Manager) EnableCluster(name string, options operator.Options, isEnable 
 
 	t := b.Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), options.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
@@ -106,7 +106,7 @@ func (m *Manager) StartCluster(name string, options operator.Options, fn ...func
 
 	t := b.Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), options.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
@@ -151,7 +151,7 @@ func (m *Manager) StopCluster(name string, options operator.Options, skipConfirm
 		}).
 		Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), options.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
@@ -196,7 +196,7 @@ func (m *Manager) RestartCluster(name string, options operator.Options, skipConf
 		}).
 		Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), options.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err

--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -332,7 +332,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *spec.Specification, gO
 		ParallelStep("+ Cleanup check files", false, cleanTasks...).
 		Build()
 
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), gOpt.Concurrency)
 	if err := t.Execute(ctx); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.

--- a/pkg/cluster/manager/cleanup.go
+++ b/pkg/cluster/manager/cleanup.go
@@ -131,7 +131,7 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 		}).
 		Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), gOpt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err

--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -354,7 +354,7 @@ func (m *Manager) Deploy(
 
 	t := builder.Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), gOpt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err

--- a/pkg/cluster/manager/destroy.go
+++ b/pkg/cluster/manager/destroy.go
@@ -72,7 +72,7 @@ func (m *Manager) DestroyCluster(name string, gOpt operator.Options, destroyOpt 
 		}).
 		Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), gOpt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err
@@ -119,7 +119,7 @@ func (m *Manager) DestroyTombstone(
 
 	b := m.sshTaskBuilder(name, topo, base.User, gOpt)
 
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), gOpt.Concurrency)
 	nodes, err := operator.DestroyTombstone(ctx, cluster, true /* returnNodesOnly */, gOpt, tlsCfg)
 	if err != nil {
 		return err

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -202,7 +202,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 	cliutil.PrintTable(clusterTable, true)
 	fmt.Printf("Total nodes: %d\n", len(clusterTable)-1)
 
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), opt.Concurrency)
 	if t, ok := topo.(*spec.Specification); ok {
 		// Check if TiKV's label set correctly
 		pdClient := api.NewPDClient(masterActive, 10*time.Second, tlsCfg)
@@ -227,7 +227,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 
 // GetClusterTopology get the topology of the cluster.
 func (m *Manager) GetClusterTopology(name string, opt operator.Options) ([]InstInfo, error) {
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), opt.Concurrency)
 	metadata, err := m.meta(name)
 	if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) &&
 		!errors.Is(perrs.Cause(err), spec.ErrNoTiSparkMaster) {

--- a/pkg/cluster/manager/exec.go
+++ b/pkg/cluster/manager/exec.go
@@ -94,7 +94,7 @@ func (m *Manager) Exec(name string, opt ExecOptions, gOpt operator.Options) erro
 		Parallel(false, shellTasks...).
 		Build()
 
-	execCtx := ctxt.New(context.Background())
+	execCtx := ctxt.New(context.Background(), gOpt.Concurrency)
 	if err := t.Execute(execCtx); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.

--- a/pkg/cluster/manager/patch.go
+++ b/pkg/cluster/manager/patch.go
@@ -97,7 +97,7 @@ func (m *Manager) Patch(name string, packagePath string, opt operator.Options, o
 		}).
 		Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), opt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err

--- a/pkg/cluster/manager/reload.go
+++ b/pkg/cluster/manager/reload.go
@@ -113,7 +113,7 @@ func (m *Manager) Reload(name string, opt operator.Options, skipRestart, skipCon
 
 	t := tb.Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), opt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err

--- a/pkg/cluster/manager/scale_in.go
+++ b/pkg/cluster/manager/scale_in.go
@@ -104,7 +104,7 @@ func (m *Manager) ScaleIn(
 		Parallel(force, buildReloadPromTasks(metadata.GetTopology(), nodes...)...).
 		Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), gOpt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -154,7 +154,7 @@ func (m *Manager) ScaleOut(
 		return err
 	}
 
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), gOpt.Concurrency)
 	ctx = context.WithValue(ctx, ctxt.CtxBaseTopo, topo)
 	if err := t.Execute(ctx); err != nil {
 		if errorx.Cast(err) != nil {

--- a/pkg/cluster/manager/transfer.go
+++ b/pkg/cluster/manager/transfer.go
@@ -106,7 +106,7 @@ func (m *Manager) Transfer(name string, opt TransferOptions, gOpt operator.Optio
 		Parallel(false, shellTasks...).
 		Build()
 
-	execCtx := ctxt.New(context.Background())
+	execCtx := ctxt.New(context.Background(), gOpt.Concurrency)
 	if err := t.Execute(execCtx); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.

--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -188,7 +188,7 @@ func (m *Manager) Upgrade(name string, clusterVersion string, opt operator.Optio
 		}).
 		Build()
 
-	if err := t.Execute(ctxt.New(context.Background())); err != nil {
+	if err := t.Execute(ctxt.New(context.Background(), opt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
 			return err

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -32,6 +32,7 @@ type Options struct {
 	IgnoreConfigCheck bool             // should we ignore the config check result after init config
 	NativeSSH         bool             // should use native ssh client or builtin easy ssh (deprecated, shoule use SSHType)
 	SSHType           executor.SSHType // the ssh type: 'builtin', 'system', 'none'
+	Concurrency       int              // max number of parallel tasks to run
 
 	// What type of things should we cleanup in clean command
 	CleanupData bool // should we cleanup data

--- a/pkg/cluster/spec/grafana_test.go
+++ b/pkg/cluster/spec/grafana_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestLocalDashboards(t *testing.T) {
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), 0)
 
 	deployDir, err := os.MkdirTemp("", "tiup-*")
 	assert.Nil(t, err)

--- a/pkg/cluster/task/init_config_test.go
+++ b/pkg/cluster/task/init_config_test.go
@@ -73,7 +73,7 @@ func Test(t *testing.T) { check.TestingT(t) }
 var _ = check.Suite(&initConfigSuite{})
 
 func (s *initConfigSuite) TestCheckConfig(c *check.C) {
-	ctx := ctxt.New(context.Background())
+	ctx := ctxt.New(context.Background(), 0)
 	defer mock.With("FakeExecutor", &fakeExecutor{})()
 
 	t := &InitConfig{

--- a/pkg/cluster/task/tls.go
+++ b/pkg/cluster/task/tls.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tiup/pkg/crypto"
 	"github.com/pingcap/tiup/pkg/file"
 	"github.com/pingcap/tiup/pkg/meta"
+	"github.com/pingcap/tiup/pkg/utils"
 )
 
 // TLSCert generates a certificate for instance
@@ -53,6 +54,11 @@ func (c *TLSCert) Execute(ctx context.Context) error {
 	}
 	cert, err := c.ca.Sign(csr)
 	if err != nil {
+		return err
+	}
+
+	// make sure the cache dir exist
+	if err := utils.CreateDir(c.paths.Cache); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #649 

### What is changed and how it works?
- [x] Add a concurrency threshold in context
- [x] Implement concurrency limiter in `task.Execute` for parallel tasks
- [x] Add a global argument to `tiup-cluster` and `tiup-dm` to let user set the concurrency

The concurrency is default to `5` as set in command line argument, and is the number of CPU threads for `task` if not set.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Related changes

 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
task: implement parallel concurrency limit
```
