### PR TITLE
cluster: add `--force` argument for `prune` subcommand

### DIFF
--- a/components/cluster/command/prune.go
+++ b/components/cluster/command/prune.go
@@ -34,5 +34,7 @@ func newPruneCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Ignore errors when deleting the instance with data from the cluster")
+
 	return cmd
 }

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -488,7 +488,12 @@ func DestroyClusterTombstone(
 			instCount[instance.GetHost()]--
 			err := StopAndDestroyInstance(ctx, cluster, instance, options, instCount[instance.GetHost()] == 0)
 			if err != nil {
-				return err
+				if options.Force {
+					log.Warnf("failed to stop and destroy instance %s (%s), ignored as --force is set, you may need to manually cleanup the files",
+						instance, err)
+				} else {
+					return err
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1546 

### What is changed and how it works?
When `--force` is set, errors are ignored when stopping and deleting the instance.

### Check List <!--REMOVE the items that are not applicable-->

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
