### PR TITLE
cluster: add ability to ignore monitor agent for instances

### DIFF
--- a/components/dm/spec/logic.go
+++ b/components/dm/spec/logic.go
@@ -45,6 +45,7 @@ type (
 		SSH() (string, int)
 		GetMainPort() int
 		IsImported() bool
+		IgnoreMonitorAgent() bool
 	}
 )
 

--- a/components/dm/spec/topology_dm.go
+++ b/components/dm/spec/topology_dm.go
@@ -118,10 +118,11 @@ func AllDMComponentNames() (roles []string) {
 
 // MasterSpec represents the Master topology specification in topology.yaml
 type MasterSpec struct {
-	Host     string `yaml:"host"`
-	SSHPort  int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
-	Imported bool   `yaml:"imported,omitempty"`
-	Patched  bool   `yaml:"patched,omitempty"`
+	Host           string `yaml:"host"`
+	SSHPort        int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
+	Imported       bool   `yaml:"imported,omitempty"`
+	Patched        bool   `yaml:"patched,omitempty"`
+	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty"`
 	// Use Name to get the name with a default value if it's empty.
 	Name            string                 `yaml:"name,omitempty"`
 	Port            int                    `yaml:"port,omitempty" default:"8261"`
@@ -178,12 +179,18 @@ func (s *MasterSpec) IsImported() bool {
 	return s.Imported
 }
 
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *MasterSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
+}
+
 // WorkerSpec represents the Master topology specification in topology.yaml
 type WorkerSpec struct {
-	Host     string `yaml:"host"`
-	SSHPort  int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
-	Imported bool   `yaml:"imported,omitempty"`
-	Patched  bool   `yaml:"patched,omitempty"`
+	Host           string `yaml:"host"`
+	SSHPort        int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
+	Imported       bool   `yaml:"imported,omitempty"`
+	Patched        bool   `yaml:"patched,omitempty"`
+	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty"`
 	// Use Name to get the name with a default value if it's empty.
 	Name            string                 `yaml:"name,omitempty"`
 	Port            int                    `yaml:"port,omitempty" default:"8262"`
@@ -231,6 +238,11 @@ func (s *WorkerSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *WorkerSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *WorkerSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // UnmarshalYAML sets default values when unmarshaling the topology file

--- a/components/dm/spec/topology_dm.go
+++ b/components/dm/spec/topology_dm.go
@@ -122,7 +122,7 @@ type MasterSpec struct {
 	SSHPort        int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported       bool   `yaml:"imported,omitempty"`
 	Patched        bool   `yaml:"patched,omitempty"`
-	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty" default:"true"`
+	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty"`
 	// Use Name to get the name with a default value if it's empty.
 	Name            string                 `yaml:"name,omitempty"`
 	Port            int                    `yaml:"port,omitempty" default:"8261"`
@@ -190,7 +190,7 @@ type WorkerSpec struct {
 	SSHPort        int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported       bool   `yaml:"imported,omitempty"`
 	Patched        bool   `yaml:"patched,omitempty"`
-	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty" default:"true"`
+	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty"`
 	// Use Name to get the name with a default value if it's empty.
 	Name            string                 `yaml:"name,omitempty"`
 	Port            int                    `yaml:"port,omitempty" default:"8262"`

--- a/components/dm/spec/topology_dm.go
+++ b/components/dm/spec/topology_dm.go
@@ -122,7 +122,7 @@ type MasterSpec struct {
 	SSHPort        int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported       bool   `yaml:"imported,omitempty"`
 	Patched        bool   `yaml:"patched,omitempty"`
-	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty"`
+	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty" default:"true"`
 	// Use Name to get the name with a default value if it's empty.
 	Name            string                 `yaml:"name,omitempty"`
 	Port            int                    `yaml:"port,omitempty" default:"8261"`
@@ -190,7 +190,7 @@ type WorkerSpec struct {
 	SSHPort        int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported       bool   `yaml:"imported,omitempty"`
 	Patched        bool   `yaml:"patched,omitempty"`
-	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty"`
+	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty" default:"true"`
 	// Use Name to get the name with a default value if it's empty.
 	Name            string                 `yaml:"name,omitempty"`
 	Port            int                    `yaml:"port,omitempty" default:"8262"`

--- a/pkg/cluster/manager/builder.go
+++ b/pkg/cluster/manager/builder.go
@@ -279,7 +279,7 @@ func buildScaleOutTask(
 			hasImported = true
 		}
 
-		// log the instance if it marks itself as ignore_exporter
+		// add the instance to ignore list if it marks itself as ignore_exporter
 		if inst.IgnoreMonitorAgent() {
 			noAgentHosts.Insert(inst.GetHost())
 		}
@@ -506,6 +506,7 @@ func buildRefreshMonitoredConfigTasks(
 	specManager *spec.SpecManager,
 	name string,
 	uniqueHosts map[string]hostInfo, // host -> ssh-port, os, arch
+	noAgentHosts set.StringSet,
 	globalOptions spec.GlobalOptions,
 	monitoredOptions *spec.MonitoredOptions,
 	sshTimeout, exeTimeout uint64,
@@ -520,6 +521,10 @@ func buildRefreshMonitoredConfigTasks(
 	// monitoring agents
 	for _, comp := range []string{spec.ComponentNodeExporter, spec.ComponentBlackboxExporter} {
 		for host, info := range uniqueHosts {
+			if noAgentHosts.Exist(host) {
+				continue
+			}
+
 			deployDir := spec.Abs(globalOptions.User, monitoredOptions.DeployDir)
 			// data dir would be empty for components which don't need it
 			dataDir := monitoredOptions.DataDir

--- a/pkg/cluster/manager/cleanup.go
+++ b/pkg/cluster/manager/cleanup.go
@@ -58,6 +58,15 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 		retainDataNodes := set.NewStringSet(cleanOpt.RetainDataNodes...)
 
 		for _, ins := range instances {
+			// not cleaning files of monitor agents if the instance does not have one
+			switch ins.ComponentName() {
+			case spec.ComponentNodeExporter,
+				spec.ComponentBlackboxExporter:
+				if ins.IgnoreMonitorAgent() {
+					continue
+				}
+			}
+
 			// Some data of instances will be retained
 			dataRetained := retainDataRoles.Exist(ins.ComponentName()) ||
 				retainDataNodes.Exist(ins.ID()) || retainDataNodes.Exist(ins.GetHost())

--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -213,7 +213,7 @@ func (m *Manager) Deploy(
 				return // skip the host to avoid issues
 			}
 
-			// log the instance if it marks itself as ignore_exporter
+			// add the instance to ignore list if it marks itself as ignore_exporter
 			if inst.IgnoreMonitorAgent() {
 				noAgentHosts.Insert(inst.GetHost())
 			}

--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -177,6 +177,7 @@ func (m *Manager) Deploy(
 
 	// Initialize environment
 	uniqueHosts := make(map[string]hostInfo) // host -> ssh-port, os, arch
+	noAgentHosts := set.NewStringSet()
 	globalOptions := base.GlobalOptions
 
 	// generate CA and client cert for TLS enabled cluster
@@ -210,6 +211,11 @@ func (m *Manager) Deploy(
 						"for instances imported from tidb-ansible and make no sense when " +
 						"deploying new instances, please delete the line or set it to 'false' for new instances")
 				return // skip the host to avoid issues
+			}
+
+			// log the instance if it marks itself as ignore_exporter
+			if inst.IgnoreMonitorAgent() {
+				noAgentHosts.Insert(inst.GetHost())
 			}
 
 			uniqueHosts[inst.GetHost()] = hostInfo{
@@ -373,6 +379,7 @@ func (m *Manager) Deploy(
 		m,
 		name,
 		uniqueHosts,
+		noAgentHosts,
 		globalOptions,
 		topo.GetMonitoredOptions(),
 		clusterVersion,

--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -76,6 +76,16 @@ func (m *Manager) Upgrade(name string, clusterVersion string, opt operator.Optio
 	for _, comp := range topo.ComponentsByUpdateOrder() {
 		for _, inst := range comp.Instances() {
 			compName := inst.ComponentName()
+
+			// ignore monitor agents for instances marked as ignore_exporter
+			switch compName {
+			case spec.ComponentNodeExporter,
+				spec.ComponentBlackboxExporter:
+				if inst.IgnoreMonitorAgent() {
+					continue
+				}
+			}
+
 			version := m.bindVersion(inst.ComponentName(), clusterVersion)
 
 			// Download component from repository

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -92,9 +92,16 @@ func Destroy(
 func StopAndDestroyInstance(ctx context.Context, cluster spec.Topology, instance spec.Instance, options Options, destroyNode bool) error {
 	ignoreErr := options.Force
 	compName := instance.ComponentName()
+	noAgentHosts := set.NewStringSet()
+
+	cluster.IterInstance(func(inst spec.Instance) {
+		if inst.IgnoreMonitorAgent() {
+			noAgentHosts.Insert(inst.GetHost())
+		}
+	})
 
 	// just try to stop and destroy
-	if err := StopComponent(ctx, []spec.Instance{instance}, options.OptTimeout); err != nil {
+	if err := StopComponent(ctx, []spec.Instance{instance}, noAgentHosts, options.OptTimeout); err != nil {
 		if !ignoreErr {
 			return errors.Annotatef(err, "failed to stop %s", compName)
 		}
@@ -112,7 +119,7 @@ func StopAndDestroyInstance(ctx context.Context, cluster spec.Topology, instance
 		monitoredOptions := cluster.GetMonitoredOptions()
 
 		if monitoredOptions != nil && !instance.IgnoreMonitorAgent() {
-			if err := StopMonitored(ctx, []string{instance.GetHost()}, monitoredOptions, options.OptTimeout); err != nil {
+			if err := StopMonitored(ctx, []string{instance.GetHost()}, noAgentHosts, monitoredOptions, options.OptTimeout); err != nil {
 				if !ignoreErr {
 					return errors.Annotatef(err, "failed to stop monitor")
 				}

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -88,7 +88,7 @@ func Destroy(
 
 // StopAndDestroyInstance stop and destroy the instance,
 // if this instance is the host's last one, and the host has monitor deployed,
-// we need to destroy the monitor, either
+// we need to destroy the monitor, too
 func StopAndDestroyInstance(ctx context.Context, cluster spec.Topology, instance spec.Instance, options Options, destroyNode bool) error {
 	ignoreErr := options.Force
 	compName := instance.ComponentName()
@@ -111,7 +111,7 @@ func StopAndDestroyInstance(ctx context.Context, cluster spec.Topology, instance
 		// monitoredOptions for dm cluster is nil
 		monitoredOptions := cluster.GetMonitoredOptions()
 
-		if monitoredOptions != nil {
+		if monitoredOptions != nil && !instance.IgnoreMonitorAgent() {
 			if err := StopMonitored(ctx, []string{instance.GetHost()}, monitoredOptions, options.OptTimeout); err != nil {
 				if !ignoreErr {
 					return errors.Annotatef(err, "failed to stop monitor")

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -32,6 +32,7 @@ type AlertmanagerSpec struct {
 	SSHPort         int                  `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported        bool                 `yaml:"imported,omitempty"`
 	Patched         bool                 `yaml:"patched,omitempty"`
+	IgnoreExporter  bool                 `yaml:"ignore_exporter,omitempty"`
 	WebPort         int                  `yaml:"web_port" default:"9093"`
 	ClusterPort     int                  `yaml:"cluster_port" default:"9094"`
 	DeployDir       string               `yaml:"deploy_dir,omitempty"`
@@ -62,6 +63,11 @@ func (s *AlertmanagerSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *AlertmanagerSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *AlertmanagerSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // AlertManagerComponent represents Alertmanager component.

--- a/pkg/cluster/spec/cdc.go
+++ b/pkg/cluster/spec/cdc.go
@@ -33,6 +33,7 @@ type CDCSpec struct {
 	SSHPort         int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported        bool                   `yaml:"imported,omitempty"`
 	Patched         bool                   `yaml:"patched,omitempty"`
+	IgnoreExporter  bool                   `yaml:"ignore_exporter,omitempty"`
 	Port            int                    `yaml:"port" default:"8300"`
 	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
 	DataDir         string                 `yaml:"data_dir,omitempty"`
@@ -65,6 +66,11 @@ func (s *CDCSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *CDCSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *CDCSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // CDCComponent represents CDC component.

--- a/pkg/cluster/spec/drainer.go
+++ b/pkg/cluster/spec/drainer.go
@@ -33,6 +33,7 @@ type DrainerSpec struct {
 	SSHPort         int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported        bool                   `yaml:"imported,omitempty"`
 	Patched         bool                   `yaml:"patched,omitempty"`
+	IgnoreExporter  bool                   `yaml:"ignore_exporter,omitempty"`
 	Port            int                    `yaml:"port" default:"8249"`
 	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
 	DataDir         string                 `yaml:"data_dir,omitempty"`
@@ -64,6 +65,11 @@ func (s *DrainerSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *DrainerSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *DrainerSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // DrainerComponent represents Drainer component.

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -35,6 +35,7 @@ type GrafanaSpec struct {
 	SSHPort         int                  `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported        bool                 `yaml:"imported,omitempty"`
 	Patched         bool                 `yaml:"patched,omitempty"`
+	IgnoreExporter  bool                 `yaml:"ignore_exporter,omitempty"`
 	Port            int                  `yaml:"port" default:"3000"`
 	DeployDir       string               `yaml:"deploy_dir,omitempty"`
 	ResourceControl meta.ResourceControl `yaml:"resource_control,omitempty" validate:"resource_control:editable"`
@@ -66,6 +67,11 @@ func (s *GrafanaSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *GrafanaSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *GrafanaSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // GrafanaComponent represents Grafana component.

--- a/pkg/cluster/spec/pd.go
+++ b/pkg/cluster/spec/pd.go
@@ -39,6 +39,7 @@ type PDSpec struct {
 	SSHPort             int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported            bool   `yaml:"imported,omitempty"`
 	Patched             bool   `yaml:"patched,omitempty"`
+	IgnoreExporter      bool   `yaml:"ignore_exporter,omitempty"`
 	// Use Name to get the name with a default value if it's empty.
 	Name            string                 `yaml:"name"`
 	ClientPort      int                    `yaml:"client_port" default:"2379"`
@@ -94,6 +95,11 @@ func (s *PDSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *PDSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *PDSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // PDComponent represents PD component.

--- a/pkg/cluster/spec/prometheus.go
+++ b/pkg/cluster/spec/prometheus.go
@@ -37,6 +37,7 @@ type PrometheusSpec struct {
 	SSHPort               int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported              bool                   `yaml:"imported,omitempty"`
 	Patched               bool                   `yaml:"patched,omitempty"`
+	IgnoreExporter        bool                   `yaml:"ignore_exporter,omitempty"`
 	Port                  int                    `yaml:"port" default:"9090"`
 	DeployDir             string                 `yaml:"deploy_dir,omitempty"`
 	DataDir               string                 `yaml:"data_dir,omitempty"`
@@ -81,6 +82,11 @@ func (s *PrometheusSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *PrometheusSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *PrometheusSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // MonitorComponent represents Monitor component.

--- a/pkg/cluster/spec/pump.go
+++ b/pkg/cluster/spec/pump.go
@@ -32,6 +32,7 @@ type PumpSpec struct {
 	SSHPort         int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported        bool                   `yaml:"imported,omitempty"`
 	Patched         bool                   `yaml:"patched,omitempty"`
+	IgnoreExporter  bool                   `yaml:"ignore_exporter,omitempty"`
 	Port            int                    `yaml:"port" default:"8250"`
 	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
 	DataDir         string                 `yaml:"data_dir,omitempty"`
@@ -62,6 +63,11 @@ func (s *PumpSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *PumpSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *PumpSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // PumpComponent represents Pump component.

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -57,6 +57,7 @@ type (
 		SSH() (string, int)
 		GetMainPort() int
 		IsImported() bool
+		IgnoreMonitorAgent() bool
 	}
 
 	// GlobalOptions represents the global options for all groups in topology

--- a/pkg/cluster/spec/tidb.go
+++ b/pkg/cluster/spec/tidb.go
@@ -34,6 +34,7 @@ type TiDBSpec struct {
 	SSHPort         int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported        bool                   `yaml:"imported,omitempty"`
 	Patched         bool                   `yaml:"patched,omitempty"`
+	IgnoreExporter  bool                   `yaml:"ignore_exporter,omitempty"`
 	Port            int                    `yaml:"port" default:"4000"`
 	StatusPort      int                    `yaml:"status_port" default:"10080"`
 	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
@@ -63,6 +64,11 @@ func (s *TiDBSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *TiDBSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *TiDBSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // TiDBComponent represents TiDB component.

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -42,6 +42,7 @@ type TiFlashSpec struct {
 	SSHPort              int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported             bool                   `yaml:"imported,omitempty"`
 	Patched              bool                   `yaml:"patched,omitempty"`
+	IgnoreExporter       bool                   `yaml:"ignore_exporter,omitempty"`
 	TCPPort              int                    `yaml:"tcp_port" default:"9000"`
 	HTTPPort             int                    `yaml:"http_port" default:"8123"`
 	FlashServicePort     int                    `yaml:"flash_service_port" default:"3930"`
@@ -89,6 +90,11 @@ func (s *TiFlashSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *TiFlashSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *TiFlashSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // key names for storage config

--- a/pkg/cluster/spec/tikv.go
+++ b/pkg/cluster/spec/tikv.go
@@ -50,6 +50,7 @@ type TiKVSpec struct {
 	SSHPort             int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
 	Imported            bool                   `yaml:"imported,omitempty"`
 	Patched             bool                   `yaml:"patched,omitempty"`
+	IgnoreExporter      bool                   `yaml:"ignore_exporter,omitempty"`
 	Port                int                    `yaml:"port" default:"20160"`
 	StatusPort          int                    `yaml:"status_port" default:"20180"`
 	AdvertiseStatusAddr string                 `yaml:"advertise_status_addr,omitempty"`
@@ -109,6 +110,11 @@ func (s *TiKVSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *TiKVSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *TiKVSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // Labels returns the labels of TiKV

--- a/pkg/cluster/spec/tispark.go
+++ b/pkg/cluster/spec/tispark.go
@@ -36,19 +36,20 @@ import (
 
 // TiSparkMasterSpec is the topology specification for TiSpark master node
 type TiSparkMasterSpec struct {
-	Host         string                 `yaml:"host"`
-	ListenHost   string                 `yaml:"listen_host,omitempty"`
-	SSHPort      int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
-	Imported     bool                   `yaml:"imported,omitempty"`
-	Patched      bool                   `yaml:"patched,omitempty"`
-	Port         int                    `yaml:"port" default:"7077"`
-	WebPort      int                    `yaml:"web_port" default:"8080"`
-	DeployDir    string                 `yaml:"deploy_dir,omitempty"`
-	JavaHome     string                 `yaml:"java_home,omitempty" validate:"java_home:editable"`
-	SparkConfigs map[string]interface{} `yaml:"spark_config,omitempty" validate:"spark_config:ignore"`
-	SparkEnvs    map[string]string      `yaml:"spark_env,omitempty" validate:"spark_env:ignore"`
-	Arch         string                 `yaml:"arch,omitempty"`
-	OS           string                 `yaml:"os,omitempty"`
+	Host           string                 `yaml:"host"`
+	ListenHost     string                 `yaml:"listen_host,omitempty"`
+	SSHPort        int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
+	Imported       bool                   `yaml:"imported,omitempty"`
+	Patched        bool                   `yaml:"patched,omitempty"`
+	IgnoreExporter bool                   `yaml:"ignore_exporter,omitempty"`
+	Port           int                    `yaml:"port" default:"7077"`
+	WebPort        int                    `yaml:"web_port" default:"8080"`
+	DeployDir      string                 `yaml:"deploy_dir,omitempty"`
+	JavaHome       string                 `yaml:"java_home,omitempty" validate:"java_home:editable"`
+	SparkConfigs   map[string]interface{} `yaml:"spark_config,omitempty" validate:"spark_config:ignore"`
+	SparkEnvs      map[string]string      `yaml:"spark_env,omitempty" validate:"spark_env:ignore"`
+	Arch           string                 `yaml:"arch,omitempty"`
+	OS             string                 `yaml:"os,omitempty"`
 }
 
 // Role returns the component role of the instance
@@ -71,19 +72,25 @@ func (s *TiSparkMasterSpec) IsImported() bool {
 	return s.Imported
 }
 
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *TiSparkMasterSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
+}
+
 // TiSparkWorkerSpec is the topology specification for TiSpark slave nodes
 type TiSparkWorkerSpec struct {
-	Host       string `yaml:"host"`
-	ListenHost string `yaml:"listen_host,omitempty"`
-	SSHPort    int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
-	Imported   bool   `yaml:"imported,omitempty"`
-	Patched    bool   `yaml:"patched,omitempty"`
-	Port       int    `yaml:"port" default:"7078"`
-	WebPort    int    `yaml:"web_port" default:"8081"`
-	DeployDir  string `yaml:"deploy_dir,omitempty"`
-	JavaHome   string `yaml:"java_home,omitempty" validate:"java_home:editable"`
-	Arch       string `yaml:"arch,omitempty"`
-	OS         string `yaml:"os,omitempty"`
+	Host           string `yaml:"host"`
+	ListenHost     string `yaml:"listen_host,omitempty"`
+	SSHPort        int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
+	Imported       bool   `yaml:"imported,omitempty"`
+	Patched        bool   `yaml:"patched,omitempty"`
+	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty"`
+	Port           int    `yaml:"port" default:"7078"`
+	WebPort        int    `yaml:"web_port" default:"8081"`
+	DeployDir      string `yaml:"deploy_dir,omitempty"`
+	JavaHome       string `yaml:"java_home,omitempty" validate:"java_home:editable"`
+	Arch           string `yaml:"arch,omitempty"`
+	OS             string `yaml:"os,omitempty"`
 }
 
 // Role returns the component role of the instance
@@ -104,6 +111,11 @@ func (s *TiSparkWorkerSpec) GetMainPort() int {
 // IsImported returns if the node is imported from TiDB-Ansible
 func (s *TiSparkWorkerSpec) IsImported() bool {
 	return s.Imported
+}
+
+// IgnoreMonitorAgent returns if the node does not have monitor agents available
+func (s *TiSparkWorkerSpec) IgnoreMonitorAgent() bool {
+	return s.IgnoreExporter
 }
 
 // TiSparkMasterComponent represents TiSpark master component.

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -365,8 +365,8 @@ func CheckClusterPortConflict(clusterList map[string]Metadata, clusterName strin
 				}
 				// if one of the instances marks itself as ignore_exporter, do not report
 				// the monitoring agent ports conflict and just skip
-				if (p1.componentName == RoleMonitor && p1.instance.IgnoreMonitorAgent()) ||
-					(p2.componentName == RoleMonitor && p2.instance.IgnoreMonitorAgent()) {
+				if (p1.componentName == RoleMonitor || p2.componentName == RoleMonitor) &&
+					(p1.instance.IgnoreMonitorAgent() || p2.instance.IgnoreMonitorAgent()) {
 					zap.L().Debug("Ignored deploy port conflict", zap.Any("info", properties))
 					continue
 				}

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -430,6 +430,10 @@ pd_servers:
   - host: 172.16.5.138
     client_port: 2234
     peer_port: 2235
+  - host: 172.16.5.139
+    client_port: 2236
+    peer_port: 2237
+    ignore_exporter: true
 `), &topo2)
 	c.Assert(err, IsNil)
 
@@ -470,6 +474,30 @@ It conflicts to a port in the existing cluster:
   Existing Component:    monitor 172.16.5.138
 
 Please change to use another port or another host.`)
+
+	// monitoring agent port conflict but the instance marked as ignore_exporter
+	topo3 = Specification{}
+	err = yaml.Unmarshal([]byte(`
+tidb_servers:
+- host: 172.16.5.138
+  ignore_exporter: true
+`), &topo3)
+	c.Assert(err, IsNil)
+	err = CheckClusterPortConflict(clsList, "topo", &topo3)
+	c.Assert(err, IsNil)
+
+	// monitoring agent port conflict but the existing instance marked as ignore_exporter
+	topo3 = Specification{}
+	err = yaml.Unmarshal([]byte(`
+monitored:
+  node_exporter_port: 9102
+  blackbox_exporter_port: 9116
+tidb_servers:
+- host: 172.16.5.139
+`), &topo3)
+	c.Assert(err, IsNil)
+	err = CheckClusterPortConflict(clsList, "topo", &topo3)
+	c.Assert(err, IsNil)
 
 	// component port conflict
 	topo4 := Specification{}

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -411,6 +411,30 @@ tispark_masters:
 	c.Assert(err.Error(), Equals, "component tispark is not supported in TLS enabled cluster")
 }
 
+func (s *metaSuiteTopo) TestMonitorAgentValidation(c *C) {
+	topo := Specification{}
+	err := yaml.Unmarshal([]byte(`
+pd_servers:
+  - host: 172.16.5.138
+    port: 1234
+  - host: 172.16.5.139
+    ignore_exporter: true
+`), &topo)
+	c.Assert(err, IsNil)
+
+	topo = Specification{}
+	err = yaml.Unmarshal([]byte(`
+pd_servers:
+  - host: 172.16.5.138
+    port: 1234
+tikv_servers:
+  - host: 172.16.5.138
+    ignore_exporter: true
+`), &topo)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "ignore_exporter mismatch for '172.16.5.138' between 'tikv_servers:true' and 'pd_servers:false'")
+}
+
 func (s *metaSuiteTopo) TestCrossClusterPortConflicts(c *C) {
 	topo1 := Specification{}
 	err := yaml.Unmarshal([]byte(`

--- a/tests/tiup-dm/test_cmd.sh
+++ b/tests/tiup-dm/test_cmd.sh
@@ -17,7 +17,11 @@ mkdir -p ~/.tiup/bin && cp -f ./root.json ~/.tiup/bin/
 tiup-dm --yes deploy $name $version $topo -i ~/.ssh/id_rsa
 
 # topology doesn't contains the section `monitored` will not deploy node_exporter, blackbox_exporter
-! tiup-dm exec $name -N $ipprefix.101 --command "ls /etc/systemd/system/{node,blackbox}_exporter-*.service"
+tiup-dm exec $name -N $ipprefix.101 --command "ls /etc/systemd/system/{node,blackbox}_exporter-*.service" || export has_exporter=1
+if [[ $has_exporter -eq 0 ]]; then
+  echo "monitoring agents should not be deployed for dm cluster if \"monitored\" section is not set."
+  exit 1;
+fi
 tiup-dm list | grep "$name"
 
 # debug https://github.com/pingcap/tiup/issues/666


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If user wants to deploy instances from multiple clusters onto one host, the monitor agents from those clusters may conflict. This PR add an optional flag in instance's spec to indicate that monitor agent is not needed for this cluster on the host. Typically this means there is already an agent deployed by another cluster.

The rendering process of Prometheus config is not changed, so that if there is already an agent, monitoring metrics in Prometheus should be fine.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has interface methods change

Side effects

 - Increased code complexity


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
