### PR TITLE
cluster,dm: add support of ssh-proxy

### DIFF
--- a/components/cluster/command/import.go
+++ b/components/cluster/command/import.go
@@ -123,7 +123,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// copy config files form deployment servers
-			if err = ansible.ImportConfig(clsName, clsMeta, gOpt.SSHTimeout, gOpt.OptTimeout, gOpt.SSHType); err != nil {
+			if err = ansible.ImportConfig(clsName, clsMeta, gOpt); err != nil {
 				return err
 			}
 

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -159,6 +159,12 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&gOpt.SSHProxyUsePassword, "ssh-proxy-use-password", false, "Use password to login the proxy host.")
 	rootCmd.PersistentFlags().Uint64Var(&gOpt.SSHProxyTimeout, "ssh-proxy-timeout", 5, "Timeout in seconds to connect the proxy host via SSH, ignored for operations that don't need an SSH connection.")
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-host")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-user")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-port")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-identity-file")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-use-password")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-timeout")
 
 	rootCmd.AddCommand(
 		newCheckCmd(),

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -33,10 +33,10 @@ import (
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/environment"
 	tiupmeta "github.com/pingcap/tiup/pkg/environment"
-	"github.com/pingcap/tiup/pkg/httproxy"
 	"github.com/pingcap/tiup/pkg/localdata"
 	"github.com/pingcap/tiup/pkg/logger"
 	"github.com/pingcap/tiup/pkg/logger/log"
+	"github.com/pingcap/tiup/pkg/proxy"
 	"github.com/pingcap/tiup/pkg/repository"
 	"github.com/pingcap/tiup/pkg/telemetry"
 	"github.com/pingcap/tiup/pkg/tui"
@@ -131,7 +131,7 @@ func init() {
 				fmt.Println("The --native-ssh flag has been deprecated, please use --ssh=system")
 			}
 
-			httpProxy, err = httproxy.MaybeStartHTTPProxy(gOpt)
+			httpProxy, err = proxy.MaybeStartProxy(gOpt)
 			if err != nil {
 				return perrs.Annotate(err, "start http-proxy")
 			}

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -143,6 +144,12 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "(EXPERIMENTAL) Use the native SSH client installed on local system instead of the build-in one.")
 	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "(EXPERIMENTAL) The executor type: 'builtin', 'system', 'none'.")
 	rootCmd.PersistentFlags().IntVarP(&gOpt.Concurrency, "concurrency", "c", 5, "max number of parallel tasks allowed")
+	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyHost, "ssh-proxy-host", "", "The SSH proxy host used to connect to remote host.")
+	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyUser, "ssh-proxy-user", utils.CurrentUser(), "The user name used to login the proxy host.")
+	rootCmd.PersistentFlags().IntVar(&gOpt.SSHProxyPort, "ssh-proxy-port", 22, "The port used to login the proxy host.")
+	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyIdentity, "ssh-proxy-identity-file", path.Join(utils.UserHome(), ".ssh", "id_rsa"), "The identity file used to login the proxy host.")
+	rootCmd.PersistentFlags().BoolVar(&gOpt.SSHProxyUsePassword, "ssh-proxy-use-password", false, "Use password to login the proxy host.")
+	rootCmd.PersistentFlags().Uint64Var(&gOpt.SSHProxyTimeout, "ssh-proxy-timeout", 5, "Timeout in seconds to connect the proxy host via SSH, ignored for operations that don't need an SSH connection.")
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")
 
 	rootCmd.AddCommand(

--- a/components/cluster/command/test.go
+++ b/components/cluster/command/test.go
@@ -22,6 +22,7 @@ import (
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/meta"
+	"github.com/pingcap/tiup/pkg/proxy"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
@@ -55,11 +56,12 @@ func newTestCmd() *cobra.Command {
 				return err
 			}
 
+			tcpProxy := proxy.GetTCPProxy()
 			switch args[1] {
 			case "writable":
-				return writable(metadata.Topology)
+				return writable(metadata.Topology, tcpProxy)
 			case "data":
-				return data(metadata.Topology)
+				return data(metadata.Topology, tcpProxy)
 			default:
 				fmt.Println("unknown command: ", args[1])
 				return cmd.Help()
@@ -70,21 +72,27 @@ func newTestCmd() *cobra.Command {
 	return cmd
 }
 
-func createDB(spec spec.TiDBSpec) (db *sql.DB, err error) {
-	dsn := fmt.Sprintf("root:@tcp(%s:%d)/?charset=utf8mb4,utf8&multiStatements=true", spec.Host, spec.Port)
+func createDB(endpoint string) (db *sql.DB, err error) {
+	dsn := fmt.Sprintf("root:@tcp(%s)/?charset=utf8mb4,utf8&multiStatements=true", endpoint)
 	db, err = sql.Open("mysql", dsn)
 
 	return
 }
 
 // To check if test.ti_cluster has data
-func data(topo *spec.Specification) error {
+func data(topo *spec.Specification, tcpProxy *proxy.TCPProxy) error {
 	errg, _ := errgroup.WithContext(context.Background())
 
 	for _, spec := range topo.TiDBServers {
-		specVal := *spec
+		spec := spec
+		endpoint := fmt.Sprintf("%s:%d", spec.Host, spec.Port)
 		errg.Go(func() error {
-			db, err := createDB(specVal)
+			if tcpProxy != nil {
+				closeC := tcpProxy.Run([]string{endpoint})
+				defer tcpProxy.Close(closeC)
+				endpoint = tcpProxy.GetEndpoints()[0]
+			}
+			db, err := createDB(endpoint)
 			if err != nil {
 				return err
 			}
@@ -99,7 +107,7 @@ func data(topo *spec.Specification) error {
 				return errors.New("table test.ti_cluster is empty")
 			}
 
-			fmt.Printf("check data %s:%d success\n", specVal.Host, specVal.Port)
+			fmt.Printf("check data %s:%d success\n", spec.Host, spec.Port)
 			return nil
 		})
 	}
@@ -107,13 +115,19 @@ func data(topo *spec.Specification) error {
 	return errg.Wait()
 }
 
-func writable(topo *spec.Specification) error {
+func writable(topo *spec.Specification, tcpProxy *proxy.TCPProxy) error {
 	errg, _ := errgroup.WithContext(context.Background())
 
 	for _, spec := range topo.TiDBServers {
-		specVal := *spec
+		spec := spec
+		endpoint := fmt.Sprintf("%s:%d", spec.Host, spec.Port)
 		errg.Go(func() error {
-			db, err := createDB(specVal)
+			if tcpProxy != nil {
+				closeC := tcpProxy.Run([]string{endpoint})
+				defer tcpProxy.Close(closeC)
+				endpoint = tcpProxy.GetEndpoints()[0]
+			}
+			db, err := createDB(endpoint)
 			if err != nil {
 				return err
 			}
@@ -128,7 +142,7 @@ func writable(topo *spec.Specification) error {
 				return err
 			}
 
-			fmt.Printf("write %s:%d success\n", specVal.Host, specVal.Port)
+			fmt.Printf("write %s:%d success\n", spec.Host, spec.Port)
 			return nil
 		})
 	}

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -126,6 +126,12 @@ please backup your data before process.`,
 	rootCmd.PersistentFlags().BoolVar(&gOpt.SSHProxyUsePassword, "ssh-proxy-use-password", false, "Use password to login the proxy host.")
 	rootCmd.PersistentFlags().Uint64Var(&gOpt.SSHProxyTimeout, "ssh-proxy-timeout", 5, "Timeout in seconds to connect the proxy host via SSH, ignored for operations that don't need an SSH connection.")
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-host")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-user")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-port")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-identity-file")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-use-password")
+	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-timeout")
 
 	rootCmd.AddCommand(
 		newDeployCmd(),

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -30,9 +30,9 @@ import (
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	cspec "github.com/pingcap/tiup/pkg/cluster/spec"
 	tiupmeta "github.com/pingcap/tiup/pkg/environment"
-	"github.com/pingcap/tiup/pkg/httproxy"
 	"github.com/pingcap/tiup/pkg/localdata"
 	"github.com/pingcap/tiup/pkg/logger"
+	"github.com/pingcap/tiup/pkg/proxy"
 	"github.com/pingcap/tiup/pkg/repository"
 	"github.com/pingcap/tiup/pkg/tui"
 	"github.com/pingcap/tiup/pkg/utils"
@@ -101,7 +101,7 @@ please backup your data before process.`,
 				fmt.Println("The --native-ssh flag has been deprecated, please use --ssh=system")
 			}
 
-			httpProxy, err = httproxy.MaybeStartHTTPProxy(gOpt)
+			httpProxy, err = proxy.MaybeStartProxy(gOpt)
 			if err != nil {
 				return perrs.Annotate(err, "start http-proxy")
 			}

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -14,18 +14,23 @@
 package command
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
+	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/components/dm/spec"
 	"github.com/pingcap/tiup/pkg/cluster/executor"
 	"github.com/pingcap/tiup/pkg/cluster/manager"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	cspec "github.com/pingcap/tiup/pkg/cluster/spec"
 	tiupmeta "github.com/pingcap/tiup/pkg/environment"
+	"github.com/pingcap/tiup/pkg/httproxy"
 	"github.com/pingcap/tiup/pkg/localdata"
 	"github.com/pingcap/tiup/pkg/logger"
 	"github.com/pingcap/tiup/pkg/repository"
@@ -42,6 +47,7 @@ var (
 	rootCmd     *cobra.Command
 	gOpt        operator.Options
 	skipConfirm bool
+	httpProxy   *http.Server
 )
 
 var dmspec *cspec.SpecManager
@@ -95,9 +101,18 @@ please backup your data before process.`,
 				fmt.Println("The --native-ssh flag has been deprecated, please use --ssh=system")
 			}
 
+			httpProxy, err = httproxy.MaybeStartHTTPProxy(gOpt)
+			if err != nil {
+				return perrs.Annotate(err, "start http-proxy")
+			}
+
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			if httpProxy != nil {
+				httpProxy.Shutdown(context.Background())
+				os.Unsetenv("TIUP_INNER_HTTP_PROXY")
+			}
 			return tiupmeta.GlobalEnv().V1Repository().Mirror().Close()
 		},
 	}
@@ -110,6 +125,12 @@ please backup your data before process.`,
 	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "Use the SSH client installed on local system instead of the build-in one.")
 	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "The executor type: 'builtin', 'system', 'none'")
 	rootCmd.PersistentFlags().IntVarP(&gOpt.Concurrency, "concurrency", "c", 5, "max number of parallel tasks allowed")
+	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyHost, "ssh-proxy-host", "", "The SSH proxy host used to connect to remote host.")
+	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyUser, "ssh-proxy-user", utils.CurrentUser(), "The user name used to login the proxy host.")
+	rootCmd.PersistentFlags().IntVar(&gOpt.SSHProxyPort, "ssh-proxy-port", 22, "The port used to login the proxy host.")
+	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyIdentity, "ssh-proxy-identity-file", path.Join(utils.UserHome(), ".ssh", "id_rsa"), "The identity file used to login the proxy host.")
+	rootCmd.PersistentFlags().BoolVar(&gOpt.SSHProxyUsePassword, "ssh-proxy-use-password", false, "Use password to login the proxy host.")
+	rootCmd.PersistentFlags().Uint64Var(&gOpt.SSHProxyTimeout, "ssh-proxy-timeout", 5, "Timeout in seconds to connect the proxy host via SSH, ignored for operations that don't need an SSH connection.")
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")
 
 	rootCmd.AddCommand(

--- a/docker/docker-compose.yml.tpl
+++ b/docker/docker-compose.yml.tpl
@@ -29,8 +29,32 @@ services:
       tiops:
         ipv4_address: {{ipprefix}}.{{id+100}}
 {% endfor %}
+{% if ssh_proxy %}
+  bastion:
+    <<: *default-node
+    container_name: tiup-cluster-bastion
+    hostname: bastion
+    networks:
+      tiops:
+        ipv4_address: {{ipprefix}}.250
+      tiproxy:
+        ipv4_address: {{proxy_prefix}}.250
 
-# docker network create --gateway {{ipprefix}}.1 --subnet {{ipprefix}}.0/24 tiup-cluster
+{% for id in range(1, nodes+1) %}
+  p{{id}}:
+    <<: *default-node
+    container_name: tiup-cluster-p{{id}}
+    hostname: p{{id}}
+    networks:
+      tiproxy:
+        ipv4_address: {{proxy_prefix}}.{{id+100}}
+{% endfor %}
+{% endif %}
+
 networks:
   tiops:
     external: true
+{% if ssh_proxy %}
+  tiproxy:
+    external: true
+{% endif %}

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -54,7 +54,8 @@ do
             ;;
         --dev)
             if [ ! "$TIUP_CLUSTER_ROOT" ]; then
-                export TIUP_CLUSTER_ROOT="$(cd ../ && pwd)"
+                TIUP_CLUSTER_ROOT="$(cd ../ && pwd)"
+                export TIUP_CLUSTER_ROOT
                 INFO "TIUP_CLUSTER_ROOT is not set, defaulting to: $TIUP_CLUSTER_ROOT"
             fi
             INFO "Running docker-compose with dev config"
@@ -144,14 +145,14 @@ if [ -z "${DEV}" ]; then
     )
 else
     INFO "Build tiup-cluster in $TIUP_CLUSTER_ROOT"
-    (cd $TIUP_CLUSTER_ROOT;make failpoint-enable;GOOS=linux GOARCH=amd64 make cluster dm;make failpoint-disable)
+    (cd "${TIUP_CLUSTER_ROOT}";make failpoint-enable;GOOS=linux GOARCH=amd64 make cluster dm;make failpoint-disable)
 fi
 
 if [ "${INIT_ONLY}" -eq 1 ]; then
     exit 0
 fi
 
-if [ ${SUBNET##*/} -ne 24 ]; then
+if [ "${SUBNET##*/}" -ne 24 ]; then
     ERROR "Only subnet mask of 24 bits are currently supported"
     exit 1
 fi
@@ -185,7 +186,7 @@ if [[ "$exist_network" == "" ]]; then
 else
     echo "Skip create tiup-cluster network"
     SUBNET=$(docker network inspect -f "{{range .IPAM.Config}}{{.Subnet}}{{end}}" tiops)
-    if [ ${SUBNET##*/} -ne 24 ]; then
+    if [ "${SUBNET##*/}" -ne 24 ]; then
         ERROR "Only subnet mask of 24 bits are currently supported"
         exit 1
     fi

--- a/pkg/cluster/api/binlog.go
+++ b/pkg/cluster/api/binlog.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/utils"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
@@ -45,12 +46,8 @@ func NewBinlogClient(pdEndpoints []string, tlsConfig *tls.Config) (*BinlogClient
 	}
 
 	return &BinlogClient{
-		tls: tlsConfig,
-		httpClient: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-			},
-		},
+		tls:        tlsConfig,
+		httpClient: utils.NewHTTPClient(5*time.Second, tlsConfig).Client(),
 		etcdClient: etcdClient,
 	}, nil
 }

--- a/pkg/cluster/api/binlog.go
+++ b/pkg/cluster/api/binlog.go
@@ -34,9 +34,9 @@ type BinlogClient struct {
 }
 
 // NewBinlogClient create a BinlogClient.
-func NewBinlogClient(pdEndpoint []string, tlsConfig *tls.Config) (*BinlogClient, error) {
+func NewBinlogClient(pdEndpoints []string, tlsConfig *tls.Config) (*BinlogClient, error) {
 	etcdClient, err := clientv3.New(clientv3.Config{
-		Endpoints:   pdEndpoint,
+		Endpoints:   pdEndpoints,
 		DialTimeout: time.Second * 5,
 		TLS:         tlsConfig,
 	})

--- a/pkg/cluster/executor/ssh_test.go
+++ b/pkg/cluster/executor/ssh_test.go
@@ -82,7 +82,7 @@ func TestNativeSSHConfigArgs(t *testing.T) {
 		},
 		{
 			&SSHConfig{
-				Timeout: time.Duration(60 * time.Second),
+				Timeout: 60 * time.Second,
 				KeyFile: "id_rsa",
 				Proxy: &SSHConfig{
 					User:    "root",
@@ -96,7 +96,7 @@ func TestNativeSSHConfigArgs(t *testing.T) {
 		},
 		{
 			&SSHConfig{
-				Timeout: time.Duration(60 * time.Second),
+				Timeout: 60 * time.Second,
 				Port:    1203,
 				KeyFile: "id_rsa",
 				Proxy: &SSHConfig{
@@ -104,7 +104,7 @@ func TestNativeSSHConfigArgs(t *testing.T) {
 					Host:    "proxy1",
 					Port:    222,
 					KeyFile: "b.id_rsa",
-					Timeout: time.Duration(10 * time.Second),
+					Timeout: 10 * time.Second,
 				},
 			},
 			false,
@@ -112,14 +112,14 @@ func TestNativeSSHConfigArgs(t *testing.T) {
 		},
 		{
 			&SSHConfig{
-				Timeout:  time.Duration(60 * time.Second),
+				Timeout:  60 * time.Second,
 				Password: "pass",
 				Proxy: &SSHConfig{
 					User:     "root",
 					Host:     "proxy1",
 					Port:     222,
 					Password: "word",
-					Timeout:  time.Duration(10 * time.Second),
+					Timeout:  10 * time.Second,
 				},
 			},
 			false,

--- a/pkg/cluster/manager/builder.go
+++ b/pkg/cluster/manager/builder.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pingcap/tiup/pkg/cluster/executor"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/cluster/task"
@@ -174,8 +173,6 @@ func buildScaleOutTask(
 				base.User,
 				gOpt.SSHTimeout,
 				gOpt.OptTimeout,
-				gOpt.SSHType,
-				topo.BaseTopo().GlobalOptions.SSHType,
 				gOpt.SSHProxyHost,
 				gOpt.SSHProxyPort,
 				gOpt.SSHProxyUser,
@@ -499,7 +496,6 @@ func buildRefreshMonitoredConfigTasks(
 	globalOptions spec.GlobalOptions,
 	monitoredOptions *spec.MonitoredOptions,
 	sshTimeout, exeTimeout uint64,
-	sshType executor.SSHType,
 	gOpt operator.Options,
 	p *tui.SSHConnectionProps,
 ) []*task.StepDisplay {
@@ -528,7 +524,6 @@ func buildRefreshMonitoredConfigTasks(
 					globalOptions.User,
 					sshTimeout,
 					exeTimeout,
-					sshType,
 					gOpt.SSHProxyHost,
 					gOpt.SSHProxyPort,
 					gOpt.SSHProxyUser,

--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -105,7 +105,7 @@ func (m *Manager) CheckCluster(clusterOrTopoName string, opt CheckOptions, gOpt 
 		}
 	}
 
-	if err := m.fillHostArch(sshConnProps, &topo, &gOpt, opt.User); err != nil {
+	if err := m.fillHostArch(sshConnProps, sshProxyProps, &topo, &gOpt, opt.User); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -89,11 +89,19 @@ func (m *Manager) CheckCluster(clusterOrTopoName string, opt CheckOptions, gOpt 
 		}
 	}
 
-	var sshConnProps *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
+	var (
+		sshConnProps  *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
+		sshProxyProps *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
+	)
 	if gOpt.SSHType != executor.SSHTypeNone {
 		var err error
 		if sshConnProps, err = tui.ReadIdentityFileOrPassword(opt.IdentityFile, opt.UsePassword); err != nil {
 			return err
+		}
+		if len(gOpt.SSHProxyHost) != 0 {
+			if sshProxyProps, err = tui.ReadIdentityFileOrPassword(gOpt.SSHProxyIdentity, gOpt.SSHProxyUsePassword); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -101,7 +109,7 @@ func (m *Manager) CheckCluster(clusterOrTopoName string, opt CheckOptions, gOpt 
 		return err
 	}
 
-	if err := checkSystemInfo(sshConnProps, &topo, &gOpt, &opt); err != nil {
+	if err := checkSystemInfo(sshConnProps, sshProxyProps, &topo, &gOpt, &opt); err != nil {
 		return err
 	}
 
@@ -115,7 +123,7 @@ func (m *Manager) CheckCluster(clusterOrTopoName string, opt CheckOptions, gOpt 
 }
 
 // checkSystemInfo performs series of checks and tests of the deploy server
-func checkSystemInfo(s *tui.SSHConnectionProps, topo *spec.Specification, gOpt *operator.Options, opt *CheckOptions) error {
+func checkSystemInfo(s, p *tui.SSHConnectionProps, topo *spec.Specification, gOpt *operator.Options, opt *CheckOptions) error {
 	var (
 		collectTasks  []*task.StepDisplay
 		checkSysTasks []*task.StepDisplay
@@ -203,6 +211,13 @@ func checkSystemInfo(s *tui.SSHConnectionProps, topo *spec.Specification, gOpt *
 						s.IdentityFilePassphrase,
 						gOpt.SSHTimeout,
 						gOpt.OptTimeout,
+						gOpt.SSHProxyHost,
+						gOpt.SSHProxyPort,
+						gOpt.SSHProxyUser,
+						p.Password,
+						p.IdentityFile,
+						p.IdentityFilePassphrase,
+						gOpt.SSHProxyTimeout,
 						gOpt.SSHType,
 						topo.GlobalOptions.SSHType,
 					).
@@ -317,6 +332,13 @@ func checkSystemInfo(s *tui.SSHConnectionProps, topo *spec.Specification, gOpt *
 					s.IdentityFilePassphrase,
 					gOpt.SSHTimeout,
 					gOpt.OptTimeout,
+					gOpt.SSHProxyHost,
+					gOpt.SSHProxyPort,
+					gOpt.SSHProxyUser,
+					p.Password,
+					p.IdentityFile,
+					p.IdentityFilePassphrase,
+					gOpt.SSHProxyTimeout,
 					gOpt.SSHType,
 					topo.GlobalOptions.SSHType,
 				).
@@ -359,6 +381,13 @@ func checkSystemInfo(s *tui.SSHConnectionProps, topo *spec.Specification, gOpt *
 				s.IdentityFilePassphrase,
 				gOpt.SSHTimeout,
 				gOpt.OptTimeout,
+				gOpt.SSHProxyHost,
+				gOpt.SSHProxyPort,
+				gOpt.SSHProxyUser,
+				p.Password,
+				p.IdentityFile,
+				p.IdentityFilePassphrase,
+				gOpt.SSHProxyTimeout,
 				gOpt.SSHType,
 				topo.GlobalOptions.SSHType,
 			)

--- a/pkg/cluster/manager/cleanup.go
+++ b/pkg/cluster/manager/cleanup.go
@@ -122,7 +122,11 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 		log.Infof("Cleanup cluster...")
 	}
 
-	t := m.sshTaskBuilder(name, topo, base.User, gOpt).
+	b, err := m.sshTaskBuilder(name, topo, base.User, gOpt)
+	if err != nil {
+		return err
+	}
+	t := b.
 		Func("StopCluster", func(ctx context.Context) error {
 			return operator.Stop(ctx, topo, operator.Options{}, tlsCfg)
 		}).

--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -137,11 +137,19 @@ func (m *Manager) Deploy(
 		return err
 	}
 
-	var sshConnProps *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
+	var (
+		sshConnProps  *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
+		sshProxyProps *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
+	)
 	if gOpt.SSHType != executor.SSHTypeNone {
 		var err error
 		if sshConnProps, err = tui.ReadIdentityFileOrPassword(opt.IdentityFile, opt.UsePassword); err != nil {
 			return err
+		}
+		if len(gOpt.SSHProxyHost) != 0 {
+			if sshProxyProps, err = tui.ReadIdentityFileOrPassword(gOpt.SSHProxyIdentity, gOpt.SSHProxyUsePassword); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -230,6 +238,13 @@ func (m *Manager) Deploy(
 					sshConnProps.IdentityFilePassphrase,
 					gOpt.SSHTimeout,
 					gOpt.OptTimeout,
+					gOpt.SSHProxyHost,
+					gOpt.SSHProxyPort,
+					gOpt.SSHProxyUser,
+					sshProxyProps.Password,
+					sshProxyProps.IdentityFile,
+					sshProxyProps.IdentityFilePassphrase,
+					gOpt.SSHProxyTimeout,
 					gOpt.SSHType,
 					globalOptions.SSHType,
 				).
@@ -273,6 +288,13 @@ func (m *Manager) Deploy(
 				globalOptions.User,
 				gOpt.SSHTimeout,
 				gOpt.OptTimeout,
+				gOpt.SSHProxyHost,
+				gOpt.SSHProxyPort,
+				gOpt.SSHProxyUser,
+				sshProxyProps.Password,
+				sshProxyProps.IdentityFile,
+				sshProxyProps.IdentityFilePassphrase,
+				gOpt.SSHProxyTimeout,
 				gOpt.SSHType,
 				globalOptions.SSHType,
 			).
@@ -355,6 +377,7 @@ func (m *Manager) Deploy(
 		topo.GetMonitoredOptions(),
 		clusterVersion,
 		gOpt,
+		sshProxyProps,
 	)
 	if err != nil {
 		return err

--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -153,7 +153,7 @@ func (m *Manager) Deploy(
 		}
 	}
 
-	if err := m.fillHostArch(sshConnProps, topo, &gOpt, opt.User); err != nil {
+	if err := m.fillHostArch(sshConnProps, sshProxyProps, topo, &gOpt, opt.User); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/manager/destroy.go
+++ b/pkg/cluster/manager/destroy.go
@@ -63,7 +63,11 @@ func (m *Manager) DestroyCluster(name string, gOpt operator.Options, destroyOpt 
 		log.Infof("Destroying cluster...")
 	}
 
-	t := m.sshTaskBuilder(name, topo, base.User, gOpt).
+	b, err := m.sshTaskBuilder(name, topo, base.User, gOpt)
+	if err != nil {
+		return err
+	}
+	t := b.
 		Func("StopCluster", func(ctx context.Context) error {
 			return operator.Stop(ctx, topo, operator.Options{Force: destroyOpt.Force}, tlsCfg)
 		}).
@@ -117,7 +121,10 @@ func (m *Manager) DestroyTombstone(
 		return err
 	}
 
-	b := m.sshTaskBuilder(name, topo, base.User, gOpt)
+	b, err := m.sshTaskBuilder(name, topo, base.User, gOpt)
+	if err != nil {
+		return err
+	}
 
 	ctx := ctxt.New(context.Background(), gOpt.Concurrency)
 	nodes, err := operator.DestroyTombstone(ctx, cluster, true /* returnNodesOnly */, gOpt, tlsCfg)

--- a/pkg/cluster/manager/exec.go
+++ b/pkg/cluster/manager/exec.go
@@ -90,7 +90,12 @@ func (m *Manager) Exec(name string, opt ExecOptions, gOpt operator.Options) erro
 		}
 	}
 
-	t := m.sshTaskBuilder(name, topo, base.User, gOpt).
+	b, err := m.sshTaskBuilder(name, topo, base.User, gOpt)
+	if err != nil {
+		return err
+	}
+
+	t := b.
 		Parallel(false, shellTasks...).
 		Build()
 

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -143,7 +143,8 @@ func (m *Manager) sshTaskBuilder(name string, topo spec.Topology, user string, o
 		)
 }
 
-func (m *Manager) fillHostArch(s *tui.SSHConnectionProps, topo spec.Topology, gOpt *operator.Options, user string) error {
+func (m *Manager) fillHostArch(s, p *tui.SSHConnectionProps, topo spec.Topology, gOpt *operator.Options, user string) error {
+	globalSSHType := topo.BaseTopo().GlobalOptions.SSHType
 	hostArch := map[string]string{}
 	var detectTasks []*task.StepDisplay
 	topo.IterInstance(func(inst spec.Instance) {
@@ -165,8 +166,15 @@ func (m *Manager) fillHostArch(s *tui.SSHConnectionProps, topo spec.Topology, gO
 				s.IdentityFilePassphrase,
 				gOpt.SSHTimeout,
 				gOpt.OptTimeout,
+				gOpt.SSHProxyHost,
+				gOpt.SSHProxyPort,
+				gOpt.SSHProxyUser,
+				p.Password,
+				p.IdentityFile,
+				p.IdentityFilePassphrase,
+				gOpt.SSHProxyTimeout,
 				gOpt.SSHType,
-				topo.BaseTopo().GlobalOptions.SSHType,
+				globalSSHType,
 			).
 			Shell(inst.GetHost(), "uname -m", "", false).
 			BuildAsStep(fmt.Sprintf("  - Detecting node %s", inst.GetHost()))

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -129,7 +129,6 @@ You may read the OpenJDK doc for a reference: https://openjdk.java.net/install/
 }
 
 func (m *Manager) sshTaskBuilder(name string, topo spec.Topology, user string, gOpt operator.Options) (*task.Builder, error) {
-
 	var p *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
 	if gOpt.SSHType != executor.SSHTypeNone && len(gOpt.SSHProxyHost) != 0 {
 		var err error

--- a/pkg/cluster/manager/patch.go
+++ b/pkg/cluster/manager/patch.go
@@ -87,8 +87,11 @@ func (m *Manager) Patch(name string, packagePath string, opt operator.Options, o
 	if err != nil {
 		return err
 	}
-	t := m.sshTaskBuilder(name, topo, base.User, opt).
-		Parallel(false, replacePackageTasks...).
+	b, err := m.sshTaskBuilder(name, topo, base.User, opt)
+	if err != nil {
+		return err
+	}
+	t := b.Parallel(false, replacePackageTasks...).
 		Func("UpgradeCluster", func(ctx context.Context) error {
 			if offline {
 				return nil

--- a/pkg/cluster/manager/reload.go
+++ b/pkg/cluster/manager/reload.go
@@ -36,8 +36,8 @@ func (m *Manager) Reload(name string, gOpt operator.Options, skipRestart, skipCo
 		return err
 	}
 
-	sshTimeout := opt.SSHTimeout
-	exeTimeout := opt.OptTimeout
+	sshTimeout := gOpt.SSHTimeout
+	exeTimeout := gOpt.OptTimeout
 
 	metadata, err := m.meta(name)
 	if err != nil {

--- a/pkg/cluster/manager/scale_in.go
+++ b/pkg/cluster/manager/scale_in.go
@@ -95,7 +95,10 @@ func (m *Manager) ScaleIn(
 		return err
 	}
 
-	b := m.sshTaskBuilder(name, topo, base.User, gOpt)
+	b, err := m.sshTaskBuilder(name, topo, base.User, gOpt)
+	if err != nil {
+		return err
+	}
 
 	scale(b, metadata, tlsCfg)
 

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -100,7 +100,7 @@ func (m *Manager) ScaleOut(
 		}
 	}
 
-	if err := m.fillHostArch(sshConnProps, newPart, &gOpt, opt.User); err != nil {
+	if err := m.fillHostArch(sshConnProps, sshProxyProps, newPart, &gOpt, opt.User); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -84,11 +84,19 @@ func (m *Manager) ScaleOut(
 		return err
 	}
 
-	var sshConnProps *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
+	var (
+		sshConnProps  *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
+		sshProxyProps *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
+	)
 	if gOpt.SSHType != executor.SSHTypeNone {
 		var err error
 		if sshConnProps, err = tui.ReadIdentityFileOrPassword(opt.IdentityFile, opt.UsePassword); err != nil {
 			return err
+		}
+		if len(gOpt.SSHProxyHost) != 0 {
+			if sshProxyProps, err = tui.ReadIdentityFileOrPassword(gOpt.SSHProxyIdentity, gOpt.SSHProxyUsePassword); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -152,7 +160,7 @@ func (m *Manager) ScaleOut(
 
 	// Build the scale out tasks
 	t, err := buildScaleOutTask(
-		m, name, metadata, mergedTopo, opt, sshConnProps, newPart,
+		m, name, metadata, mergedTopo, opt, sshConnProps, sshProxyProps, newPart,
 		patchedComponents, gOpt, afterDeploy, final)
 	if err != nil {
 		return err

--- a/pkg/cluster/manager/transfer.go
+++ b/pkg/cluster/manager/transfer.go
@@ -102,7 +102,12 @@ func (m *Manager) Transfer(name string, opt TransferOptions, gOpt operator.Optio
 		}
 	}
 
-	t := m.sshTaskBuilder(name, topo, base.User, gOpt).
+	b, err := m.sshTaskBuilder(name, topo, base.User, gOpt)
+	if err != nil {
+		return err
+	}
+
+	t := b.
 		Parallel(false, shellTasks...).
 		Build()
 

--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -177,7 +177,11 @@ func (m *Manager) Upgrade(name string, clusterVersion string, opt operator.Optio
 	if err != nil {
 		return err
 	}
-	t := m.sshTaskBuilder(name, topo, base.User, opt).
+	b, err := m.sshTaskBuilder(name, topo, base.User, opt)
+	if err != nil {
+		return err
+	}
+	t := b.
 		Parallel(false, downloadCompTasks...).
 		Parallel(opt.Force, copyCompTasks...).
 		Func("UpgradeCluster", func(ctx context.Context) error {

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -23,16 +23,22 @@ import (
 
 // Options represents the operation options
 type Options struct {
-	Roles             []string
-	Nodes             []string
-	Force             bool             // Option for upgrade subcommand
-	SSHTimeout        uint64           // timeout in seconds when connecting an SSH server
-	OptTimeout        uint64           // timeout in seconds for operations that support it, not to confuse with SSH timeout
-	APITimeout        uint64           // timeout in seconds for API operations that support it, like transferring store leader
-	IgnoreConfigCheck bool             // should we ignore the config check result after init config
-	NativeSSH         bool             // should use native ssh client or builtin easy ssh (deprecated, shoule use SSHType)
-	SSHType           executor.SSHType // the ssh type: 'builtin', 'system', 'none'
-	Concurrency       int              // max number of parallel tasks to run
+	Roles               []string
+	Nodes               []string
+	Force               bool             // Option for upgrade subcommand
+	SSHTimeout          uint64           // timeout in seconds when connecting an SSH server
+	OptTimeout          uint64           // timeout in seconds for operations that support it, not to confuse with SSH timeout
+	APITimeout          uint64           // timeout in seconds for API operations that support it, like transferring store leader
+	IgnoreConfigCheck   bool             // should we ignore the config check result after init config
+	NativeSSH           bool             // should use native ssh client or builtin easy ssh (deprecated, shoule use SSHType)
+	SSHType             executor.SSHType // the ssh type: 'builtin', 'system', 'none'
+	Concurrency         int              // max number of parallel tasks to run
+	SSHProxyHost        string           // the ssh proxy host
+	SSHProxyPort        int              // the ssh proxy port
+	SSHProxyUser        string           // the ssh proxy user
+	SSHProxyIdentity    string           // the ssh proxy identity file
+	SSHProxyUsePassword bool             // use password instead of identity file for ssh proxy connection
+	SSHProxyTimeout     uint64           // timeout in seconds when connecting the proxy host
 
 	// What type of things should we cleanup in clean command
 	CleanupData bool // should we cleanup data

--- a/pkg/cluster/spec/tikv.go
+++ b/pkg/cluster/spec/tikv.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -429,6 +430,17 @@ func makeTransport(tlsCfg *tls.Config) *http.Transport {
 	// We should clone a tlsCfg because we use it across goroutine
 	if tlsCfg != nil {
 		transport.TLSClientConfig = tlsCfg.Clone()
+	}
+
+	// prefer to use the inner http proxy
+	httpProxy := os.Getenv("TIUP_INNER_HTTP_PROXY")
+	if len(httpProxy) == 0 {
+		httpProxy = os.Getenv("HTTP_PROXY")
+	}
+	if len(httpProxy) > 0 {
+		if proxyURL, err := url.Parse(httpProxy); err == nil {
+			transport.Proxy = http.ProxyURL(proxyURL)
+		}
 	}
 	return transport
 }

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -103,23 +103,33 @@ func (b *Builder) Func(name string, fn func(ctx context.Context) error) *Builder
 }
 
 // ClusterSSH init all UserSSH need for the cluster.
-func (b *Builder) ClusterSSH(spec spec.Topology, deployUser string, sshTimeout, exeTimeout uint64, sshType, defaultSSHType executor.SSHType) *Builder {
+func (b *Builder) ClusterSSH(
+	topo spec.Topology,
+	deployUser string, sshTimeout, exeTimeout uint64,
+	proxyHost string, proxyPort int, proxyUser, proxyPassword, proxyKeyFile, proxyPassphrase string, proxySshTimeout uint64,
+	sshType, defaultSSHType executor.SSHType,
+) *Builder {
 	if sshType == "" {
 		sshType = defaultSSHType
 	}
 	var tasks []Task
-	for _, com := range spec.ComponentsByStartOrder() {
-		for _, in := range com.Instances() {
-			tasks = append(tasks, &UserSSH{
-				host:       in.GetHost(),
-				port:       in.GetSSHPort(),
-				deployUser: deployUser,
-				timeout:    sshTimeout,
-				exeTimeout: exeTimeout,
-				sshType:    sshType,
-			})
-		}
-	}
+	topo.IterInstance(func(inst spec.Instance) {
+		tasks = append(tasks, &UserSSH{
+			host:            inst.GetHost(),
+			port:            inst.GetSSHPort(),
+			deployUser:      deployUser,
+			timeout:         sshTimeout,
+			exeTimeout:      exeTimeout,
+			proxyHost:       proxyHost,
+			proxyPort:       proxyPort,
+			proxyUser:       proxyUser,
+			proxyPassword:   proxyPassword,
+			proxyKeyFile:    proxyKeyFile,
+			proxyPassphrase: proxyPassphrase,
+			proxyTimeout:    proxySshTimeout,
+			sshType:         sshType,
+		})
+	})
 
 	b.tasks = append(b.tasks, &Parallel{inner: tasks})
 

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -38,50 +38,57 @@ func NewBuilder() *Builder {
 
 // RootSSH appends a RootSSH task to the current task collection
 func (b *Builder) RootSSH(
-	host string,
-	port int,
-	user, password, keyFile, passphrase string,
-	sshTimeout uint64,
-	exeTimeout uint64,
-	sshType executor.SSHType,
-	defaultSSHType executor.SSHType,
+	host string, port int, user, password, keyFile, passphrase string, sshTimeout, exeTimeout uint64,
+	proxyHost string, proxyPort int, proxyUser, proxyPassword, proxyKeyFile, proxyPassphrase string, proxySshTimeout uint64,
+	sshType, defaultSSHType executor.SSHType,
 ) *Builder {
 	if sshType == "" {
 		sshType = defaultSSHType
 	}
 	b.tasks = append(b.tasks, &RootSSH{
-		host:       host,
-		port:       port,
-		user:       user,
-		password:   password,
-		keyFile:    keyFile,
-		passphrase: passphrase,
-		timeout:    sshTimeout,
-		exeTimeout: exeTimeout,
-		sshType:    sshType,
+		host:            host,
+		port:            port,
+		user:            user,
+		password:        password,
+		keyFile:         keyFile,
+		passphrase:      passphrase,
+		timeout:         sshTimeout,
+		exeTimeout:      exeTimeout,
+		proxyHost:       proxyHost,
+		proxyPort:       proxyPort,
+		proxyUser:       proxyUser,
+		proxyPassword:   proxyPassword,
+		proxyKeyFile:    proxyKeyFile,
+		proxyPassphrase: proxyPassphrase,
+		proxyTimeout:    proxySshTimeout,
+		sshType:         sshType,
 	})
 	return b
 }
 
 // UserSSH append a UserSSH task to the current task collection
 func (b *Builder) UserSSH(
-	host string,
-	port int,
-	deployUser string,
-	sshTimeout uint64,
-	exeTimeout uint64,
+	host string, port int, deployUser string, sshTimeout, exeTimeout uint64,
+	proxyHost string, proxyPort int, proxyUser, proxyPassword, proxyKeyFile, proxyPassphrase string, proxySshTimeout uint64,
 	sshType, defaultSSHType executor.SSHType,
 ) *Builder {
 	if sshType == "" {
 		sshType = defaultSSHType
 	}
 	b.tasks = append(b.tasks, &UserSSH{
-		host:       host,
-		port:       port,
-		deployUser: deployUser,
-		timeout:    sshTimeout,
-		exeTimeout: exeTimeout,
-		sshType:    sshType,
+		host:            host,
+		port:            port,
+		deployUser:      deployUser,
+		timeout:         sshTimeout,
+		exeTimeout:      exeTimeout,
+		proxyHost:       proxyHost,
+		proxyPort:       proxyPort,
+		proxyUser:       proxyUser,
+		proxyPassword:   proxyPassword,
+		proxyKeyFile:    proxyKeyFile,
+		proxyPassphrase: proxyPassphrase,
+		proxyTimeout:    proxySshTimeout,
+		sshType:         sshType,
 	})
 	return b
 }

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/crypto"
 	"github.com/pingcap/tiup/pkg/meta"
+	"github.com/pingcap/tiup/pkg/proxy"
 )
 
 // Builder is used to build TiUP task
@@ -153,6 +154,7 @@ func (b *Builder) UpdateTopology(cluster, profile string, metadata *spec.Cluster
 		cluster:        cluster,
 		profileDir:     profile,
 		deletedNodeIDs: deletedNodeIds,
+		tcpProxy:       proxy.GetTCPProxy(),
 	})
 	return b
 }

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -40,7 +40,7 @@ func NewBuilder() *Builder {
 // RootSSH appends a RootSSH task to the current task collection
 func (b *Builder) RootSSH(
 	host string, port int, user, password, keyFile, passphrase string, sshTimeout, exeTimeout uint64,
-	proxyHost string, proxyPort int, proxyUser, proxyPassword, proxyKeyFile, proxyPassphrase string, proxySshTimeout uint64,
+	proxyHost string, proxyPort int, proxyUser, proxyPassword, proxyKeyFile, proxyPassphrase string, proxySSHTimeout uint64,
 	sshType, defaultSSHType executor.SSHType,
 ) *Builder {
 	if sshType == "" {
@@ -61,7 +61,7 @@ func (b *Builder) RootSSH(
 		proxyPassword:   proxyPassword,
 		proxyKeyFile:    proxyKeyFile,
 		proxyPassphrase: proxyPassphrase,
-		proxyTimeout:    proxySshTimeout,
+		proxyTimeout:    proxySSHTimeout,
 		sshType:         sshType,
 	})
 	return b
@@ -70,7 +70,7 @@ func (b *Builder) RootSSH(
 // UserSSH append a UserSSH task to the current task collection
 func (b *Builder) UserSSH(
 	host string, port int, deployUser string, sshTimeout, exeTimeout uint64,
-	proxyHost string, proxyPort int, proxyUser, proxyPassword, proxyKeyFile, proxyPassphrase string, proxySshTimeout uint64,
+	proxyHost string, proxyPort int, proxyUser, proxyPassword, proxyKeyFile, proxyPassphrase string, proxySSHTimeout uint64,
 	sshType, defaultSSHType executor.SSHType,
 ) *Builder {
 	if sshType == "" {
@@ -88,7 +88,7 @@ func (b *Builder) UserSSH(
 		proxyPassword:   proxyPassword,
 		proxyKeyFile:    proxyKeyFile,
 		proxyPassphrase: proxyPassphrase,
-		proxyTimeout:    proxySshTimeout,
+		proxyTimeout:    proxySSHTimeout,
 		sshType:         sshType,
 	})
 	return b
@@ -107,7 +107,7 @@ func (b *Builder) Func(name string, fn func(ctx context.Context) error) *Builder
 func (b *Builder) ClusterSSH(
 	topo spec.Topology,
 	deployUser string, sshTimeout, exeTimeout uint64,
-	proxyHost string, proxyPort int, proxyUser, proxyPassword, proxyKeyFile, proxyPassphrase string, proxySshTimeout uint64,
+	proxyHost string, proxyPort int, proxyUser, proxyPassword, proxyKeyFile, proxyPassphrase string, proxySSHTimeout uint64,
 	sshType, defaultSSHType executor.SSHType,
 ) *Builder {
 	if sshType == "" {
@@ -127,7 +127,7 @@ func (b *Builder) ClusterSSH(
 			proxyPassword:   proxyPassword,
 			proxyKeyFile:    proxyKeyFile,
 			proxyPassphrase: proxyPassphrase,
-			proxyTimeout:    proxySshTimeout,
+			proxyTimeout:    proxySSHTimeout,
 			sshType:         sshType,
 		})
 	})

--- a/pkg/cluster/task/update_topology.go
+++ b/pkg/cluster/task/update_topology.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
+	"github.com/pingcap/tiup/pkg/proxy"
 	"github.com/pingcap/tiup/pkg/set"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -19,6 +20,7 @@ type UpdateTopology struct {
 	profileDir     string
 	metadata       *spec.ClusterMeta
 	deletedNodeIDs []string
+	tcpProxy       *proxy.TCPProxy
 }
 
 // String implements the fmt.Stringer interface
@@ -34,7 +36,14 @@ func (u *UpdateTopology) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	client, err := u.metadata.Topology.GetEtcdClient(tlsCfg)
+	var client *clientv3.Client
+	if u.tcpProxy == nil {
+		client, err = u.metadata.Topology.GetEtcdClient(tlsCfg)
+	} else {
+		var closeC chan struct{}
+		client, closeC, err = u.metadata.Topology.GetEtcdProxyClient(tlsCfg, u.tcpProxy)
+		defer u.tcpProxy.Close(closeC)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/httproxy/http_proxy.go
+++ b/pkg/httproxy/http_proxy.go
@@ -1,0 +1,268 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httproxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/appleboy/easyssh-proxy"
+	perrs "github.com/pingcap/errors"
+	operator "github.com/pingcap/tiup/pkg/cluster/operation"
+	"github.com/pingcap/tiup/pkg/tui"
+	"github.com/pingcap/tiup/pkg/utils"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
+)
+
+// HTTPProxy stands for a http proxy based on SSH connection
+type HTTPProxy struct {
+	cli    *ssh.Client
+	config *easyssh.MakeConfig
+	l      sync.RWMutex
+	tr     *http.Transport
+}
+
+// MaybeMaybeStartHTTPProxy maybe starts an inner http proxy
+func MaybeStartHTTPProxy(gOpt operator.Options) (*http.Server, error) {
+	if len(gOpt.SSHProxyHost) == 0 {
+		return nil, nil
+	}
+
+	sshProps, err := tui.ReadIdentityFileOrPassword(gOpt.SSHProxyIdentity, gOpt.SSHProxyUsePassword)
+	if err != nil {
+		return nil, err
+	}
+
+	port, err := utils.GetFreePort("127.0.0.1", 12345)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Using environment variables to share data may not be a good idea
+	os.Setenv("TIUP_INNER_HTTP_PROXY", fmt.Sprintf("http://127.0.0.1:%d", port))
+	server := &http.Server{
+		Addr: fmt.Sprintf("127.0.0.1:%d", port),
+		Handler: NewHTTPProxy(
+			gOpt.SSHProxyHost,
+			gOpt.SSHProxyPort,
+			gOpt.SSHProxyUser,
+			sshProps.Password,
+			sshProps.IdentityFile,
+			sshProps.IdentityFilePassphrase,
+		),
+	}
+
+	go server.ListenAndServe()
+
+	return server, nil
+}
+
+// NewHTTPProxy creates and initializes a new http proxy
+func NewHTTPProxy(host string, port int, user, password, keyFile, passphrase string) *HTTPProxy {
+	p := &HTTPProxy{
+		config: &easyssh.MakeConfig{
+			Server:  host,
+			Port:    strconv.Itoa(port),
+			User:    user,
+			Timeout: 10 * time.Second,
+		},
+	}
+
+	if len(keyFile) > 0 {
+		p.config.KeyPath = keyFile
+		p.config.Passphrase = passphrase
+	} else if len(password) > 0 {
+		p.config.Password = password
+	}
+
+	dial := func(network, addr string) (net.Conn, error) {
+		p.l.RLock()
+		cli := p.cli
+		p.l.RUnlock()
+
+		// reuse the old client if dial success
+		if cli != nil {
+			c, err := cli.Dial(network, addr)
+			if err == nil {
+				return c, nil
+			}
+		}
+
+		// create a new ssh client
+		_, cli, err := p.config.Connect()
+		if err != nil {
+			return nil, perrs.Annotate(err, "connect to ssh proxy")
+		}
+
+		p.l.Lock()
+		p.cli = cli
+		p.l.Unlock()
+
+		return cli.Dial(network, addr)
+	}
+
+	p.tr = &http.Transport{Dial: dial}
+	return p
+}
+
+// ServeHTTP implements http.Handler
+func (s *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodConnect:
+		s.connect(w, r)
+	default:
+		r.RequestURI = ""
+		removeHopHeaders(r.Header)
+		s.serveHTTP(w, r)
+	}
+}
+
+// connect handles the CONNECT request
+// Data flow:
+//  1. Receive CONNECT request from the client
+//  2. Dial the remote server(the one client want to conenct)
+//  3. Send 200 OK to client if the connection is established
+//  4. Exchange data between client and server
+func (s *HTTPProxy) connect(w http.ResponseWriter, r *http.Request) {
+	// Use Hijacker to get the underlying connection
+	hij, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Server does not support Hijacker", http.StatusInternalServerError)
+		return
+	}
+
+	// connect the remote client directly
+	dst, err := s.tr.Dial("tcp", r.URL.Host)
+	if err != nil {
+		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+			zap.L().Debug("CONNECT roundtrip proxy timeout")
+			return
+		}
+		zap.L().Debug("CONNECT roundtrip proxy", zap.String("error", err.Error()))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer dst.Close()
+
+	src, _, err := hij.Hijack()
+	if err != nil {
+		zap.L().Debug("CONNECT hijack", zap.String("error", err.Error()))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer src.Close()
+
+	// Once connected successfully, return OK
+	src.Write([]byte("HTTP/1.1 200 OK\r\n\r\n"))
+
+	// Proxy is no need to know anything, just exchange data between the client
+	// the the remote server.
+	var wg sync.WaitGroup
+	copyAndWait := func(dst, src net.Conn) {
+		defer wg.Done()
+		_, err := io.Copy(dst, src)
+		if err != nil {
+			zap.L().Error("CONNECT copy response", zap.Any("src", src), zap.Any("dst", dst))
+		}
+		if tcpConn, ok := dst.(interface{ CloseWrite() error }); ok {
+			tcpConn.CloseWrite()
+		}
+	}
+
+	wg.Add(2)
+	go copyAndWait(dst, src) // client to remote
+	go copyAndWait(src, dst) // remote to client
+	wg.Wait()
+
+	return
+}
+
+// serveHTTP handles the original http request
+// Data flow:
+//  1. Receive request R1 from client
+//  2. Re-post request R1 to remote server(the one client want to connect)
+//  3. Receive response P1 from remote server
+//  4. Send response P1 to client
+func (s *HTTPProxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	// Client.Do is different from DefaultTransport.RoundTrip ...
+	// Client.Do will change some part of request as a new request of the server.
+	// The underlying RoundTrip never changes anything of the request.
+	resp, err := s.tr.RoundTrip(r)
+	if err != nil {
+		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+			zap.L().Debug("PROXY roundtrip proxy timeout")
+			return
+		}
+		zap.L().Debug("PROXY roundtrip proxy", zap.String("error", err.Error()))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	// please prepare header first and write them
+	copyHeaders(w, resp)
+	w.WriteHeader(resp.StatusCode)
+
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		zap.L().Error("PROXY copy response", zap.String("error", err.Error()))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	return
+}
+
+// Hop-by-hop headers. These are removed when sent to the backend.
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+var hopHeaders = []string{
+	// If no Accept-Encoding header exists, Transport will add the headers it can accept
+	// and would wrap the response body with the relevant reader.
+	"Accept-Encoding",
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Proxy-Connection",
+	"Te", // canonicalized version of "TE"
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+// removeHopHeaders removes the hop-by-hop headers
+func removeHopHeaders(h http.Header) {
+	for _, k := range hopHeaders {
+		h.Del(k)
+	}
+}
+
+// copy and overwrite headers from r to w
+func copyHeaders(w http.ResponseWriter, r *http.Response) {
+	// copy headers
+	dst, src := w.Header(), r.Header
+	for k := range dst {
+		dst.Del(k)
+	}
+	for k, vs := range src {
+		for _, v := range vs {
+			dst.Add(k, v)
+		}
+	}
+}

--- a/pkg/proxy/http_proxy.go
+++ b/pkg/proxy/http_proxy.go
@@ -11,23 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package httproxy
+package proxy
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/appleboy/easyssh-proxy"
 	perrs "github.com/pingcap/errors"
-	operator "github.com/pingcap/tiup/pkg/cluster/operation"
-	"github.com/pingcap/tiup/pkg/tui"
-	"github.com/pingcap/tiup/pkg/utils"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 )
@@ -38,41 +33,6 @@ type HTTPProxy struct {
 	config *easyssh.MakeConfig
 	l      sync.RWMutex
 	tr     *http.Transport
-}
-
-// MaybeMaybeStartHTTPProxy maybe starts an inner http proxy
-func MaybeStartHTTPProxy(gOpt operator.Options) (*http.Server, error) {
-	if len(gOpt.SSHProxyHost) == 0 {
-		return nil, nil
-	}
-
-	sshProps, err := tui.ReadIdentityFileOrPassword(gOpt.SSHProxyIdentity, gOpt.SSHProxyUsePassword)
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := utils.GetFreePort("127.0.0.1", 12345)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Using environment variables to share data may not be a good idea
-	os.Setenv("TIUP_INNER_HTTP_PROXY", fmt.Sprintf("http://127.0.0.1:%d", port))
-	server := &http.Server{
-		Addr: fmt.Sprintf("127.0.0.1:%d", port),
-		Handler: NewHTTPProxy(
-			gOpt.SSHProxyHost,
-			gOpt.SSHProxyPort,
-			gOpt.SSHProxyUser,
-			sshProps.Password,
-			sshProps.IdentityFile,
-			sshProps.IdentityFilePassphrase,
-		),
-	}
-
-	go server.ListenAndServe()
-
-	return server, nil
 }
 
 // NewHTTPProxy creates and initializes a new http proxy

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,59 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	operator "github.com/pingcap/tiup/pkg/cluster/operation"
+	"github.com/pingcap/tiup/pkg/tui"
+	"github.com/pingcap/tiup/pkg/utils"
+)
+
+// MaybeStartProxy maybe starts an inner http proxy
+func MaybeStartProxy(gOpt operator.Options) (*http.Server, error) {
+	if len(gOpt.SSHProxyHost) == 0 {
+		return nil, nil
+	}
+
+	sshProps, err := tui.ReadIdentityFileOrPassword(gOpt.SSHProxyIdentity, gOpt.SSHProxyUsePassword)
+	if err != nil {
+		return nil, err
+	}
+
+	port, err := utils.GetFreePort("127.0.0.1", 12345)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Using environment variables to share data may not be a good idea
+	os.Setenv("TIUP_INNER_HTTP_PROXY", fmt.Sprintf("http://127.0.0.1:%d", port))
+	server := &http.Server{
+		Addr: fmt.Sprintf("127.0.0.1:%d", port),
+		Handler: NewHTTPProxy(
+			gOpt.SSHProxyHost,
+			gOpt.SSHProxyPort,
+			gOpt.SSHProxyUser,
+			sshProps.Password,
+			sshProps.IdentityFile,
+			sshProps.IdentityFilePassphrase,
+		),
+	}
+
+	go server.ListenAndServe()
+
+	return server, nil
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -63,7 +63,7 @@ func MaybeStartProxy(host string, port int, user string, usePass bool, identity 
 
 	log.Infof(color.HiGreenString("Start HTTP inner proxy %s", httpProxy.Addr))
 	go func() {
-		if err := httpProxy.ListenAndServe(); err != nil {
+		if err := httpProxy.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Errorf("Failed to listen HTTP proxy: %v", err)
 		}
 	}()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -62,7 +62,11 @@ func MaybeStartProxy(host string, port int, user string, usePass bool, identity 
 	}
 
 	log.Infof(color.HiGreenString("Start HTTP inner proxy %s", httpProxy.Addr))
-	go httpProxy.ListenAndServe()
+	go func() {
+		if err := httpProxy.ListenAndServe(); err != nil {
+			log.Errorf("Failed to listen HTTP proxy: %v", err)
+		}
+	}()
 
 	p := NewTCPProxy(
 		host, port, user,
@@ -79,11 +83,11 @@ func MaybeStartProxy(host string, port int, user string, usePass bool, identity 
 // MaybeStopProxy stops the http/tcp proxies if it has been started before
 func MaybeStopProxy() {
 	if httpProxy != nil {
-		httpProxy.Shutdown(context.Background())
+		_ = httpProxy.Shutdown(context.Background())
 		os.Unsetenv("TIUP_INNER_HTTP_PROXY")
 	}
 	if p := tcpProxy.Load(); p != nil {
-		p.(*TCPProxy).Stop()
+		_ = p.(*TCPProxy).Stop()
 	}
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -78,7 +78,6 @@ func MaybeStartProxy(host string, port int, user string, usePass bool, identity 
 
 // MaybeStopProxy stops the http/tcp proxies if it has been started before
 func MaybeStopProxy() {
-	fmt.Println("stop the proxy")
 	if httpProxy != nil {
 		httpProxy.Shutdown(context.Background())
 		os.Unsetenv("TIUP_INNER_HTTP_PROXY")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -14,46 +14,59 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
 
-	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/tui"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
-// MaybeStartProxy maybe starts an inner http proxy
-func MaybeStartProxy(gOpt operator.Options) (*http.Server, error) {
-	if len(gOpt.SSHProxyHost) == 0 {
-		return nil, nil
+var (
+	httpProxy *http.Server
+	tcpProxy  *TCPProxy
+)
+
+// MaybeStartProxy maybe starts an inner http/tcp proxies
+func MaybeStartProxy(host string, port int, user string, usePass bool, identity string) error {
+	if len(host) == 0 {
+		return nil
 	}
 
-	sshProps, err := tui.ReadIdentityFileOrPassword(gOpt.SSHProxyIdentity, gOpt.SSHProxyUsePassword)
+	sshProps, err := tui.ReadIdentityFileOrPassword(identity, usePass)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	port, err := utils.GetFreePort("127.0.0.1", 12345)
+	listenPort, err := utils.GetFreePort("127.0.0.1", 12345)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// TODO: Using environment variables to share data may not be a good idea
-	os.Setenv("TIUP_INNER_HTTP_PROXY", fmt.Sprintf("http://127.0.0.1:%d", port))
-	server := &http.Server{
+	os.Setenv("TIUP_INNER_HTTP_PROXY", fmt.Sprintf("http://127.0.0.1:%d", listenPort))
+	httpProxy = &http.Server{
 		Addr: fmt.Sprintf("127.0.0.1:%d", port),
 		Handler: NewHTTPProxy(
-			gOpt.SSHProxyHost,
-			gOpt.SSHProxyPort,
-			gOpt.SSHProxyUser,
+			host, port, user,
 			sshProps.Password,
 			sshProps.IdentityFile,
 			sshProps.IdentityFilePassphrase,
 		),
 	}
 
-	go server.ListenAndServe()
+	go httpProxy.ListenAndServe()
 
-	return server, nil
+	return nil
+}
+
+// MaMaybeStopProxy stops the http/tcp proxies if it has been started before
+func MaybeStopProxy() {
+	if httpProxy == nil {
+		return
+	}
+	httpProxy.Shutdown(context.Background())
+	os.Unsetenv("TIUP_INNER_HTTP_PROXY")
+	httpProxy = nil
 }

--- a/pkg/proxy/tcp_proxy.go
+++ b/pkg/proxy/tcp_proxy.go
@@ -1,0 +1,160 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/appleboy/easyssh-proxy"
+	perrs "github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/utils"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
+)
+
+type TCPProxy struct {
+	l         sync.RWMutex
+	cli       *ssh.Client
+	config    *easyssh.MakeConfig
+	endpoints []string
+	closeC    chan struct{}
+}
+
+func NewTCPProxy(host string, port int, user, password, keyFile, passphrase string, endpoints []string) *TCPProxy {
+	p := &TCPProxy{
+		config: &easyssh.MakeConfig{
+			Server:  host,
+			Port:    strconv.Itoa(port),
+			User:    user,
+			Timeout: 10 * time.Second,
+		},
+		endpoints: endpoints,
+	}
+
+	if len(keyFile) > 0 {
+		p.config.KeyPath = keyFile
+		p.config.Passphrase = passphrase
+	} else if len(password) > 0 {
+		p.config.Password = password
+	}
+
+	port, err := utils.GetFreePort("127.0.0.1", 22345)
+	if err != nil {
+		return nil
+	}
+
+	localListener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		log.Fatalf("net.Listen failed: %v", err)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-p.closeC:
+				return
+			default:
+				localConn, err := localListener.Accept()
+				if err != nil {
+					log.Fatalf("listen.Accept failed: %v", err)
+				}
+				go p.forward(localConn)
+			}
+		}
+	}()
+
+	return p
+}
+
+func (p *TCPProxy) getConn() (*ssh.Client, error) {
+	p.l.RLock()
+	cli := p.cli
+	p.l.RUnlock()
+
+	// reuse the old client if dial success
+	if cli == nil {
+		return cli, nil
+	}
+
+	// create a new ssh client
+	_, cli, err := p.config.Connect()
+	if err != nil {
+		return nil, perrs.Annotate(err, "connect to ssh proxy")
+	}
+
+	p.l.Lock()
+	p.cli = cli
+	p.l.Unlock()
+
+	return cli, nil
+}
+
+func (p *TCPProxy) forward(localConn net.Conn) {
+	cli, err := p.getConn()
+	if err != nil {
+		zap.L().Error("Failed to get ssh client", zap.String("error", err.Error()))
+		return
+	}
+
+	var remoteConn net.Conn
+OUTER_LOOP:
+	for _, endpoint := range p.endpoints {
+		endpoint := endpoint
+		errC := make(chan error, 1)
+		go func() {
+			var err error
+			remoteConn, err = cli.Dial("tcp", endpoint)
+			if err != nil {
+				zap.L().Error("Failed to connect endpoint", zap.String("error", err.Error()))
+			}
+
+			errC <- err
+		}()
+
+		select {
+		case err := <-errC:
+			if err == nil {
+				break OUTER_LOOP
+			}
+		case <-time.After(5 * time.Second):
+			zap.L().Debug("Connect to endpoint timeout, retry the next endpoint", zap.String("endpoint", endpoint))
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_, err = io.Copy(remoteConn, localConn)
+		if err != nil {
+			zap.L().Error("Failed to copy from local to remote", zap.String("error", err.Error()))
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, err = io.Copy(localConn, remoteConn)
+		if err != nil {
+			zap.L().Error("Failed to copy from remote to local", zap.String("error", err.Error()))
+		}
+	}()
+	wg.Wait()
+}

--- a/pkg/proxy/tcp_proxy.go
+++ b/pkg/proxy/tcp_proxy.go
@@ -41,7 +41,7 @@ type TCPProxy struct {
 	endpoint string
 }
 
-// NewNewTCPProxy starts a 1to1 TCP proxy
+// NewTCPProxy starts a 1to1 TCP proxy
 func NewTCPProxy(host string, port int, user, password, keyFile, passphrase string) *TCPProxy {
 	p := &TCPProxy{
 		config: &easyssh.MakeConfig{
@@ -76,7 +76,7 @@ func NewTCPProxy(host string, port int, user, password, keyFile, passphrase stri
 	return p
 }
 
-// GetGetEndpoints returns the endpoint list
+// GetEndpoints returns the endpoint list
 func (p *TCPProxy) GetEndpoints() []string {
 	return []string{p.endpoint}
 }
@@ -87,6 +87,7 @@ func (p *TCPProxy) Stop() error {
 	return p.listener.Close()
 }
 
+// Run runs proxy all traffic to upstream
 func (p *TCPProxy) Run(upstream []string) chan struct{} {
 	closeC := make(chan struct{})
 	go func() {
@@ -111,6 +112,7 @@ func (p *TCPProxy) Run(upstream []string) chan struct{} {
 	return closeC
 }
 
+// Close closes a proxy
 func (p *TCPProxy) Close(c chan struct{}) {
 	close(c)
 }
@@ -138,7 +140,7 @@ func (p *TCPProxy) getConn() (*ssh.Client, error) {
 	return cli, nil
 }
 
-func (p *TCPProxy) forward(localConn net.Conn, endpoints []string) {
+func (p *TCPProxy) forward(localConn io.ReadWriter, endpoints []string) {
 	cli, err := p.getConn()
 	if err != nil {
 		zap.L().Error("Failed to get ssh client", zap.String("error", err.Error()))

--- a/pkg/utils/http_client.go
+++ b/pkg/utils/http_client.go
@@ -96,6 +96,11 @@ func (c *HTTPClient) Delete(url string, body io.Reader) ([]byte, int, error) {
 	return b, statusCode, err
 }
 
+// Client returns the http.Client
+func (c *HTTPClient) Client() *http.Client {
+	return c.client
+}
+
 // WithClient uses the specified HTTP client
 func (c *HTTPClient) WithClient(client *http.Client) *HTTPClient {
 	c.client = client

--- a/pkg/utils/http_client.go
+++ b/pkg/utils/http_client.go
@@ -44,8 +44,8 @@ func NewHTTPClient(timeout time.Duration, tlsConfig *tls.Config) *HTTPClient {
 		httpProxy = os.Getenv("HTTP_PROXY")
 	}
 	if len(httpProxy) > 0 {
-		if proxyUrl, err := url.Parse(httpProxy); err == nil {
-			tr.Proxy = http.ProxyURL(proxyUrl)
+		if proxyURL, err := url.Parse(httpProxy); err == nil {
+			tr.Proxy = http.ProxyURL(proxyURL)
 		}
 	}
 	return &HTTPClient{


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Try to implement  #1417 

### What is changed and how it works?

This PR contains 3 proxy:

1. Pure SSH Proxy via [easyssh](https://github.com/appleboy/easyssh-proxy) or the built-in ssh client: used by many actions, such as check, deploy, display, exec...
2. HTTP over SSH Proxy: used by PdAPI, DMAPi, such as fetch the component's status
3. TCP over SSH Proxy: used by etcd grpc, such as UpdateTopology

You can enable this feature with the `--ssh-proxy-host` parameter，at the same time, we also provide some other `--ssh-proxy-xxx` parameters.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
