### PR TITLE
playground: fix wrong flag name

### DIFF
--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -96,9 +96,9 @@ const (
 
 	// hosts
 	clusterHost = "host"
-	dbHost      = "db.Host"
-	dbPort      = "db.Port"
-	pdHost      = "pd.Host"
+	dbHost      = "db.host"
+	dbPort      = "db.port"
+	pdHost      = "pd.host"
 
 	// config paths
 	dbConfig      = "db.config"


### PR DESCRIPTION
### What problem does this PR solve? 
playground db.host,db.port,pd.host changed to db.Host, db.Port and pd.Host,  need to be restored
https://github.com/pingcap/tiup/issues/1632


### What is changed and how it works?
![image](https://user-images.githubusercontent.com/39378935/142819824-c36ad57f-d122-4875-815f-c32dff271c5b.png)
to
![rikQV83Fld](https://user-images.githubusercontent.com/39378935/142819832-df6cd807-9832-44a8-a245-cb85be5edbd4.png)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

Code changes
 - Has persistent data change


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
