### PR TITLE
Fix telemetry timeout

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -105,7 +106,7 @@ func newMirrorSignCmd() *cobra.Command {
 			}
 
 			if strings.HasPrefix(args[0], "http") {
-				client := utils.NewHTTPClient(time.Duration(timeout)*time.Second, nil)
+				client := utils.NewHTTPClient(context.TODO(), time.Duration(timeout)*time.Second, nil)
 				data, err := client.Get(args[0])
 				if err != nil {
 					return err

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -106,8 +106,8 @@ func newMirrorSignCmd() *cobra.Command {
 			}
 
 			if strings.HasPrefix(args[0], "http") {
-				client := utils.NewHTTPClient(context.TODO(), time.Duration(timeout)*time.Second, nil)
-				data, err := client.Get(args[0])
+				client := utils.NewHTTPClient(time.Duration(timeout)*time.Second, nil)
+				data, err := client.Get(context.TODO(), args[0])
 				if err != nil {
 					return err
 				}
@@ -116,7 +116,7 @@ func newMirrorSignCmd() *cobra.Command {
 					return err
 				}
 
-				if _, err = client.Post(args[0], bytes.NewBuffer(data)); err != nil {
+				if _, err = client.Post(context.TODO(), args[0], bytes.NewBuffer(data)); err != nil {
 					return err
 				}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -242,8 +242,8 @@ func Execute() {
 			tiupReport.ExitCode = int32(code)
 			tiupReport.TakeMilliseconds = uint64(time.Since(start).Milliseconds())
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-			tele := telemetry.NewTelemetry(ctx)
-			err := tele.Report(teleReport)
+			tele := telemetry.NewTelemetry()
+			err := tele.Report(ctx, teleReport)
 			if environment.DebugMode {
 				if err != nil {
 					log.Infof("report failed: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -241,9 +241,9 @@ func Execute() {
 
 			tiupReport.ExitCode = int32(code)
 			tiupReport.TakeMilliseconds = uint64(time.Since(start).Milliseconds())
-			tele := telemetry.NewTelemetry()
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-			err := tele.Report(ctx, teleReport)
+			tele := telemetry.NewTelemetry(ctx)
+			err := tele.Report(teleReport)
 			if environment.DebugMode {
 				if err != nil {
 					log.Infof("report failed: %v", err)

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -325,8 +325,8 @@ func Execute() {
 			clusterReport.TakeMilliseconds = uint64(time.Since(start).Milliseconds())
 			clusterReport.Command = strings.Join(teleCommand, " ")
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-			tele := telemetry.NewTelemetry(ctx)
-			err := tele.Report(teleReport)
+			tele := telemetry.NewTelemetry()
+			err := tele.Report(ctx, teleReport)
 			if environment.DebugMode {
 				if err != nil {
 					log.Infof("report failed: %v", err)

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -324,9 +324,9 @@ func Execute() {
 			}
 			clusterReport.TakeMilliseconds = uint64(time.Since(start).Milliseconds())
 			clusterReport.Command = strings.Join(teleCommand, " ")
-			tele := telemetry.NewTelemetry()
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-			err := tele.Report(ctx, teleReport)
+			tele := telemetry.NewTelemetry(ctx)
+			err := tele.Report(teleReport)
 			if environment.DebugMode {
 				if err != nil {
 					log.Infof("report failed: %v", err)

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -633,8 +633,8 @@ func main() {
 			}
 			playgroundReport.TakeMilliseconds = uint64(time.Since(start).Milliseconds())
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-			tele := telemetry.NewTelemetry(ctx)
-			err := tele.Report(teleReport)
+			tele := telemetry.NewTelemetry()
+			err := tele.Report(ctx, teleReport)
 			if environment.DebugMode {
 				if err != nil {
 					log.Infof("report failed: %v", err)

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -629,9 +629,9 @@ func main() {
 				}
 			}
 			playgroundReport.TakeMilliseconds = uint64(time.Since(start).Milliseconds())
-			tele := telemetry.NewTelemetry()
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-			err := tele.Report(ctx, teleReport)
+			tele := telemetry.NewTelemetry(ctx)
+			err := tele.Report(teleReport)
 			if environment.DebugMode {
 				if err != nil {
 					log.Infof("report failed: %v", err)

--- a/pkg/cluster/api/binlog.go
+++ b/pkg/cluster/api/binlog.go
@@ -47,7 +47,7 @@ func NewBinlogClient(pdEndpoints []string, tlsConfig *tls.Config) (*BinlogClient
 
 	return &BinlogClient{
 		tls:        tlsConfig,
-		httpClient: utils.NewHTTPClient(5*time.Second, tlsConfig).Client(),
+		httpClient: utils.NewHTTPClient(context.TODO(), 5*time.Second, tlsConfig).Client(),
 		etcdClient: etcdClient,
 	}, nil
 }

--- a/pkg/cluster/api/binlog.go
+++ b/pkg/cluster/api/binlog.go
@@ -47,7 +47,7 @@ func NewBinlogClient(pdEndpoints []string, tlsConfig *tls.Config) (*BinlogClient
 
 	return &BinlogClient{
 		tls:        tlsConfig,
-		httpClient: utils.NewHTTPClient(context.TODO(), 5*time.Second, tlsConfig).Client(),
+		httpClient: utils.NewHTTPClient(5*time.Second, tlsConfig).Client(),
 		etcdClient: etcdClient,
 	}, nil
 }

--- a/pkg/cluster/api/dmapi.go
+++ b/pkg/cluster/api/dmapi.go
@@ -54,7 +54,7 @@ func NewDMMasterClient(addrs []string, timeout time.Duration, tlsConfig *tls.Con
 	return &DMMasterClient{
 		addrs:      addrs,
 		tlsEnabled: enableTLS,
-		httpClient: utils.NewHTTPClient(context.TODO(), timeout, tlsConfig),
+		httpClient: utils.NewHTTPClient(timeout, tlsConfig),
 	}
 }
 
@@ -79,7 +79,7 @@ func (dm *DMMasterClient) getEndpoints(cmd string) (endpoints []string) {
 func (dm *DMMasterClient) getMember(endpoints []string) (*dmpb.ListMemberResponse, error) {
 	resp := &dmpb.ListMemberResponse{}
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, err := dm.httpClient.Get(endpoint)
+		body, err := dm.httpClient.Get(context.TODO(), endpoint)
 		if err != nil {
 			return body, err
 		}
@@ -102,7 +102,7 @@ func (dm *DMMasterClient) getMember(endpoints []string) (*dmpb.ListMemberRespons
 func (dm *DMMasterClient) deleteMember(endpoints []string) (*dmpb.OfflineMemberResponse, error) {
 	resp := &dmpb.OfflineMemberResponse{}
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, statusCode, err := dm.httpClient.Delete(endpoint, nil)
+		body, statusCode, err := dm.httpClient.Delete(context.TODO(), endpoint, nil)
 
 		if statusCode == 404 || bytes.Contains(body, []byte("not exists")) {
 			zap.L().Debug("member to offline does not exist, ignore.")

--- a/pkg/cluster/api/dmapi.go
+++ b/pkg/cluster/api/dmapi.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"strings"
@@ -53,7 +54,7 @@ func NewDMMasterClient(addrs []string, timeout time.Duration, tlsConfig *tls.Con
 	return &DMMasterClient{
 		addrs:      addrs,
 		tlsEnabled: enableTLS,
-		httpClient: utils.NewHTTPClient(timeout, tlsConfig),
+		httpClient: utils.NewHTTPClient(context.TODO(), timeout, tlsConfig),
 	}
 }
 

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -52,7 +52,7 @@ func NewPDClient(addrs []string, timeout time.Duration, tlsConfig *tls.Config) *
 	cli := &PDClient{
 		addrs:      addrs,
 		tlsEnabled: enableTLS,
-		httpClient: utils.NewHTTPClient(context.TODO(), timeout, tlsConfig),
+		httpClient: utils.NewHTTPClient(timeout, tlsConfig),
 	}
 
 	cli.tryIdentifyVersion()
@@ -63,7 +63,7 @@ func (pc *PDClient) tryIdentifyVersion() {
 	endpoints := pc.getEndpoints(pdVersionURI)
 	response := map[string]string{}
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, err := pc.httpClient.Get(endpoint)
+		body, err := pc.httpClient.Get(context.TODO(), endpoint)
 		if err != nil {
 			return body, err
 		}
@@ -151,7 +151,7 @@ func (pc *PDClient) CheckHealth() error {
 	endpoints := pc.getEndpoints(pdPingURI)
 
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, err := pc.httpClient.Get(endpoint)
+		body, err := pc.httpClient.Get(context.TODO(), endpoint)
 		if err != nil {
 			return body, err
 		}
@@ -175,7 +175,7 @@ func (pc *PDClient) GetStores() (*StoresInfo, error) {
 	storesInfo := StoresInfo{}
 
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, err := pc.httpClient.Get(endpoint)
+		body, err := pc.httpClient.Get(context.TODO(), endpoint)
 		if err != nil {
 			return body, err
 		}
@@ -268,7 +268,7 @@ func (pc *PDClient) GetLeader() (*pdpb.Member, error) {
 	leader := pdpb.Member{}
 
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, err := pc.httpClient.Get(endpoint)
+		body, err := pc.httpClient.Get(context.TODO(), endpoint)
 		if err != nil {
 			return body, err
 		}
@@ -289,7 +289,7 @@ func (pc *PDClient) GetMembers() (*pdpb.GetMembersResponse, error) {
 	members := pdpb.GetMembersResponse{}
 
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, err := pc.httpClient.Get(endpoint)
+		body, err := pc.httpClient.Get(context.TODO(), endpoint)
 		if err != nil {
 			return body, err
 		}
@@ -313,7 +313,7 @@ func (pc *PDClient) GetConfig() (map[string]interface{}, error) {
 	pdConfig := map[string]interface{}{}
 
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, err := pc.httpClient.Get(endpoint)
+		body, err := pc.httpClient.Get(context.TODO(), endpoint)
 		if err != nil {
 			return body, err
 		}
@@ -359,7 +359,7 @@ func (pc *PDClient) EvictPDLeader(retryOpt *utils.RetryOption) error {
 	endpoints := pc.getEndpoints(cmd)
 
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, err := pc.httpClient.Post(endpoint, nil)
+		body, err := pc.httpClient.Post(context.TODO(), endpoint, nil)
 		if err != nil {
 			return body, err
 		}
@@ -439,7 +439,7 @@ func (pc *PDClient) EvictStoreLeader(host string, retryOpt *utils.RetryOption, c
 	endpoints := pc.getEndpoints(pdSchedulersURI)
 
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		return pc.httpClient.Post(endpoint, bytes.NewBuffer(scheduler))
+		return pc.httpClient.Post(context.TODO(), endpoint, bytes.NewBuffer(scheduler))
 	})
 	if err != nil {
 		return err
@@ -499,7 +499,7 @@ func (pc *PDClient) RemoveStoreEvict(host string) error {
 	endpoints := pc.getEndpoints(cmd)
 
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, statusCode, err := pc.httpClient.Delete(endpoint, nil)
+		body, statusCode, err := pc.httpClient.Delete(context.TODO(), endpoint, nil)
 		if err != nil {
 			if statusCode == http.StatusNotFound || bytes.Contains(body, []byte("scheduler not found")) {
 				log.Debugf("Store leader evicting scheduler does not exist, ignore.")
@@ -534,7 +534,7 @@ func (pc *PDClient) DelPD(name string, retryOpt *utils.RetryOption) error {
 	endpoints := pc.getEndpoints(cmd)
 
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, statusCode, err := pc.httpClient.Delete(endpoint, nil)
+		body, statusCode, err := pc.httpClient.Delete(context.TODO(), endpoint, nil)
 		if err != nil {
 			if statusCode == http.StatusNotFound || bytes.Contains(body, []byte("not found, pd")) {
 				log.Debugf("PD node does not exist, ignore: %s", body)
@@ -621,7 +621,7 @@ func (pc *PDClient) DelStore(host string, retryOpt *utils.RetryOption) error {
 	endpoints := pc.getEndpoints(cmd)
 
 	_, err = tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, statusCode, err := pc.httpClient.Delete(endpoint, nil)
+		body, statusCode, err := pc.httpClient.Delete(context.TODO(), endpoint, nil)
 		if err != nil {
 			if statusCode == http.StatusNotFound || bytes.Contains(body, []byte("not found")) {
 				log.Debugf("store %d %s does not exist, ignore: %s", storeID, host, body)
@@ -674,7 +674,7 @@ func (pc *PDClient) DelStore(host string, retryOpt *utils.RetryOption) error {
 func (pc *PDClient) updateConfig(url string, body io.Reader) error {
 	endpoints := pc.getEndpoints(url)
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		return pc.httpClient.Post(endpoint, body)
+		return pc.httpClient.Post(context.TODO(), endpoint, body)
 	})
 	return err
 }
@@ -688,7 +688,7 @@ func (pc *PDClient) UpdateReplicateConfig(body io.Reader) error {
 func (pc *PDClient) GetReplicateConfig() ([]byte, error) {
 	endpoints := pc.getEndpoints(pdConfigReplicate)
 	return tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		return pc.httpClient.Get(endpoint)
+		return pc.httpClient.Get(context.TODO(), endpoint)
 	})
 }
 
@@ -745,7 +745,7 @@ func (pc *PDClient) CheckRegion(state string) (*RegionsInfo, error) {
 	regionsInfo := RegionsInfo{}
 
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {
-		body, err := pc.httpClient.Get(endpoint)
+		body, err := pc.httpClient.Get(context.TODO(), endpoint)
 		if err != nil {
 			return body, err
 		}

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -51,7 +52,7 @@ func NewPDClient(addrs []string, timeout time.Duration, tlsConfig *tls.Config) *
 	cli := &PDClient{
 		addrs:      addrs,
 		tlsEnabled: enableTLS,
-		httpClient: utils.NewHTTPClient(timeout, tlsConfig),
+		httpClient: utils.NewHTTPClient(context.TODO(), timeout, tlsConfig),
 	}
 
 	cli.tryIdentifyVersion()

--- a/pkg/cluster/spec/util.go
+++ b/pkg/cluster/spec/util.go
@@ -125,7 +125,7 @@ func LoadClientCert(dir string) (*tls.Config, error) {
 
 // statusByHost queries current status of the instance by http status api.
 func statusByHost(host string, port int, path string, tlsCfg *tls.Config) string {
-	client := utils.NewHTTPClient(context.TODO(), statusQueryTimeout, tlsCfg)
+	client := utils.NewHTTPClient(statusQueryTimeout, tlsCfg)
 
 	scheme := "http"
 	if tlsCfg != nil {
@@ -137,7 +137,7 @@ func statusByHost(host string, port int, path string, tlsCfg *tls.Config) string
 	url := fmt.Sprintf("%s://%s:%d%s", scheme, host, port, path)
 
 	// body doesn't have any status section needed
-	body, err := client.Get(url)
+	body, err := client.Get(context.TODO(), url)
 	if err != nil || body == nil {
 		return "Down"
 	}
@@ -152,9 +152,9 @@ func UptimeByHost(host string, port int, tlsCfg *tls.Config) time.Duration {
 	}
 	url := fmt.Sprintf("%s://%s:%d/metrics", scheme, host, port)
 
-	client := utils.NewHTTPClient(context.TODO(), statusQueryTimeout, tlsCfg)
+	client := utils.NewHTTPClient(statusQueryTimeout, tlsCfg)
 
-	body, err := client.Get(url)
+	body, err := client.Get(context.TODO(), url)
 	if err != nil || body == nil {
 		return 0
 	}

--- a/pkg/cluster/spec/util.go
+++ b/pkg/cluster/spec/util.go
@@ -15,6 +15,7 @@ package spec
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"path/filepath"
@@ -124,7 +125,7 @@ func LoadClientCert(dir string) (*tls.Config, error) {
 
 // statusByHost queries current status of the instance by http status api.
 func statusByHost(host string, port int, path string, tlsCfg *tls.Config) string {
-	client := utils.NewHTTPClient(statusQueryTimeout, tlsCfg)
+	client := utils.NewHTTPClient(context.TODO(), statusQueryTimeout, tlsCfg)
 
 	scheme := "http"
 	if tlsCfg != nil {
@@ -151,7 +152,7 @@ func UptimeByHost(host string, port int, tlsCfg *tls.Config) time.Duration {
 	}
 	url := fmt.Sprintf("%s://%s:%d/metrics", scheme, host, port)
 
-	client := utils.NewHTTPClient(statusQueryTimeout, tlsCfg)
+	client := utils.NewHTTPClient(context.TODO(), statusQueryTimeout, tlsCfg)
 
 	body, err := client.Get(url)
 	if err != nil || body == nil {

--- a/pkg/cluster/template/install/local_install.sh.go
+++ b/pkg/cluster/template/install/local_install.sh.go
@@ -83,6 +83,10 @@ fi
 
 chmod 755 "$bin_dir/tiup"
 
+# telemetry is not needed for offline installations
+"$bin_dir/tiup" telemetry disable
+
+# set mirror to the local path
 "$bin_dir/tiup" mirror set ${script_dir}
 
 bold=$(tput bold 2>/dev/null)

--- a/pkg/repository/store/txn.go
+++ b/pkg/repository/store/txn.go
@@ -161,8 +161,8 @@ func (t *localTxn) ReadManifest(filename string, role v1manifest.ValidManifest) 
 		defer file.Close()
 	case os.IsNotExist(err) && t.store.upstream != "":
 		url := fmt.Sprintf("%s/%s", t.store.upstream, filename)
-		client := utils.NewHTTPClient(context.TODO(), time.Minute, nil)
-		body, err := client.Get(url)
+		client := utils.NewHTTPClient(time.Minute, nil)
+		body, err := client.Get(context.TODO(), url)
 		if err != nil {
 			return nil, errors.Annotatef(err, "fetch %s", url)
 		}

--- a/pkg/repository/store/txn.go
+++ b/pkg/repository/store/txn.go
@@ -15,6 +15,7 @@ package store
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -160,7 +161,7 @@ func (t *localTxn) ReadManifest(filename string, role v1manifest.ValidManifest) 
 		defer file.Close()
 	case os.IsNotExist(err) && t.store.upstream != "":
 		url := fmt.Sprintf("%s/%s", t.store.upstream, filename)
-		client := utils.NewHTTPClient(time.Minute, nil)
+		client := utils.NewHTTPClient(context.TODO(), time.Minute, nil)
 		body, err := client.Get(url)
 		if err != nil {
 			return nil, errors.Annotatef(err, "fetch %s", url)

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -32,8 +32,8 @@ type Telemetry struct {
 }
 
 // NewTelemetry return a new Telemetry instance.
-func NewTelemetry(ctx context.Context) *Telemetry {
-	cli := utils.NewHTTPClient(ctx, time.Second*10, nil)
+func NewTelemetry() *Telemetry {
+	cli := utils.NewHTTPClient(time.Second*10, nil)
 
 	return &Telemetry{
 		url: defaultURL,
@@ -42,13 +42,13 @@ func NewTelemetry(ctx context.Context) *Telemetry {
 }
 
 // Report report the msg right away.
-func (t *Telemetry) Report(msg *Report) error {
+func (t *Telemetry) Report(ctx context.Context, msg *Report) error {
 	dst, err := json.Marshal(msg)
 	if err != nil {
 		return errors.AddStack(err)
 	}
 
-	if _, err = t.cli.Post(t.url, bytes.NewReader(dst)); err != nil {
+	if _, err = t.cli.Post(ctx, t.url, bytes.NewReader(dst)); err != nil {
 		return errors.AddStack(err)
 	}
 

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -32,8 +32,8 @@ type Telemetry struct {
 }
 
 // NewTelemetry return a new Telemetry instance.
-func NewTelemetry() *Telemetry {
-	cli := utils.NewHTTPClient(time.Second*10, nil)
+func NewTelemetry(ctx context.Context) *Telemetry {
+	cli := utils.NewHTTPClient(ctx, time.Second*10, nil)
 
 	return &Telemetry{
 		url: defaultURL,
@@ -42,7 +42,7 @@ func NewTelemetry() *Telemetry {
 }
 
 // Report report the msg right away.
-func (t *Telemetry) Report(ctx context.Context, msg *Report) error {
+func (t *Telemetry) Report(msg *Report) error {
 	dst, err := json.Marshal(msg)
 	if err != nil {
 		return errors.AddStack(err)

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -55,17 +55,17 @@ func (s *TelemetrySuite) TestReport(c *check.C) {
 
 	defer ts.Close()
 
-	tele := NewTelemetry()
+	tele := NewTelemetry(context.TODO())
 	tele.cli = &utils.HTTPClient{}
 	tele.cli.WithClient(ts.Client())
 	tele.url = ts.URL
 
 	msg := new(Report)
 
-	err := tele.Report(context.Background(), msg)
+	err := tele.Report(msg)
 	c.Assert(err, check.NotNil)
 
 	msg.EventUUID = "dfdfdf"
-	err = tele.Report(context.Background(), msg)
+	err = tele.Report(msg)
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -55,17 +55,17 @@ func (s *TelemetrySuite) TestReport(c *check.C) {
 
 	defer ts.Close()
 
-	tele := NewTelemetry(context.TODO())
+	tele := NewTelemetry()
 	tele.cli = &utils.HTTPClient{}
 	tele.cli.WithClient(ts.Client())
 	tele.url = ts.URL
 
 	msg := new(Report)
 
-	err := tele.Report(msg)
+	err := tele.Report(context.TODO(), msg)
 	c.Assert(err, check.NotNil)
 
 	msg.EventUUID = "dfdfdf"
-	err = tele.Report(msg)
+	err = tele.Report(context.TODO(), msg)
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/utils/http_client.go
+++ b/pkg/utils/http_client.go
@@ -28,11 +28,10 @@ import (
 // HTTPClient is a wrap of http.Client
 type HTTPClient struct {
 	client *http.Client
-	ctx    context.Context
 }
 
 // NewHTTPClient returns a new HTTP client with timeout and HTTPS support
-func NewHTTPClient(ctx context.Context, timeout time.Duration, tlsConfig *tls.Config) *HTTPClient {
+func NewHTTPClient(timeout time.Duration, tlsConfig *tls.Config) *HTTPClient {
 	if timeout < time.Second {
 		timeout = 10 * time.Second // default timeout is 10s
 	}
@@ -55,19 +54,18 @@ func NewHTTPClient(ctx context.Context, timeout time.Duration, tlsConfig *tls.Co
 			Timeout:   timeout,
 			Transport: tr,
 		},
-		ctx: ctx,
 	}
 }
 
 // Get fetch an URL with GET method and returns the response
-func (c *HTTPClient) Get(url string) ([]byte, error) {
+func (c *HTTPClient) Get(ctx context.Context, url string) ([]byte, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if c.ctx != nil {
-		req = req.WithContext(c.ctx)
+	if ctx != nil {
+		req = req.WithContext(ctx)
 	}
 	res, err := c.client.Do(req)
 	if err != nil {
@@ -79,15 +77,15 @@ func (c *HTTPClient) Get(url string) ([]byte, error) {
 }
 
 // Post send a POST request to the url and returns the response
-func (c *HTTPClient) Post(url string, body io.Reader) ([]byte, error) {
+func (c *HTTPClient) Post(ctx context.Context, url string, body io.Reader) ([]byte, error) {
 	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	if c.ctx != nil {
-		req = req.WithContext(c.ctx)
+	if ctx != nil {
+		req = req.WithContext(ctx)
 	}
 	res, err := c.client.Do(req)
 	if err != nil {
@@ -99,15 +97,15 @@ func (c *HTTPClient) Post(url string, body io.Reader) ([]byte, error) {
 }
 
 // Delete send a DELETE request to the url and returns the response and status code.
-func (c *HTTPClient) Delete(url string, body io.Reader) ([]byte, int, error) {
+func (c *HTTPClient) Delete(ctx context.Context, url string, body io.Reader) ([]byte, int, error) {
 	var statusCode int
 	req, err := http.NewRequest("DELETE", url, body)
 	if err != nil {
 		return nil, statusCode, err
 	}
 
-	if c.ctx != nil {
-		req = req.WithContext(c.ctx)
+	if ctx != nil {
+		req = req.WithContext(ctx)
 	}
 	res, err := c.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The timeout setting (hard coded 2s) was not taking affect. It was introduced in #1327 

### What is changed and how it works?
- Disable telemetry in `local_install.sh` as offline installations does not need telemetry at all (they typically don't have access to the Internet)
- Add support of context in the `HTTPClient` in `utils` to handle timeout correctly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
