### PR TITLE
clone_mirror: refuse to clone from self

### DIFF
--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -52,7 +52,10 @@ func CloneMirror(repo *V1Repository,
 	targetDir string,
 	selectedVersions []string,
 	options CloneOptions) error {
-	fmt.Printf("Start to clone mirror, targetDir is %s, selectedVersions are [%s]\n", targetDir, strings.Join(selectedVersions, ","))
+	if strings.TrimRight(targetDir, "/") == strings.TrimRight(repo.Mirror().Source(), "/") {
+		return errors.Errorf("Refusing to clone from %s to %s", targetDir, repo.Mirror().Source())
+	}
+	fmt.Printf("Start to clone mirror, targetDir is %s, source mirror is %s, selectedVersions are [%s]\n", targetDir, repo.Mirror().Source(), strings.Join(selectedVersions, ","))
 	fmt.Println("If this does not meet expectations, please abort this process, read `tiup mirror clone --help` and run again")
 
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
@@ -341,7 +344,7 @@ func cloneComponents(repo *V1Repository,
 
 			if err := repo.Mirror().Download(url, tmpDir); err != nil {
 				if errors.Cause(err) == ErrNotFound {
-					fmt.Printf("TiUP donesn't have %s/%s, skipped\n", goos, goarch)
+					fmt.Printf("TiUP doesn't have %s/%s, skipped\n", goos, goarch)
 					continue
 				}
 				return nil, err


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

When running something like this:
```
tiup mirror clone /tmp/tidb_mirror -a amd64 --prefix v5.1.0 --os linux
tiup mirror set /tmp/tidb_mirror
tiup mirror clone /tmp/tidb_mirror -a amd64 --prefix v5.1.0 --os linux
```
This results in metadata being changed/corrupted.

Then the next `tiup mirror clone ...` results in:
```
Error: read manifest from mirror(/tmp/tidb_mirror) failed: not enough signatures (0) for threshold 1 in timestamp.json
```

This can easily be fixed with `tiup mirror set ...`, but it is best to
avoid this. And also cloning from self is probably not what the user
wanted in the first place. So adding the source to the output to make
this easier to spot.

Related: https://tidbcommunity.slack.com/archives/C019S7HLP61/p1625059913130200

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)





Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
A clear error is given when trying to clone a mirror from itself
```
