### PR TITLE
playground: Set terminal title

### DIFF
--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -595,6 +595,9 @@ func newEtcdClient(endpoint string) (*clientv3.Client, error) {
 }
 
 func main() {
+	dataDir := os.Getenv(localdata.EnvNameInstanceDataDir)
+	instanceName := dataDir[strings.LastIndex(dataDir, "/")+1:]
+	fmt.Printf("\033]0;TiUP Playground: %s\a", instanceName)
 	start := time.Now()
 	code := 0
 	err := execute()


### PR DESCRIPTION
### What problem does this PR solve?

This sets the terminal title to "TiUP Playground: <name>" where name
is the last part of the datadir. With `tiup -T foobar playground` etc.
this name can be set. Also `tiup client` uses the same names.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)





Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
TiUP Playground now sets the terminal title to the name of the playground
```
