### PR TITLE
playground: ensure unique sockets

### DIFF
--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -39,6 +39,7 @@ type instance struct {
 	StatusPort int // client port for PD
 	ConfigPath string
 	BinPath    string
+	Socket     string
 }
 
 // Instance represent running component

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -16,6 +16,7 @@ package instance
 import (
 	"context"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -43,6 +44,7 @@ func NewTiDBInstance(binPath string, dir, host, configPath string, id, port int,
 			Dir:        dir,
 			Host:       host,
 			Port:       utils.MustGetFreePort(host, port),
+			Socket:     path.Join("/tmp", fmt.Sprintf("tidb_%d.sock", id)),
 			StatusPort: utils.MustGetFreePort("0.0.0.0", 10080),
 			ConfigPath: configPath,
 		},
@@ -60,6 +62,7 @@ func (inst *TiDBInstance) Start(ctx context.Context, version utils.Version) erro
 		"--store=tikv",
 		fmt.Sprintf("--host=%s", inst.Host),
 		fmt.Sprintf("--status=%d", inst.StatusPort),
+		fmt.Sprintf("--socket=%s", inst.Socket),
 		fmt.Sprintf("--path=%s", strings.Join(endpoints, ",")),
 		fmt.Sprintf("--log-file=%s", filepath.Join(inst.Dir, "tidb.log")),
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Setting `socket = "/tmp/tidb.sock"` in `tidb.toml` and then running `tiup playground --db 2 --db.config tidb.toml` causes issues as the socket path needs to be unique per instance. With https://github.com/pingcap/tidb/pull/28486 this might also cause issues with the default config.


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
A unique socket file is set for each TiDB instance
```
