### PR TITLE
cluster: update error message of tiflash not ready

### DIFF
--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -780,7 +780,7 @@ func (i *TiFlashInstance) Ready(ctx context.Context, e ctxt.Executor, timeout ui
 			return nil
 		}
 
-		err = fmt.Errorf("tiflash store status '%s' not ready", string(body))
+		err = fmt.Errorf("tiflash store status is '%s', not fully running yet", string(body))
 		queryErr = err
 		return err
 	}, retryOpt); err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The status TiFlash reports could be `Ready` before it becomes `Running`, so the current error message could be confusing.
![图片](https://user-images.githubusercontent.com/596538/141434166-c01e4183-0c7c-481a-af03-21c69e60f4f8.png)
![图片](https://user-images.githubusercontent.com/596538/141434228-5f5e72a5-c43a-463d-8a45-ac60823780e7.png)


### What is changed and how it works?
Adjust the error message.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
