### PR TITLE
cluster/prometheus: tikv accelerate rules if version 3

### DIFF
--- a/.github/workflows/integrate-cluster-cmd.yaml
+++ b/.github/workflows/integrate-cluster-cmd.yaml
@@ -34,9 +34,9 @@ jobs:
       matrix:
         cases:
           - 'test_cmd'
-          # - "test_cmd_tls_native_ssh"
+          # - 'test_cmd_tls_native_ssh'
           - 'test_upgrade'
-          # - "test_upgrade_tls"
+          - 'test_upgrade_tls'
     env:
       working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
     steps:

--- a/embed/templates/config/prometheus.yml.tpl
+++ b/embed/templates/config/prometheus.yml.tpl
@@ -27,7 +27,9 @@ rule_files:
 {{- end}}
 {{- if .TiKVStatusAddrs}}
   - 'tikv.rules.yml'
+{{- if .HasTiKVAccelerateRules}}
   - 'tikv.accelerate.rules.yml'
+{{- end}}
 {{- end}}
 {{- if .TiFlashStatusAddrs}}
   - 'tiflash.rules.yml'

--- a/pkg/cluster/spec/prometheus.go
+++ b/pkg/cluster/spec/prometheus.go
@@ -179,7 +179,7 @@ func (i *MonitorInstance) InitConfig(
 
 	// transfer config
 	fp = filepath.Join(paths.Cache, fmt.Sprintf("prometheus_%s_%d.yml", i.GetHost(), i.GetPort()))
-	cfig := config.NewPrometheusConfig(clusterName, enableTLS)
+	cfig := config.NewPrometheusConfig(clusterName, clusterVersion, enableTLS)
 	if monitoredOptions != nil {
 		cfig.AddBlackbox(i.GetHost(), uint64(monitoredOptions.BlackboxExporterPort))
 	}

--- a/pkg/cluster/template/config/prometheus.go
+++ b/pkg/cluster/template/config/prometheus.go
@@ -21,6 +21,7 @@ import (
 	"text/template"
 
 	"github.com/pingcap/tiup/embed"
+	"golang.org/x/mod/semver"
 )
 
 // PrometheusConfig represent the data to generate Prometheus config
@@ -46,6 +47,7 @@ type PrometheusConfig struct {
 	BlackboxAddr              string
 	KafkaExporterAddr         string
 	GrafanaAddr               string
+	HasTiKVAccelerateRules    bool
 
 	DMMasterAddrs []string
 	DMWorkerAddrs []string
@@ -55,11 +57,17 @@ type PrometheusConfig struct {
 }
 
 // NewPrometheusConfig returns a PrometheusConfig
-func NewPrometheusConfig(cluster string, enableTLS bool) *PrometheusConfig {
-	return &PrometheusConfig{
-		ClusterName: cluster,
+func NewPrometheusConfig(clusterName, clusterVersion string, enableTLS bool) *PrometheusConfig {
+	cfg := &PrometheusConfig{
+		ClusterName: clusterName,
 		TLSEnabled:  enableTLS,
 	}
+
+	// tikv.accelerate.rules.yml was first introduced in v4.0.0
+	if semver.Compare(clusterVersion, "v4.0.0") >= 0 {
+		cfg.HasTiKVAccelerateRules = true
+	}
+	return cfg
 }
 
 // AddKafka add a kafka address


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

I'm deploying a cluster of version 3.0.12, but failed to start it. The error message as below:

```bash
Error: init config failed: n1:9090: executor.ssh.execute_failed: Failed to execute command over SSH for 'tidb@n1:22' {ssh_stderr:   FAILED: "/home/tidb/deploy/prometheus-9090/conf/tikv.accelerate.rules.yml" does not point to an existing file
, ssh_stdout: Checking /home/tidb/deploy/prometheus-9090/conf/prometheus.yml
, ssh_command: export LANG=C; PATH=$PATH:/usr/bin:/usr/sbin /home/tidb/deploy/prometheus-9090/bin/prometheus/promtool check config /home/tidb/deploy/prometheus-9090/conf/prometheus.yml}, cause: Process exited with status 1: check config failed
```

This shows the Prometheus package missing the rule file `tikv.accelerate.rules.yml`, then  found this file was introduced in v4.0.0 


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
