### PR TITLE
pkg/cluster/spec: add supported configuration for grafana

### DIFF
--- a/embed/templates/config/grafana.ini.tpl
+++ b/embed/templates/config/grafana.ini.tpl
@@ -169,7 +169,11 @@ admin_password = {{.Password}}
 ;login_hint = email or username
 
 # Default UI theme ("dark" or "light")
+{{- if .DefaultTheme}}
+default_theme = {{.DefaultTheme}}
+{{- else}}
 ;default_theme = dark
+{{- end}}
 
 ############### Set Cookie Name for Multiple Instances #######################
 [auth]
@@ -182,10 +186,18 @@ enabled = true
 {{- end}}
 
 # specify organization name that should be used for unauthenticated users
+{{- if .OrgName}}
+org_name = {{.OrgName}}
+{{- else}}
 ;org_name = Main Org.
+{{- end}}
 
 # specify role for unauthenticated users
+{{- if .OrgRole}}
+org_role = {{.OrgRole}}
+{{- else}}
 ;org_role = Viewer
+{{- end}}
 
 #################################### Basic Auth ##########################
 [auth.basic]

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -47,6 +47,9 @@ type GrafanaSpec struct {
 	AnonymousEnable bool                 `yaml:"anonymous_enable" default:"false" validate:"anonymous_enable:editable"`
 	RootURL         string               `yaml:"root_url" validate:"root_url:editable"`
 	Domain          string               `yaml:"domain" validate:"domain:editable"`
+	DefaultTheme    string               `yaml:"default_theme,omitempty" validate:"default_theme:editable"`
+	OrgName         string               `yaml:"org_name,omitempty" validate:"org_name:editable"`
+	OrgRole         string               `yaml:"org_role,omitempty" validate:"org_role:editable"`
 }
 
 // Role returns the component role of the instance
@@ -166,6 +169,9 @@ func (i *GrafanaInstance) InitConfig(
 		WithAnonymousenable(spec.AnonymousEnable).
 		WithRootURL(spec.RootURL).
 		WithDomain(spec.Domain).
+		WithDefaultTheme(spec.DefaultTheme).
+		WithOrgName(spec.OrgName).
+		WithOrgRole(spec.OrgRole).
 		ConfigToFile(fp); err != nil {
 		return err
 	}

--- a/pkg/cluster/template/config/grafana.go
+++ b/pkg/cluster/template/config/grafana.go
@@ -32,6 +32,9 @@ type GrafanaConfig struct {
 	AnonymousEnable bool   // anonymous enable
 	RootURL         string // root_url
 	Domain          string // domain
+	DefaultTheme    string // default_theme
+	OrgName         string // org_name
+	OrgRole         string // org_role
 }
 
 // NewGrafanaConfig returns a GrafanaConfig
@@ -76,6 +79,24 @@ func (c *GrafanaConfig) WithRootURL(rootURL string) *GrafanaConfig {
 // WithDomain sets domain of server domain
 func (c *GrafanaConfig) WithDomain(domain string) *GrafanaConfig {
 	c.Domain = domain
+	return c
+}
+
+// WithDefaultTheme sets defaultTheme of default theme
+func (c *GrafanaConfig) WithDefaultTheme(defaultTheme string) *GrafanaConfig {
+	c.DefaultTheme = defaultTheme
+	return c
+}
+
+// WithOrgName sets orgName of org name
+func (c *GrafanaConfig) WithOrgName(orgName string) *GrafanaConfig {
+	c.OrgName = orgName
+	return c
+}
+
+// WithOrgRole sets orgName of org role
+func (c *GrafanaConfig) WithOrgRole(orgRole string) *GrafanaConfig {
+	c.OrgRole = orgRole
 	return c
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
Add `default_theme`, `org_name`, `org_role` as supported configurations for Grafana.

### What is changed and how it works?
Add sub-targets under grafana_servers in topology.yaml which is used as the configuration file for `tiup-cluster deploy` command.
Sample topology.yaml: 
```yaml
global:
  user: "root"
  ssh_port: 22
  deploy_dir: "/root/tidb-deploy"
  data_dir: "/root/tidb-data"
  arch: "amd64"

monitored:
  node_exporter_port: 9100
  blackbox_exporter_port: 9115

pd_servers:
  - host: $HOST_IP

tidb_servers:
  - host: $HOST_IP
    port: 4000
    status_port: 10080
    deploy_dir: "/root/tidb-deploy/tidb-4000"
    log_dir: "/root/tidb-deploy/tidb-4000/log"

tikv_servers:
  - host: $HOST_IP
    port: 20160
    status_port: 20180
    deploy_dir: "/root/data1/tidb-deploy/tikv-20160"
    data_dir: "/root/tidb-data/tikv-20160"
    log_dir: "/root/tidb-deploy/tikv-20160/log"

monitoring_servers:
  - host: $HOST_IP

grafana_servers:
  - host: $HOST_IP
    anonymous_enable: true
    default_theme: light
    org_name: Main Org.
    org_role: Viewer

alertmanager_servers:
  - host: $HOST_IP
```

### Check List

Tests

 - Manual test (add detailed scripts or steps below)
   - Step one
      In Linux environment, run `make` under the project's root path to generate the binary file in the bin directory
   - Step two
      Run `./tiup-cluster deploy test-tidb v5.1.1 /path/to/topology.yaml` and `./tiup-cluster start test-tidb` to start a TiDB cluster. You can use the provided sample topology.yaml above, remember to substitute $HOST_IP with yours.
      Also, you may also need to provide credentials by passing `-u -p` or `-u -i` in the deploy command, see `tiup-cluster deploy -h`.
    - Step three
       Open browser and type in `$HOST_IP:3000`. If you use the provided topology.yaml file above, you should find that you have logged in automatically and the theme is light.
       You can also make sure that the configuration takes effect by checking the value of default_theme, org_name, org_role, enabled in /root/tidb-deploy/grafana-3000/conf/grafana.ini. It should be the same as below.
       ```ini
       # Default UI theme ("dark" or "light")
       default_theme = light

       ############### Set Cookie Name for Multiple Instances               
       #######################
       [auth]
       login_cookie_name = grafana_session_3000

       #################################### Anonymous Auth        
       ##########################
       [auth.anonymous]
       enabled = true

       # specify organization name that should be used for unauthenticated users
       org_name = Main Org.

       # specify role for unauthenticated users
       org_role = Viewer
       ```
      

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
```release-note
Add `default_theme`, `org_name`, `org_role` as supported configurations for Grafana
```
