### PR TITLE
cluster: add envs to skip topology sanity check in scale-in process

### DIFF
--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -463,6 +463,7 @@ func DestroyClusterTombstone(
 
 	if forcePDEndpoints != "" {
 		pdEndpoints = strings.Split(forcePDEndpoints, ",")
+		log.Warnf("%s is set, using %s as PD endpoints", EnvNamePDEndpointOverwrite, pdEndpoints)
 	} else {
 		pdEndpoints = cluster.GetPDList()
 	}

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -458,7 +458,15 @@ func DestroyClusterTombstone(
 		}
 	}
 
-	pdEndpoints := cluster.GetPDList()
+	var pdEndpoints []string
+	forcePDEndpoints := os.Getenv(EnvNamePDEndpointOverwrite) // custom set PD endpoint list
+
+	if forcePDEndpoints != "" {
+		pdEndpoints = strings.Split(forcePDEndpoints, ",")
+	} else {
+		pdEndpoints = cluster.GetPDList()
+	}
+
 	var pdClient = api.NewPDClient(pdEndpoints, 10*time.Second, tlsCfg)
 
 	tcpProxy := proxy.GetTCPProxy()

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -21,6 +21,12 @@ import (
 	"github.com/pingcap/tiup/pkg/set"
 )
 
+// environment variable names that used to interrupt operations
+const (
+	EnvNameSkipScaleInTopoCheck = "SKIP_SCALEIN_TOPO_CHECK"
+	EnvNamePDEndpointOverwrite  = "FORCE_PD_ENDPOINTS"
+)
+
 // Options represents the operation options
 type Options struct {
 	Roles               []string

--- a/pkg/cluster/operation/scale_in.go
+++ b/pkg/cluster/operation/scale_in.go
@@ -150,7 +150,7 @@ func ScaleInCluster(
 	forcePDEndpoints := os.Getenv(EnvNamePDEndpointOverwrite) // custom set PD endpoint list
 
 	if forcePDEndpoints != "" {
-		pdEndpoints = append(pdEndpoints, strings.Split(forcePDEndpoints, ",")...)
+		pdEndpoints = strings.Split(forcePDEndpoints, ",")
 	} else {
 		for _, instance := range (&spec.PDComponent{Topology: cluster}).Instances() {
 			if !deletedNodes.Exist(instance.ID()) {

--- a/pkg/cluster/operation/upgrade.go
+++ b/pkg/cluster/operation/upgrade.go
@@ -70,6 +70,7 @@ func Upgrade(
 		case spec.ComponentTiKV:
 			if forcePDEndpoints != "" {
 				pdEndpoints = strings.Split(forcePDEndpoints, ",")
+				log.Warnf("%s is set, using %s as PD endpoints", EnvNamePDEndpointOverwrite, pdEndpoints)
 			} else {
 				pdEndpoints = topo.(*spec.Specification).GetPDList()
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1616 

### What is changed and how it works?
Add 2 new environment variables in `pkg/cluster/operation`:
 - `SKIP_SCALEIN_TOPO_CHECK`: If not empty, skip topology sanity check so that it's possible to delete the last PD, the last TiKV and the last TiSpark master node with worker node remains
 - `FORCE_PD_ENDPOINTS`: A common separated list of available PD endpoints. Used to overwrite pd list in the topology, so that when there is no PD available in the topology `tiup-cluster` acknowledged but some are working in the actual cluster, it's still possible to scale in other instances

These two environment are **very dangerous** and are highly possible to make the cluster broken, so they are not supposed to be documented in any public documentations, they are only supposed to be used by developers and expert users who know 100% what they are doing. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Not tested, use as your own risk...

Code changes

 - Has exported function/method change


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
