### PR TITLE
cluster: prohibit the clean operations during scale-out

### DIFF
--- a/pkg/cluster/manager/cleanup.go
+++ b/pkg/cluster/manager/cleanup.go
@@ -37,6 +37,11 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 		return err
 	}
 
+	// check locked
+	if err := m.specManager.ScaleOutLockedErr(name); err != nil {
+		return err
+	}
+
 	metadata, err := m.meta(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? 

prohibit the clean operations during scale-out 

Because the clean operation will stop the cluster, if the cluster is stopped while the scale-out is not completed, the scale-out will be abnormal.


### What is changed and how it works?
Will check the scale-out file lock before clean

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```shell
./tiup-cluster scale-out <cluster-name>  scale-out.yaml --stage1
./tiup-cluster clean <cluster-name> --all
```

```shell

Error: Scale-out file lock already exists (spec.scale-out lock)

Verbose debug logs has been written to /home/tidb/.tiup/logs/tiup-cluster-debug-2021-11-29-12-06-08.log.

Please run 'tiup-cluster scale-out --stage2' to continue.
```

Code changes

 - Has exported variable/fields change


Side effects

 - Possible performance regression


Related changes

 - Need to cherry-pick to the release branch

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
