### PR TITLE
Add display tikv labels feature

### DIFF
--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -34,6 +34,7 @@ func newDisplayCmd() *cobra.Command {
 		clusterName       string
 		showDashboardOnly bool
 		showVersionOnly   bool
+		showTiKVLables    bool
 	)
 	cmd := &cobra.Command{
 		Use:   "display <cluster-name>",
@@ -75,6 +76,10 @@ func newDisplayCmd() *cobra.Command {
 				return displayDashboardInfo(clusterName, tlsCfg)
 			}
 
+			if showTiKVLables {
+				return cm.DisplayTiKVLabels(clusterName, gOpt)
+			}
+
 			return cm.Display(clusterName, gOpt)
 		},
 	}
@@ -84,6 +89,7 @@ func newDisplayCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&gOpt.ShowUptime, "uptime", false, "Display with uptime")
 	cmd.Flags().BoolVar(&showDashboardOnly, "dashboard", false, "Only display TiDB Dashboard information")
 	cmd.Flags().BoolVar(&showVersionOnly, "version", false, "Only display TiDB cluster version")
+	cmd.Flags().BoolVar(&showTiKVLables, "labels", false, "Only display specified tikv role or nodes lables")
 
 	return cmd
 }

--- a/pkg/cluster/ansible/inventory.go
+++ b/pkg/cluster/ansible/inventory.go
@@ -494,7 +494,7 @@ func parseGroupVars(dir, ansCfgFile string, clsMeta *spec.ClusterMeta, inv *aini
 
 			clsMeta.Topology.Grafanas = append(clsMeta.Topology.Grafanas, tmpIns)
 		}
-		log.Infof("Imported %d Grafana node(s).", len(clsMeta.Topology.Alertmanagers))
+		log.Infof("Imported %d Grafana node(s).", len(clsMeta.Topology.Grafanas))
 	}
 
 	// kafka_exporter_servers

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/jeremywohl/flatten"
@@ -730,6 +731,42 @@ func (pc *PDClient) GetTiKVLabels() (map[string]map[string]string, error) {
 		locationLabels[s.Store.GetAddress()] = labels
 	}
 	return locationLabels, nil
+}
+
+// GetTiKVStoreStateAndLabels implements TiKVLabelProvider
+func (pc *PDClient) GetTiKVStoreStateAndLabels() ([]map[string]string, error) {
+	r, err := pc.GetStores()
+	if err != nil {
+		return nil, err
+	}
+
+	var storeState []map[string]string
+	for _, s := range r.Stores {
+		if s.Store.State == metapb.StoreState_Up || s.Store.State == metapb.StoreState_Offline {
+			lbs := s.Store.GetLabels()
+			var labels []string
+			for _, lb := range lbs {
+				// Skip tiflash
+				if lb.GetKey() != "tiflash" {
+					labels = append(labels, fmt.Sprintf("%s: %s", lb.GetKey(), lb.GetValue()))
+				}
+			}
+
+			label := fmt.Sprintf("%s%s%s", "{", strings.Join(labels, ","), "}")
+			storeState = append(storeState, map[string]string{
+				strings.Split(s.Store.GetAddress(), ":")[0]: fmt.Sprintf("%s|%d|%s|%d|%d|%v|%v|%s",
+					strings.Split(s.Store.GetAddress(), ":")[1],
+					s.Store.GetId(),
+					s.Store.State.String(),
+					s.Status.LeaderCount,
+					s.Status.RegionCount,
+					s.Status.Capacity.MarshalString(),
+					s.Status.Available.MarshalString(),
+					label),
+			})
+		}
+	}
+	return storeState, nil
 }
 
 // UpdateScheduleConfig updates the PD schedule config

--- a/pkg/cluster/api/typeutil/size.go
+++ b/pkg/cluster/api/typeutil/size.go
@@ -51,3 +51,8 @@ func (b *ByteSize) UnmarshalText(text []byte) error {
 	*b = ByteSize(v)
 	return nil
 }
+
+// MarshalString returns the size as a string.
+func (b ByteSize) MarshalString() string {
+	return units.BytesSize(float64(b))
+}

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -162,6 +162,123 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 	return nil
 }
 
+// DisplayTiKVLabels display cluster tikv labels
+func (m *Manager) DisplayTiKVLabels(name string, opt operator.Options) error {
+	if err := clusterutil.ValidateClusterNameOrError(name); err != nil {
+		return err
+	}
+
+	clusterInstInfos, err := m.GetClusterTopology(name, opt)
+	if err != nil {
+		return err
+	}
+
+	metadata, _ := m.meta(name)
+	topo := metadata.GetTopology()
+	base := metadata.GetBaseMeta()
+	// display cluster meta
+	cyan := color.New(color.FgCyan, color.Bold)
+	fmt.Printf("Cluster type:       %s\n", cyan.Sprint(m.sysName))
+	fmt.Printf("Cluster name:       %s\n", cyan.Sprint(name))
+	fmt.Printf("Cluster version:    %s\n", cyan.Sprint(base.Version))
+	fmt.Printf("SSH type:           %s\n", cyan.Sprint(topo.BaseTopo().GlobalOptions.SSHType))
+	fmt.Printf("Component name:     %s\n", cyan.Sprint("TiKV"))
+
+	// display TLS info
+	if topo.BaseTopo().GlobalOptions.TLSEnabled {
+		fmt.Printf("TLS encryption:  	%s\n", cyan.Sprint("enabled"))
+		fmt.Printf("CA certificate:     %s\n", cyan.Sprint(
+			m.specManager.Path(name, spec.TLSCertKeyDir, spec.TLSCACert),
+		))
+		fmt.Printf("Client private key: %s\n", cyan.Sprint(
+			m.specManager.Path(name, spec.TLSCertKeyDir, spec.TLSClientKey),
+		))
+		fmt.Printf("Client certificate: %s\n", cyan.Sprint(
+			m.specManager.Path(name, spec.TLSCertKeyDir, spec.TLSClientCert),
+		))
+	}
+
+	// display topology
+	var clusterTable [][]string
+	clusterTable = append(clusterTable, []string{"Machine", "Port", "Store", "Status", "Leaders", "Regions", "Capacity", "Available", "Labels"})
+
+	masterActive := make([]string, 0)
+	tikvStoreIP := make(map[string]struct{})
+	for _, v := range clusterInstInfos {
+		if v.ComponentName == spec.ComponentTiKV {
+			tikvStoreIP[v.Host] = struct{}{}
+		}
+	}
+
+	masterList := topo.BaseTopo().MasterList
+	tlsCfg, err := topo.TLSConfig(m.specManager.Path(name, spec.TLSCertKeyDir))
+	if err != nil {
+		return err
+	}
+	topo.IterInstance(func(ins spec.Instance) {
+		if ins.ComponentName() == spec.ComponentPD {
+			status := ins.Status(tlsCfg, masterList...)
+			if strings.HasPrefix(status, "Up") || strings.HasPrefix(status, "Healthy") {
+				instAddr := fmt.Sprintf("%s:%d", ins.GetHost(), ins.GetPort())
+				masterActive = append(masterActive, instAddr)
+			}
+		}
+	})
+
+	if _, ok := topo.(*spec.Specification); ok {
+		// Check if TiKV's label set correctly
+		pdClient := api.NewPDClient(masterActive, 10*time.Second, tlsCfg)
+		lbs, err := pdClient.GetLocationLabels()
+		if err != nil {
+			log.Debugf("get location labels from pd failed: %v", err)
+		}
+		fmt.Printf("Location labels:    %s\n", cyan.Sprint(strings.Join(lbs, ",")))
+
+		storeStates, err := pdClient.GetTiKVStoreStateAndLabels()
+		if err != nil {
+			log.Debugf("get tikv state and labels from pd failed: %v", err)
+		}
+
+		for storeIP := range tikvStoreIP {
+			row := []string{
+				color.CyanString(storeIP),
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+			}
+			clusterTable = append(clusterTable, row)
+
+			for _, val := range storeStates {
+				if _, ok := val[storeIP]; ok {
+					storeInfo := strings.Split(val[storeIP], "|")
+					row := []string{
+						"",
+						storeInfo[0],
+						storeInfo[1],
+						color.CyanString(storeInfo[2]),
+						storeInfo[3],
+						storeInfo[4],
+						storeInfo[5],
+						storeInfo[6],
+						storeInfo[7],
+					}
+					clusterTable = append(clusterTable, row)
+				}
+			}
+		}
+	}
+
+	cliutil.PrintTable(clusterTable, true)
+	fmt.Printf("Total nodes: %d\n", len(clusterTable)-1)
+
+	return nil
+}
+
 // GetClusterTopology get the topology of the cluster.
 func (m *Manager) GetClusterTopology(name string, opt operator.Options) ([]InstInfo, error) {
 	ctx := ctxt.New(context.Background())


### PR DESCRIPTION
tiup cluster display  support display tikv labels features，improve yaml meta file TiKV Labels has poor readability and checkability
- if -R/-N not set，display all tikv labels
- if -N set, display current machine tikv labels

![image](https://user-images.githubusercontent.com/34805682/125189214-83772880-e269-11eb-88be-c7030d6ce5a0.png)
![image](https://user-images.githubusercontent.com/34805682/125189252-b6212100-e269-11eb-94cc-94064df20057.png)
