### PR TITLE
cluster: fix getClusterID() type

### DIFF
--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -330,9 +330,6 @@ func (pc *PDClient) GetConfig() (map[string]interface{}, error) {
 // GetClusterID return cluster ID
 func (pc *PDClient) GetClusterID() (string, error) {
 	endpoints := pc.getEndpoints(pdClusterIDURI)
-
-	// We don't use the `github.com/tikv/pd/server/config` directly because
-	// there is compatible issue: https://github.com/pingcap/tiup/issues/637
 	clusterID := map[string]interface{}{}
 
 	_, err := tryURLs(endpoints, func(endpoint string) ([]byte, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

getClusterID() return wrong type in last commit

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
