### PR TITLE
cluster: implement pure JSON output mode (experimental)

### DIFF
--- a/components/cluster/command/deploy.go
+++ b/components/cluster/command/deploy.go
@@ -79,8 +79,8 @@ func newDeploy() *cobra.Command {
 	return cmd
 }
 
-func postDeployHook(builder *task.Builder, topo spec.Topology) {
-	nodeInfoTask := task.NewBuilder().Func("Check status", func(ctx context.Context) error {
+func postDeployHook(builder *task.Builder, topo spec.Topology, gOpt operator.Options) {
+	nodeInfoTask := task.NewBuilder(gOpt.DisplayMode).Func("Check status", func(ctx context.Context) error {
 		var err error
 		teleNodeInfos, err = operator.GetNodeInfo(ctx, topo)
 		_ = err
@@ -92,7 +92,7 @@ func postDeployHook(builder *task.Builder, topo spec.Topology) {
 		builder.ParallelStep("+ Check status", false, nodeInfoTask)
 	}
 
-	enableTask := task.NewBuilder().Func("Setting service auto start on boot", func(ctx context.Context) error {
+	enableTask := task.NewBuilder(gOpt.DisplayMode).Func("Setting service auto start on boot", func(ctx context.Context) error {
 		return operator.Enable(ctx, topo, operator.Options{}, true)
 	}).BuildAsStep("Enable service").SetHidden(true)
 

--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -88,7 +88,6 @@ func newDisplayCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&showDashboardOnly, "dashboard", false, "Only display TiDB Dashboard information")
 	cmd.Flags().BoolVar(&showVersionOnly, "version", false, "Only display TiDB cluster version")
 	cmd.Flags().BoolVar(&showTiKVLabels, "labels", false, "Only display labels of specified TiKV role or nodes")
-	cmd.Flags().BoolVar(&gOpt.JSON, "json", false, "Output in JSON format when applicable")
 
 	return cmd
 }

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -100,6 +100,15 @@ func init() {
 		SilenceErrors: true,
 		Version:       version.NewTiUPVersion().String(),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			switch strings.ToLower(gOpt.DisplayMode) {
+			case "json":
+				log.SetDisplayMode(log.DisplayModeJSON)
+			case "plain", "text":
+				log.SetDisplayMode(log.DisplayModePlain)
+			default:
+				log.SetDisplayMode(log.DisplayModeDefault)
+			}
+
 			var err error
 			var env *tiupmeta.Environment
 			if err = spec.Initialize("cluster"); err != nil {
@@ -124,9 +133,11 @@ func init() {
 
 			if gOpt.NativeSSH {
 				gOpt.SSHType = executor.SSHTypeSystem
-				zap.L().Info("System ssh client will be used",
-					zap.String(localdata.EnvNameNativeSSHClient, os.Getenv(localdata.EnvNameNativeSSHClient)))
-				fmt.Println("The --native-ssh flag has been deprecated, please use --ssh=system")
+				log.Infof(
+					"System ssh client will be used (%s=%s)",
+					localdata.EnvNameNativeSSHClient,
+					os.Getenv(localdata.EnvNameNativeSSHClient))
+				log.Infof("The --native-ssh flag has been deprecated, please use --ssh=system")
 			}
 
 			err = proxy.MaybeStartProxy(gOpt.SSHProxyHost, gOpt.SSHProxyPort, gOpt.SSHProxyUser, gOpt.SSHProxyUsePassword, gOpt.SSHProxyIdentity)

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -152,6 +152,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "(EXPERIMENTAL) Use the native SSH client installed on local system instead of the build-in one.")
 	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "(EXPERIMENTAL) The executor type: 'builtin', 'system', 'none'.")
 	rootCmd.PersistentFlags().IntVarP(&gOpt.Concurrency, "concurrency", "c", 5, "max number of parallel tasks allowed")
+	rootCmd.PersistentFlags().StringVar(&gOpt.DisplayMode, "format", "default", "The format of output, available values are [default, json]")
 	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyHost, "ssh-proxy-host", "", "The SSH proxy host used to connect to remote host.")
 	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyUser, "ssh-proxy-user", utils.CurrentUser(), "The user name used to login the proxy host.")
 	rootCmd.PersistentFlags().IntVar(&gOpt.SSHProxyPort, "ssh-proxy-port", 22, "The port used to login the proxy host.")

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -163,7 +163,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "(EXPERIMENTAL) Use the native SSH client installed on local system instead of the build-in one.")
 	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "(EXPERIMENTAL) The executor type: 'builtin', 'system', 'none'.")
 	rootCmd.PersistentFlags().IntVarP(&gOpt.Concurrency, "concurrency", "c", 5, "max number of parallel tasks allowed")
-	rootCmd.PersistentFlags().StringVar(&gOpt.DisplayMode, "format", "default", "The format of output, available values are [default, json]")
+	rootCmd.PersistentFlags().StringVar(&gOpt.DisplayMode, "format", "default", "(EXPERIMENTAL) The format of output, available values are [default, json]")
 	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyHost, "ssh-proxy-host", "", "The SSH proxy host used to connect to remote host.")
 	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyUser, "ssh-proxy-user", utils.CurrentUser(), "The user name used to login the proxy host.")
 	rootCmd.PersistentFlags().IntVar(&gOpt.SSHProxyPort, "ssh-proxy-port", 22, "The port used to login the proxy host.")
@@ -362,7 +362,7 @@ func Execute() {
 		if err != nil {
 			fmt.Printf("{\"exit_code\":%d, \"error\":\"%s\"}", code, err)
 		}
-		fmt.Println(string(data))
+		fmt.Fprintln(os.Stderr, string(data))
 	default:
 		if err != nil {
 			if errx := errorx.Cast(err); errx != nil {

--- a/components/cluster/command/scale_out.go
+++ b/components/cluster/command/scale_out.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 
 	"github.com/pingcap/tiup/pkg/cluster/manager"
+	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/cluster/task"
 	"github.com/pingcap/tiup/pkg/utils"
@@ -67,7 +68,7 @@ func newScaleOutCmd() *cobra.Command {
 	return cmd
 }
 
-func final(builder *task.Builder, name string, meta spec.Metadata) {
+func final(builder *task.Builder, name string, meta spec.Metadata, gOpt operator.Options) {
 	builder.UpdateTopology(name,
 		tidbSpec.Path(name),
 		meta.(*spec.ClusterMeta),
@@ -75,6 +76,6 @@ func final(builder *task.Builder, name string, meta spec.Metadata) {
 	)
 }
 
-func postScaleOutHook(builder *task.Builder, newPart spec.Topology) {
-	postDeployHook(builder, newPart)
+func postScaleOutHook(builder *task.Builder, newPart spec.Topology, gOpt operator.Options) {
+	postDeployHook(builder, newPart, gOpt)
 }

--- a/components/dm/command/deploy.go
+++ b/components/dm/command/deploy.go
@@ -81,8 +81,8 @@ func supportVersion(vs string) error {
 	return nil
 }
 
-func postDeployHook(builder *task.Builder, topo spec.Topology) {
-	enableTask := task.NewBuilder().Func("Setting service auto start on boot", func(ctx context.Context) error {
+func postDeployHook(builder *task.Builder, topo spec.Topology, gOpt operator.Options) {
+	enableTask := task.NewBuilder(gOpt.DisplayMode).Func("Setting service auto start on boot", func(ctx context.Context) error {
 		return operator.Enable(ctx, topo, operator.Options{}, true)
 	}).BuildAsStep("Enable service").SetHidden(true)
 

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -120,6 +120,7 @@ please backup your data before process.`,
 	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "Use the SSH client installed on local system instead of the build-in one.")
 	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "The executor type: 'builtin', 'system', 'none'")
 	rootCmd.PersistentFlags().IntVarP(&gOpt.Concurrency, "concurrency", "c", 5, "max number of parallel tasks allowed")
+	rootCmd.PersistentFlags().StringVar(&gOpt.DisplayMode, "format", "default", "(EXPERIMENTAL) The format of output, available values are [default, json]")
 	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyHost, "ssh-proxy-host", "", "The SSH proxy host used to connect to remote host.")
 	rootCmd.PersistentFlags().StringVar(&gOpt.SSHProxyUser, "ssh-proxy-user", utils.CurrentUser(), "The user name used to login the proxy host.")
 	rootCmd.PersistentFlags().IntVar(&gOpt.SSHProxyPort, "ssh-proxy-port", 22, "The port used to login the proxy host.")
@@ -240,7 +241,7 @@ func Execute() {
 				fmt.Printf("{\"error\": \"%s\"}", err)
 				break
 			}
-			fmt.Println(string(data))
+			fmt.Fprintln(os.Stderr, string(data))
 		default:
 			if errx := errorx.Cast(err); errx != nil {
 				printErrorMessageForErrorX(errx)

--- a/components/dm/command/scale_out.go
+++ b/components/dm/command/scale_out.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 
 	"github.com/pingcap/tiup/pkg/cluster/manager"
+	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/cluster/task"
 	"github.com/pingcap/tiup/pkg/utils"
@@ -50,6 +51,6 @@ func newScaleOutCmd() *cobra.Command {
 	return cmd
 }
 
-func postScaleOutHook(builder *task.Builder, newPart spec.Topology) {
-	postDeployHook(builder, newPart)
+func postScaleOutHook(builder *task.Builder, newPart spec.Topology, gOpt operator.Options) {
+	postDeployHook(builder, newPart, gOpt)
 }

--- a/pkg/cluster/ansible/config.go
+++ b/pkg/cluster/ansible/config.go
@@ -51,7 +51,7 @@ func ImportConfig(name string, clsMeta *spec.ClusterMeta, gOpt operator.Options)
 		for _, inst := range comp.Instances() {
 			switch inst.ComponentName() {
 			case spec.ComponentPD, spec.ComponentTiKV, spec.ComponentPump, spec.ComponentTiDB, spec.ComponentDrainer:
-				t := task.NewBuilder().
+				t := task.NewBuilder("").
 					SSHKeySet(
 						spec.ClusterPath(name, "ssh", "id_rsa"),
 						spec.ClusterPath(name, "ssh", "id_rsa.pub")).
@@ -84,7 +84,7 @@ func ImportConfig(name string, clsMeta *spec.ClusterMeta, gOpt operator.Options)
 					Build()
 				copyFileTasks = append(copyFileTasks, t)
 			case spec.ComponentTiFlash:
-				t := task.NewBuilder().
+				t := task.NewBuilder("").
 					SSHKeySet(
 						spec.ClusterPath(name, "ssh", "id_rsa"),
 						spec.ClusterPath(name, "ssh", "id_rsa.pub")).
@@ -131,7 +131,7 @@ func ImportConfig(name string, clsMeta *spec.ClusterMeta, gOpt operator.Options)
 			}
 		}
 	}
-	t := task.NewBuilder().
+	t := task.NewBuilder("").
 		Parallel(false, copyFileTasks...).
 		Build()
 

--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -151,7 +151,7 @@ func checkSystemInfo(s, p *tui.SSHConnectionProps, topo *spec.Specification, gOp
 			archKey := fmt.Sprintf("%s-%s", inst.OS(), inst.Arch())
 			if _, found := uniqueArchList[archKey]; !found {
 				uniqueArchList[archKey] = struct{}{}
-				t0 := task.NewBuilder().
+				t0 := task.NewBuilder(gOpt.DisplayMode).
 					Download(
 						spec.ComponentCheckCollector,
 						inst.OS(),
@@ -162,7 +162,7 @@ func checkSystemInfo(s, p *tui.SSHConnectionProps, topo *spec.Specification, gOp
 				downloadTasks = append(downloadTasks, t0)
 			}
 
-			t1 := task.NewBuilder()
+			t1 := task.NewBuilder(gOpt.DisplayMode)
 			// checks that applies to each instance
 			if opt.ExistCluster {
 				t1 = t1.CheckSys(
@@ -201,7 +201,7 @@ func checkSystemInfo(s, p *tui.SSHConnectionProps, topo *spec.Specification, gOp
 			if _, found := uniqueHosts[inst.GetHost()]; !found {
 				uniqueHosts[inst.GetHost()] = inst.GetSSHPort()
 				// build system info collecting tasks
-				t2 := task.NewBuilder().
+				t2 := task.NewBuilder(gOpt.DisplayMode).
 					RootSSH(
 						inst.GetHost(),
 						inst.GetSSHPort(),
@@ -322,7 +322,7 @@ func checkSystemInfo(s, p *tui.SSHConnectionProps, topo *spec.Specification, gOp
 				t1.BuildAsStep(fmt.Sprintf("  - Checking node %s", inst.GetHost())),
 			)
 
-			t3 := task.NewBuilder().
+			t3 := task.NewBuilder(gOpt.DisplayMode).
 				RootSSH(
 					inst.GetHost(),
 					inst.GetSSHPort(),
@@ -348,7 +348,7 @@ func checkSystemInfo(s, p *tui.SSHConnectionProps, topo *spec.Specification, gOp
 		}
 	}
 
-	t := task.NewBuilder().
+	t := task.NewBuilder(gOpt.DisplayMode).
 		ParallelStep("+ Download necessary tools", false, downloadTasks...).
 		ParallelStep("+ Collect basic system information", false, collectTasks...).
 		ParallelStep("+ Check system requirements", false, checkSysTasks...).
@@ -371,7 +371,7 @@ func checkSystemInfo(s, p *tui.SSHConnectionProps, topo *spec.Specification, gOp
 	}
 	checkResults := make([]HostCheckResult, 0)
 	for host := range uniqueHosts {
-		tf := task.NewBuilder().
+		tf := task.NewBuilder(gOpt.DisplayMode).
 			RootSSH(
 				host,
 				uniqueHosts[host],
@@ -406,7 +406,7 @@ func checkSystemInfo(s, p *tui.SSHConnectionProps, topo *spec.Specification, gOp
 	tui.PrintTable(checkResultTable, true)
 
 	if opt.ApplyFix {
-		tc := task.NewBuilder().
+		tc := task.NewBuilder(gOpt.DisplayMode).
 			ParallelStep("+ Try to apply changes to fix failed checks", false, applyFixTasks...).
 			Build()
 		if err := tc.Execute(ctx); err != nil {

--- a/pkg/cluster/manager/destroy.go
+++ b/pkg/cluster/manager/destroy.go
@@ -131,7 +131,7 @@ func (m *Manager) DestroyTombstone(
 	if err != nil {
 		return err
 	}
-	regenConfigTasks, _ := buildRegenConfigTasks(m, name, topo, base, nodes, true)
+	regenConfigTasks, _ := buildRegenConfigTasks(m, name, topo, base, gOpt, nodes, true)
 
 	t := b.
 		Func("FindTomestoneNodes", func(ctx context.Context) (err error) {
@@ -150,7 +150,7 @@ func (m *Manager) DestroyTombstone(
 		UpdateMeta(name, clusterMeta, nodes).
 		UpdateTopology(name, m.specManager.Path(name), clusterMeta, nodes).
 		ParallelStep("+ Refresh instance configs", true, regenConfigTasks...).
-		Parallel(true, buildReloadPromTasks(metadata.GetTopology())...).
+		Parallel(true, buildReloadPromTasks(metadata.GetTopology(), gOpt)...).
 		Build()
 
 	if err := t.Execute(ctx); err != nil {

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -107,7 +107,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 	cyan := color.New(color.FgCyan, color.Bold)
 	// display cluster meta
 	var j *JSONOutput
-	if strings.ToLower(opt.DisplayMode) == "json" {
+	if log.GetDisplayMode() == log.DisplayModeJSON {
 		j = &JSONOutput{
 			ClusterMetaInfo: ClusterMetaInfo{
 				m.sysName,
@@ -198,7 +198,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 			if tlsCfg != nil {
 				scheme = "https"
 			}
-			if strings.ToLower(opt.DisplayMode) == "json" {
+			if log.GetDisplayMode() == log.DisplayModeJSON {
 				j.ClusterMetaInfo.DashboardURL = fmt.Sprintf("%s://%s/dashboard", scheme, dashboardAddr)
 			} else {
 				fmt.Printf("Dashboard URL:      %s\n", cyan.Sprintf("%s://%s/dashboard", scheme, dashboardAddr))
@@ -206,7 +206,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 		}
 	}
 
-	if strings.ToLower(opt.DisplayMode) == "json" {
+	if log.GetDisplayMode() == log.DisplayModeJSON {
 		d, err := json.MarshalIndent(j, "", "  ")
 		if err != nil {
 			return err

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -107,7 +107,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 	cyan := color.New(color.FgCyan, color.Bold)
 	// display cluster meta
 	var j *JSONOutput
-	if opt.JSON {
+	if strings.ToLower(opt.DisplayMode) == "json" {
 		j = &JSONOutput{
 			ClusterMetaInfo: ClusterMetaInfo{
 				m.sysName,
@@ -198,7 +198,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 			if tlsCfg != nil {
 				scheme = "https"
 			}
-			if opt.JSON {
+			if strings.ToLower(opt.DisplayMode) == "json" {
 				j.ClusterMetaInfo.DashboardURL = fmt.Sprintf("%s://%s/dashboard", scheme, dashboardAddr)
 			} else {
 				fmt.Printf("Dashboard URL:      %s\n", cyan.Sprintf("%s://%s/dashboard", scheme, dashboardAddr))
@@ -206,7 +206,7 @@ func (m *Manager) Display(name string, opt operator.Options) error {
 		}
 	}
 
-	if opt.JSON {
+	if strings.ToLower(opt.DisplayMode) == "json" {
 		d, err := json.MarshalIndent(j, "", "  ")
 		if err != nil {
 			return err
@@ -259,7 +259,7 @@ func (m *Manager) DisplayTiKVLabels(name string, opt operator.Options) error {
 	cyan := color.New(color.FgCyan, color.Bold)
 
 	var j *JSONOutput
-	if opt.JSON {
+	if strings.ToLower(opt.DisplayMode) == "json" {
 		j = &JSONOutput{
 			ClusterMetaInfo: ClusterMetaInfo{
 				m.sysName,
@@ -383,7 +383,7 @@ func (m *Manager) DisplayTiKVLabels(name string, opt operator.Options) error {
 		}
 	}
 
-	if opt.JSON {
+	if strings.ToLower(opt.DisplayMode) == "json" {
 		j.LocationLabel = strings.Join(locationLabel, ",")
 		j.LabelInfos = labelInfoArr
 		d, err := json.MarshalIndent(j, "", "  ")

--- a/pkg/cluster/manager/exec.go
+++ b/pkg/cluster/manager/exec.go
@@ -84,7 +84,7 @@ func (m *Manager) Exec(name string, opt ExecOptions, gOpt operator.Options) erro
 		host := strings.Split(hostKey, "-")[0]
 		for _, cmd := range i.Slice() {
 			shellTasks = append(shellTasks,
-				task.NewBuilder().
+				task.NewBuilder(gOpt.DisplayMode).
 					Shell(host, cmd, hostKey+cmd, opt.Sudo).
 					Build())
 		}

--- a/pkg/cluster/manager/list.go
+++ b/pkg/cluster/manager/list.go
@@ -14,10 +14,13 @@
 package manager
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
+	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/pingcap/tiup/pkg/meta"
 	"github.com/pingcap/tiup/pkg/tui"
 )
@@ -38,21 +41,34 @@ func (m *Manager) ListCluster() error {
 		return err
 	}
 
-	clusterTable := [][]string{
-		// Header
-		{"Name", "User", "Version", "Path", "PrivateKey"},
+	switch log.GetDisplayMode() {
+	case log.DisplayModeJSON:
+		clusterObj := struct {
+			Clusters []Cluster `json:"clusters"`
+		}{
+			Clusters: clusters,
+		}
+		data, err := json.Marshal(clusterObj)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+	default:
+		clusterTable := [][]string{
+			// Header
+			{"Name", "User", "Version", "Path", "PrivateKey"},
+		}
+		for _, v := range clusters {
+			clusterTable = append(clusterTable, []string{
+				v.Name,
+				v.User,
+				v.Version,
+				v.Path,
+				v.PrivateKey,
+			})
+		}
+		tui.PrintTable(clusterTable, true)
 	}
-	for _, v := range clusters {
-		clusterTable = append(clusterTable, []string{
-			v.Name,
-			v.User,
-			v.Version,
-			v.Path,
-			v.PrivateKey,
-		})
-	}
-
-	tui.PrintTable(clusterTable, true)
 	return nil
 }
 

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -137,7 +137,7 @@ func (m *Manager) sshTaskBuilder(name string, topo spec.Topology, user string, g
 		}
 	}
 
-	return task.NewBuilder().
+	return task.NewBuilder(gOpt.DisplayMode).
 		SSHKeySet(
 			m.specManager.Path(name, "ssh", "id_rsa"),
 			m.specManager.Path(name, "ssh", "id_rsa.pub"),
@@ -172,7 +172,7 @@ func (m *Manager) fillHostArch(s, p *tui.SSHConnectionProps, topo spec.Topology,
 		}
 		hostArch[inst.GetHost()] = ""
 
-		tf := task.NewBuilder().
+		tf := task.NewBuilder(gOpt.DisplayMode).
 			RootSSH(
 				inst.GetHost(),
 				inst.GetSSHPort(),
@@ -201,7 +201,7 @@ func (m *Manager) fillHostArch(s, p *tui.SSHConnectionProps, topo spec.Topology,
 	}
 
 	ctx := ctxt.New(context.Background(), gOpt.Concurrency)
-	t := task.NewBuilder().
+	t := task.NewBuilder(gOpt.DisplayMode).
 		ParallelStep("+ Detect CPU Arch", false, detectTasks...).
 		Build()
 

--- a/pkg/cluster/manager/patch.go
+++ b/pkg/cluster/manager/patch.go
@@ -77,7 +77,7 @@ func (m *Manager) Patch(name string, packagePath string, opt operator.Options, o
 	var replacePackageTasks []task.Task
 	for _, inst := range insts {
 		deployDir := spec.Abs(base.User, inst.DeployDir())
-		tb := task.NewBuilder()
+		tb := task.NewBuilder(opt.DisplayMode)
 		tb.BackupComponent(inst.ComponentName(), base.Version, inst.GetHost(), deployDir).
 			InstallPackage(packagePath, inst.GetHost(), deployDir)
 		replacePackageTasks = append(replacePackageTasks, tb.Build())

--- a/pkg/cluster/manager/reload.go
+++ b/pkg/cluster/manager/reload.go
@@ -86,7 +86,7 @@ func (m *Manager) Reload(name string, gOpt operator.Options, skipRestart, skipCo
 		}
 	})
 
-	refreshConfigTasks, hasImported := buildRegenConfigTasks(m, name, topo, base, nil, gOpt.IgnoreConfigCheck)
+	refreshConfigTasks, hasImported := buildRegenConfigTasks(m, name, topo, base, gOpt, nil, gOpt.IgnoreConfigCheck)
 	monitorConfigTasks := buildRefreshMonitoredConfigTasks(
 		m.specManager,
 		name,

--- a/pkg/cluster/manager/scale_in.go
+++ b/pkg/cluster/manager/scale_in.go
@@ -84,7 +84,7 @@ func (m *Manager) ScaleIn(
 	base := metadata.GetBaseMeta()
 
 	// Regenerate configuration
-	regenConfigTasks, hasImported := buildRegenConfigTasks(m, name, topo, base, nodes, true)
+	regenConfigTasks, hasImported := buildRegenConfigTasks(m, name, topo, base, gOpt, nodes, true)
 
 	// handle dir scheme changes
 	if hasImported {
@@ -107,7 +107,7 @@ func (m *Manager) ScaleIn(
 
 	t := b.
 		ParallelStep("+ Refresh instance configs", force, regenConfigTasks...).
-		Parallel(force, buildReloadPromTasks(metadata.GetTopology(), nodes...)...).
+		Parallel(force, buildReloadPromTasks(metadata.GetTopology(), gOpt, nodes...)...).
 		Build()
 
 	if err := t.Execute(ctxt.New(context.Background(), gOpt.Concurrency)); err != nil {

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -41,8 +41,8 @@ import (
 func (m *Manager) ScaleOut(
 	name string,
 	topoFile string,
-	afterDeploy func(b *task.Builder, newPart spec.Topology),
-	final func(b *task.Builder, name string, meta spec.Metadata),
+	afterDeploy func(b *task.Builder, newPart spec.Topology, gOpt operator.Options),
+	final func(b *task.Builder, name string, meta spec.Metadata, gOpt operator.Options),
 	opt DeployOptions,
 	skipConfirm bool,
 	gOpt operator.Options,

--- a/pkg/cluster/manager/transfer.go
+++ b/pkg/cluster/manager/transfer.go
@@ -92,7 +92,7 @@ func (m *Manager) Transfer(name string, opt TransferOptions, gOpt operator.Optio
 	for hostKey, i := range uniqueHosts {
 		host := strings.Split(hostKey, "-")[0]
 		for _, p := range i.Slice() {
-			t := task.NewBuilder()
+			t := task.NewBuilder(gOpt.DisplayMode)
 			if opt.Pull {
 				t.CopyFile(p, srcPath, host, opt.Pull, opt.Limit)
 			} else {

--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -92,7 +92,7 @@ func (m *Manager) Upgrade(name string, clusterVersion string, opt operator.Optio
 			key := fmt.Sprintf("%s-%s-%s-%s", compName, version, inst.OS(), inst.Arch())
 			if _, found := uniqueComps[key]; !found {
 				uniqueComps[key] = struct{}{}
-				t := task.NewBuilder().
+				t := task.NewBuilder(opt.DisplayMode).
 					Download(inst.ComponentName(), inst.OS(), inst.Arch(), version).
 					Build()
 				downloadCompTasks = append(downloadCompTasks, t)
@@ -105,7 +105,7 @@ func (m *Manager) Upgrade(name string, clusterVersion string, opt operator.Optio
 			logDir := spec.Abs(base.User, inst.LogDir())
 
 			// Deploy component
-			tb := task.NewBuilder()
+			tb := task.NewBuilder(opt.DisplayMode)
 
 			// for some component, dataDirs might need to be created due to upgrade
 			// eg: TiCDC support DataDir since v4.0.13

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -51,8 +51,8 @@ type Options struct {
 	// Show uptime or not
 	ShowUptime bool
 
-	JSON      bool
-	Operation Operation
+	DisplayMode string // the output format
+	Operation   Operation
 }
 
 // Operation represents the type of cluster operation

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -24,6 +24,7 @@ import (
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/crypto"
+	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/pingcap/tiup/pkg/meta"
 	"github.com/pingcap/tiup/pkg/proxy"
 )
@@ -31,21 +32,21 @@ import (
 // Builder is used to build TiUP task
 type Builder struct {
 	tasks       []Task
-	displayMode DisplayMode
+	DisplayMode log.DisplayMode
 }
 
 // NewBuilder returns a *Builder instance
 func NewBuilder(mode string) *Builder {
-	var dp DisplayMode
+	var dp log.DisplayMode
 	switch strings.ToLower(mode) {
 	case "json":
-		dp = DisplayModeJSON
+		dp = log.DisplayModeJSON
 	case "plain", "text":
-		dp = DisplayModePlain
+		dp = log.DisplayModePlain
 	default:
-		dp = DisplayModeDefault
+		dp = log.DisplayModeDefault
 	}
-	return &Builder{displayMode: dp}
+	return &Builder{DisplayMode: dp}
 }
 
 // RootSSH appends a RootSSH task to the current task collection
@@ -471,19 +472,19 @@ func (b *Builder) Build() Task {
 
 // Step appends a new StepDisplay task, which will print single line progress for inner tasks.
 func (b *Builder) Step(prefix string, inner Task) *Builder {
-	b.Serial(newStepDisplay(prefix, inner, b.displayMode))
+	b.Serial(newStepDisplay(prefix, inner, b.DisplayMode))
 	return b
 }
 
 // ParallelStep appends a new ParallelStepDisplay task, which will print multi line progress in parallel
 // for inner tasks. Inner tasks must be a StepDisplay task.
 func (b *Builder) ParallelStep(prefix string, ignoreError bool, tasks ...*StepDisplay) *Builder {
-	b.tasks = append(b.tasks, newParallelStepDisplay(prefix, ignoreError, tasks...).SetDisplayMode(b.displayMode))
+	b.tasks = append(b.tasks, newParallelStepDisplay(prefix, ignoreError, tasks...).SetDisplayMode(b.DisplayMode))
 	return b
 }
 
 // BuildAsStep returns a task that is wrapped by a StepDisplay. The task will print single line progress.
 func (b *Builder) BuildAsStep(prefix string) *StepDisplay {
 	inner := b.Build()
-	return newStepDisplay(prefix, inner, b.displayMode)
+	return newStepDisplay(prefix, inner, b.DisplayMode)
 }

--- a/pkg/cluster/task/step.go
+++ b/pkg/cluster/task/step.go
@@ -20,17 +20,8 @@ import (
 	"strings"
 
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
+	"github.com/pingcap/tiup/pkg/logger/log"
 	"github.com/pingcap/tiup/pkg/tui/progress"
-)
-
-// DisplayMode control the output format
-type DisplayMode int
-
-// display modes
-const (
-	DisplayModeDefault DisplayMode = iota // default is the interactive output
-	DisplayModePlain                      // plain text
-	DisplayModeJSON                       // JSON
 )
 
 // StepDisplay is a task that will display a progress bar for inner task.
@@ -39,7 +30,7 @@ type StepDisplay struct {
 	inner       Task
 	prefix      string
 	children    map[Task]struct{}
-	displayMode DisplayMode
+	DisplayMode log.DisplayMode
 	progressBar progress.Bar
 }
 
@@ -65,14 +56,14 @@ func addChildren(m map[Task]struct{}, task Task) {
 	}
 }
 
-func newStepDisplay(prefix string, inner Task, m DisplayMode) *StepDisplay {
+func newStepDisplay(prefix string, inner Task, m log.DisplayMode) *StepDisplay {
 	children := make(map[Task]struct{})
 	addChildren(children, inner)
 	return &StepDisplay{
 		inner:       inner,
 		prefix:      prefix,
 		children:    children,
-		displayMode: m,
+		DisplayMode: m,
 		progressBar: progress.NewSingleBar(prefix),
 	}
 }
@@ -83,9 +74,9 @@ func (s *StepDisplay) SetHidden(h bool) *StepDisplay {
 	return s
 }
 
-// SetDisplayMode set the value of displayMode flag
-func (s *StepDisplay) SetDisplayMode(m DisplayMode) *StepDisplay {
-	s.displayMode = m
+// SetDisplayMode set the value of log.DisplayMode flag
+func (s *StepDisplay) SetDisplayMode(m log.DisplayMode) *StepDisplay {
+	s.DisplayMode = m
 	return s
 }
 
@@ -104,8 +95,8 @@ func (s *StepDisplay) Execute(ctx context.Context) error {
 		return err
 	}
 
-	switch s.displayMode {
-	case DisplayModeJSON:
+	switch s.DisplayMode {
+	case log.DisplayModeJSON:
 		break
 	default:
 		if singleBar, ok := s.progressBar.(*progress.SingleBar); ok {
@@ -133,8 +124,8 @@ func (s *StepDisplay) Execute(ctx context.Context) error {
 		}
 	}
 
-	switch s.displayMode {
-	case DisplayModeJSON:
+	switch s.DisplayMode {
+	case log.DisplayModeJSON:
 		return printDp(dp)
 	default:
 		s.progressBar.UpdateDisplay(dp)
@@ -160,8 +151,8 @@ func (s *StepDisplay) handleTaskBegin(task Task) {
 		Prefix: s.prefix,
 		Suffix: strings.Split(task.String(), "\n")[0],
 	}
-	switch s.displayMode {
-	case DisplayModeJSON:
+	switch s.DisplayMode {
+	case log.DisplayModeJSON:
 		_ = printDp(dp)
 	default:
 		s.progressBar.UpdateDisplay(dp)
@@ -176,8 +167,8 @@ func (s *StepDisplay) handleTaskProgress(task Task, p string) {
 		Prefix: s.prefix,
 		Suffix: strings.Split(p, "\n")[0],
 	}
-	switch s.displayMode {
-	case DisplayModeJSON:
+	switch s.DisplayMode {
+	case log.DisplayModeJSON:
 		_ = printDp(dp)
 	default:
 		s.progressBar.UpdateDisplay(dp)
@@ -189,7 +180,7 @@ func (s *StepDisplay) handleTaskProgress(task Task, p string) {
 type ParallelStepDisplay struct {
 	inner       *Parallel
 	prefix      string
-	displayMode DisplayMode
+	DisplayMode log.DisplayMode
 	progressBar *progress.MultiBar
 }
 
@@ -209,16 +200,16 @@ func newParallelStepDisplay(prefix string, ignoreError bool, sdTasks ...*StepDis
 	}
 }
 
-// SetDisplayMode set the value of displayMode flag
-func (ps *ParallelStepDisplay) SetDisplayMode(m DisplayMode) *ParallelStepDisplay {
-	ps.displayMode = m
+// SetDisplayMode set the value of log.DisplayMode flag
+func (ps *ParallelStepDisplay) SetDisplayMode(m log.DisplayMode) *ParallelStepDisplay {
+	ps.DisplayMode = m
 	return ps
 }
 
 // Execute implements the Task interface
 func (ps *ParallelStepDisplay) Execute(ctx context.Context) error {
-	switch ps.displayMode {
-	case DisplayModeJSON:
+	switch ps.DisplayMode {
+	case log.DisplayModeJSON:
 		break
 	default:
 		ps.progressBar.StartRenderLoop()

--- a/pkg/tui/progress/display_props.go
+++ b/pkg/tui/progress/display_props.go
@@ -29,7 +29,7 @@ const (
 
 // DisplayProps controls the display of the progress bar.
 type DisplayProps struct {
-	Prefix string
-	Suffix string // If `Mode == Done / Error`, Suffix is not printed
-	Mode   Mode
+	Prefix string `json:"prefix,omitempty"`
+	Suffix string `json:"suffix,omitempty"` // If `Mode == Done / Error`, Suffix is not printed
+	Mode   Mode   `json:"mode,omitempty"`
 }

--- a/pkg/tui/progress/display_props.go
+++ b/pkg/tui/progress/display_props.go
@@ -13,6 +13,11 @@
 
 package progress
 
+import (
+	"encoding/json"
+	"strings"
+)
+
 // Mode determines how the progress bar is rendered
 type Mode int
 
@@ -26,6 +31,46 @@ const (
 	// ModeError renders as "Error" message.
 	ModeError
 )
+
+// MarshalJSON implements JSON marshaler
+func (m Mode) MarshalJSON() ([]byte, error) {
+	var s string
+	switch m {
+	case ModeSpinner:
+		s = "spinner"
+	case ModeProgress:
+		s = "progress"
+	case ModeDone:
+		s = "done"
+	case ModeError:
+		s = "error"
+	default:
+		s = "unknown"
+	}
+	return json.Marshal(s)
+}
+
+// UnmarshalJSON implements JSON unmarshaler
+func (m *Mode) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch strings.ToLower(s) {
+	case "spinner":
+		*m = ModeSpinner
+	case "progress":
+		*m = ModeProgress
+	case "done":
+		*m = ModeDone
+	case "error":
+		*m = ModeError
+	default:
+		panic("unknown mode")
+	}
+
+	return nil
+}
 
 // DisplayProps controls the display of the progress bar.
 type DisplayProps struct {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Partially implement #1208

This is an experimental feature and may due to changes and refactors in the future.

Also add an optional `TIUP_AUDIT_ID` environment variable that will be appended to timestamp based audit id string.

### What is changed and how it works?
 - Add a global argument `--format` to define output format and replaces `--json`.
 - Make task outputs and loggers support JSON format

The output will be multiple JSON lines, and the last line is a `{"exit_code": 0}` (or other codes) printed to stderr.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Increased code complexity

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
