### PR TITLE
cluster: fix wrong keys detecting host arch

### DIFF
--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -164,13 +164,13 @@ func (m *Manager) fillHostArch(s, p *tui.SSHConnectionProps, topo spec.Topology,
 	hostArch := map[string]string{}
 	var detectTasks []*task.StepDisplay
 	topo.IterInstance(func(inst spec.Instance) {
+		if inst.Arch() != "" {
+			return
+		}
 		if _, ok := hostArch[inst.GetHost()]; ok {
 			return
 		}
 		hostArch[inst.GetHost()] = ""
-		if inst.Arch() != "" {
-			return
-		}
 
 		tf := task.NewBuilder().
 			RootSSH(


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Introduced in #1423 

```
$ tiup cluster deploy aws-test-v530 v5.3.0 topo.yaml -i id_rsa -u centos
Starting component `cluster`: /home/centos/.tiup/components/cluster/v1.6.0/tiup-cluster deploy aws-test-v530 v5.3.0 topo.yaml -i id_rsa -u centos





+ Detect CPU Arch
  - Detecting node 172.31.38.22 ... ⠼ Shell: host=172.31.38.22, sudo=false, command=`uname -m`
  - Detecting node 172.31.40.219 ... ⠼ Shell: host=172.31.40.219, sudo=false, command=`uname -m`
+ Detect CPU Arch
+ Detect CPU Arch
  - Detecting node 172.31.38.22 ... Done
  - Detecting node 172.31.40.219 ... Done
  - Detecting node 172.31.46.81 ... Done
  - Detecting node 172.31.42.64 ... Done
  - Detecting node 172.31.37.178 ... Done
  - Detecting node 172.31.36.128 ... Done
  - Detecting node 172.31.34.177 ... Done
  - Detecting node 172.31.41.3 ... Done
  - Detecting node 172.31.36.51 ... Done

Error: no check results found for 172.31.47.49

Verbose debug logs has been written to /home/centos/.tiup/logs/tiup-cluster-debug-2021-11-04-09-09-08.log.
Error: run `/home/centos/.tiup/components/cluster/v1.6.0/tiup-cluster` (wd:/home/centos/.tiup/data/SnmiNyB) failed: exit status 1
```
While `172.31.47.79` is the console machine itself and has multiple instances defined on it in the topology.

### What is changed and how it works?
When detecting host arch, empty value should not be added to the host set before checking of the value of its `arch` field.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
