### PR TITLE
update root.json only when necessary

### DIFF
--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -219,7 +219,7 @@ func (r *V1Repository) updateLocalSnapshot() (*v1manifest.Snapshot, error) {
 	}(time.Now())
 
 	timestampChanged, tsManifest, err := r.fetchTimestamp()
-	if v1manifest.IsSignatureError(errors.Cause(err)) {
+	if v1manifest.IsSignatureError(errors.Cause(err)) || v1manifest.IsExpirationError(errors.Cause(err)) {
 		// The signature is wrong, update our signatures from the root manifest and try again.
 		err = r.updateLocalRoot()
 		if err != nil {

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -203,25 +203,10 @@ func (r *V1Repository) ensureManifests() error {
 		log.Verbose("Ensure manifests finished in %s", time.Since(start))
 	}(time.Now())
 
-	// Update root before anything else.
-	if err := r.updateLocalRoot(); err != nil {
-		return err
-	}
-
 	// Update snapshot.
 	snapshot, err := r.updateLocalSnapshot()
 	if err != nil {
 		return err
-	}
-
-	// Check that the version of root we have is the same as declared in the snapshot.
-	newRoot, err := r.loadRoot()
-	if err != nil {
-		return err
-	}
-	snapRootVersion := snapshot.Meta[v1manifest.ManifestURLRoot].Version
-	if newRoot.Version != snapRootVersion {
-		return fmt.Errorf("root version mismatch. Expected: %v, found: %v", snapRootVersion, newRoot.Version)
 	}
 
 	return r.updateLocalIndex(snapshot)
@@ -281,6 +266,22 @@ func (r *V1Repository) updateLocalSnapshot() (*v1manifest.Snapshot, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// Update root if needed and restart the update process
+		var oldRoot v1manifest.Root
+		_, _, err = r.local.LoadManifest(&oldRoot)
+		if err != nil {
+			return nil, err
+		}
+		newRootVersion := snapshot.Meta[v1manifest.ManifestURLRoot].Version
+
+		if newRootVersion > oldRoot.Version {
+			err := r.updateLocalRoot()
+			if err != nil {
+				return nil, err
+			}
+			return r.updateLocalSnapshot()
+		}
 	}
 
 	if timestampChanged {
@@ -303,11 +304,6 @@ func FnameWithVersion(fname string, version uint) string {
 }
 
 func (r *V1Repository) updateLocalRoot() error {
-	// There is no need to update root.json if other manifest not changed
-	if r.timestamp != nil {
-		return nil
-	}
-
 	defer func(start time.Time) {
 		log.Verbose("Update local root finished in %s", time.Since(start))
 	}(time.Now())

--- a/pkg/repository/v1manifest/key_store.go
+++ b/pkg/repository/v1manifest/key_store.go
@@ -120,7 +120,7 @@ func (s *KeyStore) verifySignature(signed []byte, role string, signatures []Sign
 	has := make(map[string]struct{})
 	for _, sig := range signatures {
 		if _, ok := has[sig.KeyID]; ok {
-			return errors.Errorf("signature section of %s contains duplicate signatures", filename)
+			return newSignatureError(filename, errors.Errorf("signature section of %s contains duplicate signatures", filename))
 		}
 		has[sig.KeyID] = struct{}{}
 	}
@@ -152,7 +152,7 @@ func (s *KeyStore) verifySignature(signed []byte, role string, signatures []Sign
 		}
 	}
 	if validSigs < keys.threshold {
-		return errors.Errorf("not enough signatures (%v) for threshold %v in %s", validSigs, keys.threshold, filename)
+		return newSignatureError(filename, errors.Errorf("not enough signatures (%v) for threshold %v in %s", validSigs, keys.threshold, filename))
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

No need to update root.json every time update something

### What is changed and how it works?

remote update of root.json before get timestamp.json, add it after get snapshot.json

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
