### PR TITLE
Add some desc when execute `tiup-cluster restart`

### DIFF
--- a/pkg/cluster/manager/basic.go
+++ b/pkg/cluster/manager/basic.go
@@ -192,7 +192,7 @@ func (m *Manager) RestartCluster(name string, gOpt operator.Options, skipConfirm
 
 	if !skipConfirm {
 		if err := tui.PromptForConfirmOrAbortError(
-			fmt.Sprintf("Will restart the cluster %s with nodes: %s roles: %s.\nDo you want to continue? [y/N]:",
+			fmt.Sprintf("Will restart the cluster %s with nodes: %s roles: %s.\nCluster will be unavailable\nDo you want to continue? [y/N]:",
 				color.HiYellowString(name),
 				color.HiYellowString(strings.Join(gOpt.Nodes, ",")),
 				color.HiYellowString(strings.Join(gOpt.Roles, ",")),


### PR DESCRIPTION
Add a warning description when the cluster restarts
Help understand the impact of restart,

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has persistent data change

Side effects

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
