### PR TITLE
cluster: reverse the order of audit log list

### DIFF
--- a/pkg/cluster/audit/audit.go
+++ b/pkg/cluster/audit/audit.go
@@ -132,7 +132,7 @@ func GetAuditList(dir string) ([]Item, error) {
 	}
 
 	sort.Slice(auditList, func(i, j int) bool {
-		return auditList[i].Time > auditList[j].Time
+		return auditList[i].Time < auditList[j].Time
 	})
 
 	return auditList, nil

--- a/pkg/cluster/audit/audit_test.go
+++ b/pkg/cluster/audit/audit_test.go
@@ -118,11 +118,11 @@ func (s *testAuditSuite) TestShowAuditLog(c *C) {
 	// tabby table size is based on column width, while time.RFC3339 maybe print out timezone like +08:00 or Z(UTC)
 	// skip the first two lines
 	list := strings.Join(strings.Split(readFakeStdout(f), "\n")[2:], "\n")
-	c.Assert(list, Equals, fmt.Sprintf(`ftmpqzww84Q  %s  test with nanosecond
-4F7ZTL       %s  test with second
+	c.Assert(list, Equals, fmt.Sprintf(`4F7ZTL       %s  test with second
+ftmpqzww84Q  %s  test with nanosecond
 `,
-		time.Unix(nanoSecond/1e9, 0).Format(time.RFC3339),
 		time.Unix(second, 0).Format(time.RFC3339),
+		time.Unix(nanoSecond/1e9, 0).Format(time.RFC3339),
 	))
 	f.Close()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1525 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
