### PR TITLE
cluster: fix mistake error about TLS

### DIFF
--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -89,7 +89,8 @@ func (m *Manager) Deploy(
 		return err
 	}
 	if clusterSpec, ok := topo.(*spec.Specification); ok {
-		if semver.Compare(clusterVersion, "v4.0.5") < 0 &&
+		if clusterSpec.GlobalOptions.TLSEnabled &&
+			semver.Compare(clusterVersion, "v4.0.5") < 0 &&
 			len(clusterSpec.TiFlashServers) > 0 {
 			return fmt.Errorf("TiFlash %s is not supported in TLS enabled cluster", clusterVersion)
 		}

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -80,7 +80,8 @@ func (m *Manager) ScaleOut(
 	}
 
 	if clusterSpec, ok := topo.(*spec.Specification); ok {
-		if semver.Compare(base.Version, "v4.0.5") < 0 &&
+		if clusterSpec.GlobalOptions.TLSEnabled &&
+			semver.Compare(base.Version, "v4.0.5") < 0 &&
 			len(clusterSpec.TiFlashServers) > 0 {
 			return fmt.Errorf("TiFlash %s is not supported in TLS enabled cluster", base.Version)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- tiup cluster report errror "TiFlash %s is not supported in TLS enabled cluster" when not enable TLS

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
