### PR TITLE
tests: fix CI tests

### DIFF
--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.16-bullseye
 
 
 # Use mirrors for poor network...

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,5 +1,5 @@
 # Based on the deprecated `https://github.com/tutumcloud/tutum-debian`
-FROM golang:1.16
+FROM golang:1.16-bullseye
 
 # Use mirrors for poor network...
 #RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list && \

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
         openssh-server \
         openjdk-11-jre-headless \
         sudo vim \
+        iproute2 \
         && \
     mkdir -p /var/run/sshd && \
     sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && \

--- a/pkg/cluster/executor/local.go
+++ b/pkg/cluster/executor/local.go
@@ -49,7 +49,7 @@ func (l *Local) Execute(ctx context.Context, cmd string, sudo bool, timeout ...t
 	}
 
 	// set a basic PATH in case it's empty on login
-	cmd = fmt.Sprintf("PATH=$PATH:/usr/bin:/usr/sbin %s", cmd)
+	cmd = fmt.Sprintf("PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin %s", cmd)
 
 	if l.Locale != "" {
 		cmd = fmt.Sprintf("export LANG=%s; %s", l.Locale, cmd)

--- a/pkg/cluster/executor/ssh.go
+++ b/pkg/cluster/executor/ssh.go
@@ -143,7 +143,7 @@ func (e *EasySSHExecutor) Execute(ctx context.Context, cmd string, sudo bool, ti
 	}
 
 	// set a basic PATH in case it's empty on login
-	cmd = fmt.Sprintf("PATH=$PATH:/usr/bin:/usr/sbin %s", cmd)
+	cmd = fmt.Sprintf("PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin %s", cmd)
 
 	if e.Locale != "" {
 		cmd = fmt.Sprintf("export LANG=%s; %s", e.Locale, cmd)
@@ -280,7 +280,7 @@ func (e *NativeSSHExecutor) Execute(ctx context.Context, cmd string, sudo bool, 
 	}
 
 	// set a basic PATH in case it's empty on login
-	cmd = fmt.Sprintf("PATH=$PATH:/usr/bin:/usr/sbin %s", cmd)
+	cmd = fmt.Sprintf("PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin %s", cmd)
 
 	if e.Locale != "" {
 		cmd = fmt.Sprintf("export LANG=%s; %s", e.Locale, cmd)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In `golang:1.16` (the image we use to build node container in Github Actions), `ss` command seems not installed by default anymore.

### What is changed and how it works?
- Add `/bin` and `/sbin` to the `PATH` when running commands.
- Install `iproute2` in docker images

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
