### PR TITLE
Use absolute path for sudo command #1515

### DIFF
--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -74,8 +74,8 @@ var (
 )
 
 const (
-	mode        = "mode"
-	withMonitor = "monitor"
+	mode           = "mode"
+	withMonitor    = "monitor"
 	withoutMonitor = "without-monitor"
 
 	// instance numbers

--- a/pkg/cluster/executor/local.go
+++ b/pkg/cluster/executor/local.go
@@ -43,9 +43,9 @@ var _ ctxt.Executor = &Local{}
 func (l *Local) Execute(ctx context.Context, cmd string, sudo bool, timeout ...time.Duration) ([]byte, []byte, error) {
 	// try to acquire root permission
 	if l.Sudo || sudo {
-		cmd = fmt.Sprintf("sudo -H -u root bash -c 'cd; %s'", cmd)
+		cmd = fmt.Sprintf("/usr/bin/sudo -H -u root bash -c 'cd; %s'", cmd)
 	} else {
-		cmd = fmt.Sprintf("sudo -H -u %s bash -c 'cd; %s'", l.Config.User, cmd)
+		cmd = fmt.Sprintf("/usr/bin/sudo -H -u %s bash -c 'cd; %s'", l.Config.User, cmd)
 	}
 
 	// set a basic PATH in case it's empty on login
@@ -114,7 +114,7 @@ func (l *Local) Transfer(ctx context.Context, src, dst string, download bool, li
 	if download || user.Username == l.Config.User {
 		cmd = fmt.Sprintf("cp %s %s", src, dst)
 	} else {
-		cmd = fmt.Sprintf("sudo -H -u root bash -c \"cp %[1]s %[2]s && chown %[3]s:$(id -g -n %[3]s) %[2]s\"", src, dst, l.Config.User)
+		cmd = fmt.Sprintf("/usr/bin/sudo -H -u root bash -c \"cp %[1]s %[2]s && chown %[3]s:$(id -g -n %[3]s) %[2]s\"", src, dst, l.Config.User)
 	}
 
 	command := exec.Command("/bin/sh", "-c", cmd)

--- a/pkg/cluster/executor/ssh.go
+++ b/pkg/cluster/executor/ssh.go
@@ -139,7 +139,7 @@ func (e *EasySSHExecutor) initialize(config SSHConfig) {
 func (e *EasySSHExecutor) Execute(ctx context.Context, cmd string, sudo bool, timeout ...time.Duration) ([]byte, []byte, error) {
 	// try to acquire root permission
 	if e.Sudo || sudo {
-		cmd = fmt.Sprintf("sudo -H bash -c \"%s\"", cmd)
+		cmd = fmt.Sprintf("/usr/bin/sudo -H bash -c \"%s\"", cmd)
 	}
 
 	// set a basic PATH in case it's empty on login
@@ -276,7 +276,7 @@ func (e *NativeSSHExecutor) Execute(ctx context.Context, cmd string, sudo bool, 
 
 	// try to acquire root permission
 	if e.Sudo || sudo {
-		cmd = fmt.Sprintf("sudo -H bash -c \"%s\"", cmd)
+		cmd = fmt.Sprintf("/usr/bin/sudo -H bash -c \"%s\"", cmd)
 	}
 
 	// set a basic PATH in case it's empty on login

--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -831,7 +831,7 @@ func CheckDirPermission(ctx context.Context, e ctxt.Executor, user, path string)
 
 	_, stderr, err := e.Execute(ctx,
 		fmt.Sprintf(
-			"sudo -u %[1]s touch %[2]s/.tiup_cluster_check_file && rm -f %[2]s/.tiup_cluster_check_file",
+			"/usr/bin/sudo -u %[1]s touch %[2]s/.tiup_cluster_check_file && rm -f %[2]s/.tiup_cluster_check_file",
 			user,
 			path,
 		),


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

sudo error when use devtoolset
```
[root@ip-172-16-5-33 ~]# /opt/rh/devtoolset-8/root/usr/bin/sudo -l
/var/tmp/sclk5fzvz: line 8: -l: command not found
```

fix: #1515 

### What is changed and how it works?

use `/usr/bin/sudo` insted of `sudo`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
