### PR TITLE
fix panic when cant openDB on tiup-bench

### DIFF
--- a/components/bench/main.go
+++ b/components/bench/main.go
@@ -51,7 +51,7 @@ func closeDB() {
 	globalDB = nil
 }
 
-func openDB() {
+func openDB() error {
 	// TODO: support other drivers
 	var tmpDB *sql.DB
 	ds := fmt.Sprintf("%s:%s@tcp(%s:%d)/", user, password, host, port)
@@ -59,7 +59,7 @@ func openDB() {
 	var err error
 	globalDB, err = sql.Open(mysqlDriver, dsn)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	if err := globalDB.Ping(); err != nil {
 		errString := err.Error()
@@ -67,14 +67,16 @@ func openDB() {
 			tmpDB, _ = sql.Open(mysqlDriver, ds)
 			defer tmpDB.Close()
 			if _, err := tmpDB.Exec(createDBDDL + dbName); err != nil {
-				panic(fmt.Errorf("failed to create database, err %v", err))
+				return fmt.Errorf("failed to create database, err %v", err)
 			}
 		} else {
 			globalDB = nil
+			return err
 		}
 	} else {
 		globalDB.SetMaxIdleConns(threads + 1)
 	}
+	return nil
 }
 
 func main() {

--- a/components/bench/tpcc.go
+++ b/components/bench/tpcc.go
@@ -26,7 +26,11 @@ func executeTpcc(action string) {
 	}
 	runtime.GOMAXPROCS(maxProcs)
 
-	openDB()
+	if err := openDB(); err != nil {
+		fmt.Println(err)
+		fmt.Println("Cannot open database, pleae check it (ip/port/username/password)")
+		os.Exit(1)
+	}
 
 	tpccConfig.DBName = dbName
 	tpccConfig.Threads = threads

--- a/components/bench/tpch.go
+++ b/components/bench/tpch.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/pingcap/go-tpc/tpch"
@@ -11,7 +13,11 @@ import (
 var tpchConfig tpch.Config
 
 func executeTpch(action string, _ []string) {
-	openDB()
+	if err := openDB(); err != nil {
+		fmt.Println(err)
+		fmt.Println("Cannot open database, pleae check it (ip/port/username/password)")
+		os.Exit(1)
+	}
 	defer closeDB()
 
 	tpchConfig.DBName = dbName


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

when cannot connect to DB, tiup-bench panic .  fix #1548 

### What is changed and how it works?

instead of  panic, just exit(1) and warning

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
