### PR TITLE
ignore exporters when check data_dir overlap

### DIFF
--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -227,11 +227,19 @@ func CheckClusterDirOverlap(entries []DirEntry) error {
 				if d1.instance.IsImported() && d2.instance.IsImported() {
 					continue
 				}
-				// overlap is alloed in the case one side is imported and the other is monitor,
+				// overlap is allowed in the case one side is imported and the other is monitor,
 				// we assume that the monitor is deployed with the first instance in that host,
 				// it implies that the monitor is imported too.
 				if (strings.HasPrefix(d1.dirKind, "monitor") && d2.instance.IsImported()) ||
 					(d1.instance.IsImported() && strings.HasPrefix(d2.dirKind, "monitor")) {
+					continue
+				}
+
+				// overlap is allowed in the case one side is data dir of a monitor instance,
+				// as the *_exporter don't need data dir, the field is only kept for compatiability
+				// with legacy tidb-ansible deployments.
+				if (strings.HasPrefix(d1.dirKind, "monitor data directory")) ||
+					(strings.HasPrefix(d2.dirKind, "monitor data directory")) {
 					continue
 				}
 

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -1046,6 +1046,32 @@ tikv_servers:
     log_dir: "/home/tidb6wu/tidb1-data/tikv-32160-log"
     data_dir: "/home/tidb6wu/tidb1-data/tikv-32160"
 `,
+		`
+monitored:
+  node_exporter_port: 9100
+  blackbox_exporter_port: 9115
+  deploy_dir: /data/deploy/monitor-9100
+  data_dir: /data/deploy/monitor-9100
+  log_dir: /data/deploy/monitor-9100/log
+pd_servers:
+  - host: n0
+    name: pd0
+    imported: true
+    deploy_dir: /data/deploy
+    data_dir: /data/deploy/data.pd
+    log_dir: /data/deploy/log
+  - host: n1
+    name: pd1
+    log_dir: "/data/deploy/pd-2379/log"
+    data_dir: "/data/pd-2379"
+    deploy_dir: "/data/deploy/pd-2379"
+cdc_servers:
+  - host: n1
+    port: 8300
+    deploy_dir: /data/deploy/ticdc-8300
+    data_dir: /data1/ticdc-8300
+    log_dir: /data/deploy/ticdc-8300/log
+`,
 	}
 	for _, s := range goodTopos {
 		err = yaml.Unmarshal([]byte(s), &topo)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When user scale out new instance on a host where an imported instance already exist, and the global options set monitor paths to where the imported instance is located (and the log dir overlaps with data dir), the dir overlap check fails.

### What is changed and how it works?
Ignore log dir overlapping if one of the compared dir is data dir of a monitor instance, as node_exporter and blackbox_exporter don't need data dir at all, the field is only kept for compatibility with tidb-ansible as the field was available there.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: ignore exporters when check data_dir overlap
```
