### PR TITLE
Improve Dumpling/Lightning compatibility

### DIFF
--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -261,6 +261,12 @@ func launchComponent(ctx context.Context, component string, version utils.Versio
 		instanceDir = env.LocalPath(localdata.DataParentDir, tag)
 	}
 
+	if len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+		}
+	}
+
 	params := &PrepareCommandParams{
 		Ctx:         ctx,
 		Component:   component,


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

When executing `tiup <component> -- <options>` this removes the `--` from being passed down to the command that's called.

- https://github.com/pingcap/tiup/issues/862
- https://github.com/pingcap/dumpling/issues/312

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Using `--` to separate arguments for tiup and the component being called is no longer passed down to the component
```
