### PR TITLE
cluster: upgrade tikv first then cdc

### DIFF
--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -661,14 +661,14 @@ func (s *Specification) ComponentsByStartOrder() (comps []Component) {
 
 // ComponentsByUpdateOrder return component in the order need to be updated.
 func (s *Specification) ComponentsByUpdateOrder() (comps []Component) {
-	// "tiflash", "cdc", "pd", "tikv", "pump", "tidb", "drainer", "prometheus", "grafana", "alertmanager"
+	// "tiflash", "pd", "tikv", "pump", "tidb", "drainer", "cdc", "prometheus", "grafana", "alertmanager"
 	comps = append(comps, &TiFlashComponent{s})
-	comps = append(comps, &CDCComponent{s})
 	comps = append(comps, &PDComponent{s})
 	comps = append(comps, &TiKVComponent{s})
 	comps = append(comps, &PumpComponent{s})
 	comps = append(comps, &TiDBComponent{s})
 	comps = append(comps, &DrainerComponent{s})
+	comps = append(comps, &CDCComponent{s})
 	comps = append(comps, &MonitorComponent{s})
 	comps = append(comps, &GrafanaComponent{s})
 	comps = append(comps, &AlertManagerComponent{s})


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Upgrade tikv first then cdc, to be compatible with v5.2.0 TiCDC.

### What is changed and how it works?

Change upgrade order.

### Check List <!--REMOVE the items that are not applicable-->


 - Manual test (add detailed scripts or steps below)

```
# deploy and start cdc cluster v5.0.3
tiup cluster deploy cdc-cluster1 v5.0.3 top1.1kv.yml -y && tiup cluster start cdc-cluster1 -y
# upgrade cdc cluster to v5.2.0
./tiup-cluster upgrade cdc-cluster1 5.2.0 -y
...
+ [ Serial ] - UpgradeCluster
Upgrading component pd
        Restarting instance 172.16.5.33:47902
        Restart instance 172.16.5.33:47902 success
Upgrading component tikv
        Restarting instance 172.16.5.33:47906
        Restart instance 172.16.5.33:47906 success
Upgrading component tidb
        Restarting instance 172.16.5.33:47904
        Restart instance 172.16.5.33:47904 success
Upgrading component cdc
        Restarting instance 172.16.5.33:47913
        Restart instance 172.16.5.33:47913 success
Upgrading component prometheus
        Restarting instance 172.16.5.33:47908
        Restart instance 172.16.5.33:47908 success
Upgrading component grafana
        Restarting instance 172.16.5.33:47909
        Restart instance 172.16.5.33:47909 success
Upgrading component alertmanager
        Restarting instance 172.16.5.33:47910
        Restart instance 172.16.5.33:47910 success
Upgraded cluster `cdc-cluster1` successfully
```

Release notes:

```release-note
Fix TiCDC v5.2.0 upgrade failure.
```
