### PR TITLE
playground: ignore version check error in some cases

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -678,22 +678,6 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		return fmt.Errorf("all components count must be great than 0 (tikv=%v, pd=%v)", options.TiKV.Num, options.PD.Num)
 	}
 
-	{
-		version, err := env.V1Repository().ResolveComponentVersion(spec.ComponentTiDB, options.Version)
-		if err != nil {
-			return err
-		}
-		fmt.Println(color.YellowString(`Using the version %s for version constraint "%s".
-
-If you'd like to use a TiDB version other than %s, cancel and retry with the following arguments:
-    Specify version manually:   tiup playground <version>
-    Specify version range:      tiup playground ^5
-    The nightly version:        tiup playground nightly
-`, version, options.Version, version))
-
-		options.Version = version.String()
-	}
-
 	if !utils.Version(options.Version).IsNightly() {
 		if semver.Compare(options.Version, "v3.1.0") < 0 && options.TiFlash.Num != 0 {
 			fmt.Println(color.YellowString("Warning: current version %s doesn't support TiFlash", options.Version))


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Introduced in #1325, hopefully fix #1481

### What is changed and how it works?
If the user has any of the `binpath` arguments set, we assume the user is a developer testing their latest code, so use the latest possible version for other components if needed. The version is resolved with `linux-amd64` as platform as it's the platform with every released versions available, and ignore the real platform the user is using. This, however, may cause issue if the user didn't specify `binpath` for **all components** used, and the latest version is not available for those components in the user's platform. In such cases, the user should either specify `binpath` for all the remaining components as well, or set a version that available for those components.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

I have **not** tested this PR as I don't have access to any Apple M1 device, on which the issue is reproducible.

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
