### PR TITLE
Fix the issue that exec command doesn't handle tiflash nodes

### DIFF
--- a/pkg/cluster/manager/transfer.go
+++ b/pkg/cluster/manager/transfer.go
@@ -129,9 +129,11 @@ func renderInstanceSpec(t string, inst spec.Instance) ([]string, error) {
 			}
 			tfs.DataDir = d
 			key := inst.ID() + d + uuid.New().String()
-			if s, err := renderSpec(t, tfs, key); err == nil {
-				result = append(result, s)
+			s, err := renderSpec(t, inst.(*spec.TiFlashInstance), key)
+			if err != nil {
+				log.Debugf("error rendering tiflash spec: %s", err)
 			}
+			result = append(result, s)
 		}
 	default:
 		s, err := renderSpec(t, inst, inst.ID())


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When execute the command `tiup cluster exec <cluster-name> -R tiflash`, tiup will do nothing because it can't deal with tiflash node correctlly.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
