### PR TITLE
cluster/executor: fix the issue of native ssh connect refused if port not 22

### DIFF
--- a/pkg/cluster/executor/ssh_test.go
+++ b/pkg/cluster/executor/ssh_test.go
@@ -36,7 +36,7 @@ func TestNativeSSHConfigArgs(t *testing.T) {
 		},
 		{
 			&SSHConfig{
-				Timeout: time.Duration(60 * time.Second),
+				Timeout: 60 * time.Second,
 				Port:    23,
 				KeyFile: "id_rsa",
 			},
@@ -45,7 +45,7 @@ func TestNativeSSHConfigArgs(t *testing.T) {
 		},
 		{
 			&SSHConfig{
-				Timeout: time.Duration(60 * time.Second),
+				Timeout: 60 * time.Second,
 				Port:    23,
 				KeyFile: "id_rsa",
 			},
@@ -54,7 +54,7 @@ func TestNativeSSHConfigArgs(t *testing.T) {
 		},
 		{
 			&SSHConfig{
-				Timeout:    time.Duration(60 * time.Second),
+				Timeout:    60 * time.Second,
 				KeyFile:    "id_rsa",
 				Port:       23,
 				Passphrase: "tidb",
@@ -64,7 +64,7 @@ func TestNativeSSHConfigArgs(t *testing.T) {
 		},
 		{
 			&SSHConfig{
-				Timeout:    time.Duration(60 * time.Second),
+				Timeout:    60 * time.Second,
 				KeyFile:    "id_rsa",
 				Port:       23,
 				Passphrase: "tidb",
@@ -74,7 +74,7 @@ func TestNativeSSHConfigArgs(t *testing.T) {
 		},
 		{
 			&SSHConfig{
-				Timeout:  time.Duration(60 * time.Second),
+				Timeout:  60 * time.Second,
 				Password: "tidb",
 			},
 			true,

--- a/pkg/cluster/executor/ssh_test.go
+++ b/pkg/cluster/executor/ssh_test.go
@@ -1,0 +1,90 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNativeSSHConfigArgs(t *testing.T) {
+	testcases := []struct {
+		c *SSHConfig
+		s bool
+		e string
+	}{
+		{
+			&SSHConfig{
+				KeyFile: "id_rsa",
+			},
+			false,
+			"-i id_rsa",
+		},
+		{
+			&SSHConfig{
+				Timeout: time.Duration(60 * time.Second),
+				Port:    23,
+				KeyFile: "id_rsa",
+			},
+			false,
+			"-p 23 -o ConnectTimeout=60 -i id_rsa",
+		},
+		{
+			&SSHConfig{
+				Timeout: time.Duration(60 * time.Second),
+				Port:    23,
+				KeyFile: "id_rsa",
+			},
+			true,
+			"-P 23 -o ConnectTimeout=60 -i id_rsa",
+		},
+		{
+			&SSHConfig{
+				Timeout:    time.Duration(60 * time.Second),
+				KeyFile:    "id_rsa",
+				Port:       23,
+				Passphrase: "tidb",
+			},
+			false,
+			"sshpass -p tidb -P passphrase -p 23 -o ConnectTimeout=60 -i id_rsa",
+		},
+		{
+			&SSHConfig{
+				Timeout:    time.Duration(60 * time.Second),
+				KeyFile:    "id_rsa",
+				Port:       23,
+				Passphrase: "tidb",
+			},
+			true,
+			"sshpass -p tidb -P passphrase -P 23 -o ConnectTimeout=60 -i id_rsa",
+		},
+		{
+			&SSHConfig{
+				Timeout:  time.Duration(60 * time.Second),
+				Password: "tidb",
+			},
+			true,
+			"sshpass -p tidb -P password -o ConnectTimeout=60",
+		},
+	}
+
+	e := &NativeSSHExecutor{}
+	for _, tc := range testcases {
+		e.Config = tc.c
+		assert.Equal(t, tc.e, strings.Join(e.configArgs([]string{}, tc.s), " "))
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the issue of missing the port in ssh connect args

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
