### PR TITLE
Update manifest errors in list component should not be returned, change to warning

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -92,7 +93,7 @@ func (lr *listResult) print() {
 func showComponentList(env *environment.Environment, opt listOptions) (*listResult, error) {
 	err := env.V1Repository().UpdateComponentManifests()
 	if err != nil {
-		return nil, err
+		tui.ColorWarningMsg.Fprint(os.Stderr, "Warn: Update component manifest failed, err_msg=[", err.Error(), "]\n")
 	}
 
 	installed, err := env.Profile().InstalledComponents()


### PR DESCRIPTION
Update manifest errors in `list` command should not be returned, change to warning

Reason:
1. If the manifest is already available locally, the local component
   should be listed, but output warning

2. If there is no local manifest, in case of update manifest error,
   init manifest will also fail and will not continue

https://github.com/pingcap/tiup/issues/1465

