### PR TITLE
cluster: skip updating topology when reload with --skip-restart

### DIFF
--- a/pkg/cluster/manager/reload.go
+++ b/pkg/cluster/manager/reload.go
@@ -103,7 +103,7 @@ func (m *Manager) Reload(name string, gOpt operator.Options, skipRestart, skipCo
 	if err != nil {
 		return err
 	}
-	if topo.Type() == spec.TopoTypeTiDB {
+	if topo.Type() == spec.TopoTypeTiDB && !skipRestart {
 		b.UpdateTopology(
 			name,
 			m.specManager.Path(name),
@@ -117,11 +117,11 @@ func (m *Manager) Reload(name string, gOpt operator.Options, skipRestart, skipCo
 		b.ParallelStep("+ Refresh monitor configs", gOpt.Force, monitorConfigTasks...)
 	}
 
-	tlsCfg, err := topo.TLSConfig(m.specManager.Path(name, spec.TLSCertKeyDir))
-	if err != nil {
-		return err
-	}
 	if !skipRestart {
+		tlsCfg, err := topo.TLSConfig(m.specManager.Path(name, spec.TLSCertKeyDir))
+		if err != nil {
+			return err
+		}
 		b.Func("UpgradeCluster", func(ctx context.Context) error {
 			return operator.Upgrade(ctx, topo, gOpt, tlsCfg)
 		})


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1507 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
