### PR TITLE
use stdout on update and verbose information

### DIFF
--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -59,7 +59,7 @@ func RunComponent(env *environment.Environment, tag, spec, binPath string, args 
 		}
 	}
 	if err != nil {
-		fmt.Printf("Failed to start component `%s`\n", component)
+		fmt.Fprintf(os.Stderr, "Failed to start component `%s`\n", component)
 		return err
 	}
 
@@ -77,7 +77,7 @@ func RunComponent(env *environment.Environment, tag, spec, binPath string, args 
 					(sig == syscall.SIGINT && strings.Contains(errs, "exit status 1")) {
 					continue
 				}
-				fmt.Printf("Component `%s` exit with error: %s\n", component, errs)
+				fmt.Fprintf(os.Stderr, "Component `%s` exit with error: %s\n", component, errs)
 				return
 			}
 		}
@@ -120,7 +120,7 @@ Found %[1]s newer version:
 	select {
 	case s := <-sc:
 		sig = s.(syscall.Signal)
-		fmt.Printf("Got signal %v (Component: %v ; PID: %v)\n", s, component, p.Pid)
+		fmt.Fprintf(os.Stderr, "Got signal %v (Component: %v ; PID: %v)\n", s, component, p.Pid)
 		if component == "tidb" {
 			return syscall.Kill(p.Pid, syscall.SIGKILL)
 		}
@@ -130,7 +130,7 @@ Found %[1]s newer version:
 		return nil
 
 	case err := <-ch:
-		defer fmt.Print(<-updateC)
+		defer fmt.Fprint(os.Stderr, <-updateC)
 		return errors.Annotatef(err, "run `%s` (wd:%s) failed", p.Exec, p.Dir)
 	}
 }
@@ -140,7 +140,7 @@ func cleanDataDir(rm bool, dir string) {
 		return
 	}
 	if err := os.RemoveAll(dir); err != nil {
-		fmt.Println("clean data directory failed: ", err.Error())
+		fmt.Fprintln(os.Stderr, "clean data directory failed: ", err.Error())
 	}
 }
 

--- a/pkg/logger/log/verbose.go
+++ b/pkg/logger/log/verbose.go
@@ -31,5 +31,5 @@ func Verbose(format string, args ...interface{}) {
 	if !verbose {
 		return
 	}
-	fmt.Println("Verbose:", fmt.Sprintf(format, args...))
+	fmt.Fprintln(os.Stderr, "Verbose:", fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Sometimes some information output to stdout  mistakenly, for example: after `tiup cluster template > topology.yaml` ,the file has lines like "verbose: xxx"

### What is changed and how it works?

change to stderr

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
