### PR TITLE
tiup: implement renew subcommand to extend expiration date of compone…

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -373,10 +373,6 @@ func newMirrorRenewCmd() *cobra.Command {
 			} else {
 				v1manifest.RenewManifest(m, time.Now())
 			}
-			flagSet := set.NewStringSet()
-			cmd.Flags().Visit(func(f *pflag.Flag) {
-				flagSet.Insert(f.Name)
-			})
 
 			manifest, err := sign(privPath, m)
 			if err != nil {

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -71,6 +71,7 @@ of components or the repository itself.`,
 		newMirrorShowCmd(),
 		newMirrorSetCmd(),
 		newMirrorModifyCmd(),
+		newMirrorRenewCmd(),
 		newMirrorGrantCmd(),
 		newMirrorRotateCmd(),
 	)
@@ -334,6 +335,60 @@ func newMirrorModifyCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&standalone, "standalone", "", standalone, "can this component run directly")
 	cmd.Flags().BoolVarP(&hidden, "hide", "", hidden, "is this component visible in list")
 	cmd.Flags().BoolVarP(&yanked, "yank", "", yanked, "is this component deprecated")
+	return cmd
+}
+
+// the `mirror renew` sub command
+func newMirrorRenewCmd() *cobra.Command {
+	var privPath string
+	var days int
+
+	cmd := &cobra.Command{
+		Use:   "renew <component> [flags]",
+		Short: "Renew the manifest of a published component.",
+		Long:  "Renew the manifest of a published component, bump version and extend its expire time.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			teleCommand = cmd.CommandPath()
+			if len(args) != 1 {
+				return cmd.Help()
+			}
+
+			component := args[0]
+
+			env := environment.GlobalEnv()
+
+			comp, _ := environment.ParseCompVersion(component)
+			m, err := env.V1Repository().FetchComponentManifest(comp, true)
+			if err != nil {
+				// ignore manifest expiration error
+				if v1manifest.IsExpirationError(perrs.Cause(err)) {
+					fmt.Println(err)
+				} else {
+					return err
+				}
+			}
+
+			if days > 0 {
+				v1manifest.RenewManifest(m, time.Now(), time.Hour*24*time.Duration(days))
+			} else {
+				v1manifest.RenewManifest(m, time.Now())
+			}
+			flagSet := set.NewStringSet()
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				flagSet.Insert(f.Name)
+			})
+
+			manifest, err := sign(privPath, m)
+			if err != nil {
+				return err
+			}
+
+			return env.V1Repository().Mirror().Publish(manifest, &model.PublishInfo{})
+		},
+	}
+
+	cmd.Flags().StringVarP(&privPath, "key", "k", "", "private key path")
+	cmd.Flags().IntVar(&days, "days", 0, "after how many days the manifest expires, 0 means builtin default values of manifests")
 	return cmd
 }
 

--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -415,14 +415,18 @@ func ReadManifest(input io.Reader, role ValidManifest, keys *KeyStore) (*Manifes
 }
 
 // RenewManifest resets and extends the expire time of manifest
-func RenewManifest(m ValidManifest, startTime time.Time) {
+func RenewManifest(m ValidManifest, startTime time.Time, extend ...time.Duration) {
 	// manifest with 0 version means it's unversioned
 	if m.Base().Version > 0 {
 		m.Base().Version++
 	}
 
-	// only update expire field when it's old than target expire time
-	targetExpire := startTime.Add(ManifestsConfig[m.Base().Ty].Expire)
+	// only update expire field when it's older than target expire time
+	duration := ManifestsConfig[m.Base().Ty].Expire
+	if len(extend) > 0 {
+		duration = extend[0]
+	}
+	targetExpire := startTime.Add(duration)
 	currentExpire, err := time.Parse(time.RFC3339, m.Base().Expires)
 	if err != nil {
 		m.Base().Expires = targetExpire.Format(time.RFC3339)


### PR DESCRIPTION
…nt manifest

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add a new subcommand of `tiup mirror` to renew manifest of a component. The renew process only bumps the manifest version and extends its expiration time.

We may implement renew operation for other manifests as well in the future.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
tiup: implement renew subcommand to extend expiration date of component manifest
```
