### PR TITLE
cluster: print more clear warning when scale in with `--force`

### DIFF
--- a/pkg/cluster/manager/scale_in.go
+++ b/pkg/cluster/manager/scale_in.go
@@ -48,19 +48,22 @@ func (m *Manager) ScaleIn(
 		nodes []string = gOpt.Nodes
 	)
 	if !skipConfirm {
+		if force {
+			if err := tui.PromptForConfirmOrAbortError(
+				color.HiRedString("Forcing scale in is unsafe and may result in data loss for stateful components.\n"+
+					"The process is irreversible and could NOT be cancelled.\n") +
+					"Only use `--force` when some of the servers are already permanently offline.\n" +
+					"Are you sure to continue? [y/N]:",
+			); err != nil {
+				return err
+			}
+		}
+
 		if err := tui.PromptForConfirmOrAbortError(
 			"This operation will delete the %s nodes in `%s` and all their data.\nDo you want to continue? [y/N]:",
 			strings.Join(nodes, ","),
 			color.HiYellowString(name)); err != nil {
 			return err
-		}
-
-		if force {
-			if err := tui.PromptForConfirmOrAbortError(
-				"Forcing scale in is unsafe and may result in data lost for stateful components.\nDo you want to continue? [y/N]:",
-			); err != nil {
-				return err
-			}
 		}
 
 		log.Infof("Scale-in nodes...")


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1453 

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
