### PR TITLE
*: implement plain text output and custom output writer

### DIFF
--- a/pkg/cluster/task/step.go
+++ b/pkg/cluster/task/step.go
@@ -126,7 +126,9 @@ func (s *StepDisplay) Execute(ctx context.Context) error {
 
 	switch s.DisplayMode {
 	case log.DisplayModeJSON:
-		_ = printDp(dp)
+		_ = printDpJSON(dp)
+	case log.DisplayModePlain:
+		_ = printDpPlain(dp)
 	default:
 		s.progressBar.UpdateDisplay(dp)
 	}
@@ -153,7 +155,9 @@ func (s *StepDisplay) handleTaskBegin(task Task) {
 	}
 	switch s.DisplayMode {
 	case log.DisplayModeJSON:
-		_ = printDp(dp)
+		_ = printDpJSON(dp)
+	case log.DisplayModePlain:
+		_ = printDpPlain(dp)
 	default:
 		s.progressBar.UpdateDisplay(dp)
 	}
@@ -169,7 +173,9 @@ func (s *StepDisplay) handleTaskProgress(task Task, p string) {
 	}
 	switch s.DisplayMode {
 	case log.DisplayModeJSON:
-		_ = printDp(dp)
+		_ = printDpJSON(dp)
+	case log.DisplayModePlain:
+		_ = printDpPlain(dp)
 	default:
 		s.progressBar.UpdateDisplay(dp)
 	}
@@ -229,11 +235,21 @@ func (ps *ParallelStepDisplay) String() string {
 	return ps.inner.String()
 }
 
-func printDp(dp *progress.DisplayProps) error {
+func printDpJSON(dp *progress.DisplayProps) error {
 	output, err := json.Marshal(dp)
 	if err != nil {
 		return err
 	}
 	fmt.Println(string(output))
+	return nil
+}
+
+func printDpPlain(dp *progress.DisplayProps) error {
+	switch dp.Mode {
+	case progress.ModeError:
+		log.Errorf("progress: %s", dp)
+	default:
+		log.Infof("progress: %s", dp)
+	}
 	return nil
 }

--- a/pkg/cluster/task/step.go
+++ b/pkg/cluster/task/step.go
@@ -96,7 +96,8 @@ func (s *StepDisplay) Execute(ctx context.Context) error {
 	}
 
 	switch s.DisplayMode {
-	case log.DisplayModeJSON:
+	case log.DisplayModeJSON,
+		log.DisplayModePlain:
 		break
 	default:
 		if singleBar, ok := s.progressBar.(*progress.SingleBar); ok {
@@ -128,7 +129,7 @@ func (s *StepDisplay) Execute(ctx context.Context) error {
 	case log.DisplayModeJSON:
 		_ = printDpJSON(dp)
 	case log.DisplayModePlain:
-		_ = printDpPlain(dp)
+		printDpPlain(dp)
 	default:
 		s.progressBar.UpdateDisplay(dp)
 	}
@@ -157,7 +158,7 @@ func (s *StepDisplay) handleTaskBegin(task Task) {
 	case log.DisplayModeJSON:
 		_ = printDpJSON(dp)
 	case log.DisplayModePlain:
-		_ = printDpPlain(dp)
+		printDpPlain(dp)
 	default:
 		s.progressBar.UpdateDisplay(dp)
 	}
@@ -175,7 +176,7 @@ func (s *StepDisplay) handleTaskProgress(task Task, p string) {
 	case log.DisplayModeJSON:
 		_ = printDpJSON(dp)
 	case log.DisplayModePlain:
-		_ = printDpPlain(dp)
+		printDpPlain(dp)
 	default:
 		s.progressBar.UpdateDisplay(dp)
 	}
@@ -215,7 +216,8 @@ func (ps *ParallelStepDisplay) SetDisplayMode(m log.DisplayMode) *ParallelStepDi
 // Execute implements the Task interface
 func (ps *ParallelStepDisplay) Execute(ctx context.Context) error {
 	switch ps.DisplayMode {
-	case log.DisplayModeJSON:
+	case log.DisplayModeJSON,
+		log.DisplayModePlain:
 		break
 	default:
 		ps.progressBar.StartRenderLoop()
@@ -244,12 +246,11 @@ func printDpJSON(dp *progress.DisplayProps) error {
 	return nil
 }
 
-func printDpPlain(dp *progress.DisplayProps) error {
+func printDpPlain(dp *progress.DisplayProps) {
 	switch dp.Mode {
 	case progress.ModeError:
 		log.Errorf("progress: %s", dp)
 	default:
 		log.Infof("progress: %s", dp)
 	}
-	return nil
 }

--- a/pkg/logger/log/log.go
+++ b/pkg/logger/log/log.go
@@ -24,6 +24,9 @@ import (
 
 var (
 	outputFmt DisplayMode = DisplayModeDefault // global output format of logger
+
+	stdout io.Writer = os.Stdout
+	stderr io.Writer = os.Stderr
 )
 
 // DisplayMode control the output format
@@ -76,19 +79,29 @@ func Debugf(format string, args ...interface{}) {
 // Deprecated: Use zap.L().Info() instead
 func Infof(format string, args ...interface{}) {
 	zap.L().Info(fmt.Sprintf(format, args...))
-	printLog(os.Stdout, "info", format, args...)
+	printLog(stdout, "info", format, args...)
 }
 
 // Warnf output the warning message to console
 // Deprecated: Use zap.L().Warn() instead
 func Warnf(format string, args ...interface{}) {
 	zap.L().Warn(fmt.Sprintf(format, args...))
-	printLog(os.Stderr, "warn", format, args...)
+	printLog(stderr, "warn", format, args...)
 }
 
 // Errorf output the error message to console
 // Deprecated: Use zap.L().Error() instead
 func Errorf(format string, args ...interface{}) {
 	zap.L().Error(fmt.Sprintf(format, args...))
-	printLog(os.Stderr, "error", format, args...)
+	printLog(stderr, "error", format, args...)
+}
+
+// SetStdout redirect stdout to a custom writer
+func SetStdout(w io.Writer) {
+	stdout = w
+}
+
+// SetStderr redirect stderr to a custom writer
+func SetStderr(w io.Writer) {
+	stderr = w
 }

--- a/pkg/logger/log/verbose.go
+++ b/pkg/logger/log/verbose.go
@@ -31,5 +31,5 @@ func Verbose(format string, args ...interface{}) {
 	if !verbose {
 		return
 	}
-	fmt.Fprintln(os.Stderr, "Verbose:", fmt.Sprintf(format, args...))
+	fmt.Fprintln(stderr, "Verbose:", fmt.Sprintf(format, args...))
 }

--- a/pkg/tui/progress/display_props.go
+++ b/pkg/tui/progress/display_props.go
@@ -15,6 +15,7 @@ package progress
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -72,9 +73,37 @@ func (m *Mode) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// String implements string
+func (m Mode) String() string {
+	var s string
+	switch m {
+	case ModeSpinner:
+		s = "spinner"
+	case ModeProgress:
+		s = "progress"
+	case ModeDone:
+		s = "done"
+	case ModeError:
+		s = "error"
+	default:
+		s = "unknown"
+	}
+	return s
+}
+
 // DisplayProps controls the display of the progress bar.
 type DisplayProps struct {
 	Prefix string `json:"prefix,omitempty"`
 	Suffix string `json:"suffix,omitempty"` // If `Mode == Done / Error`, Suffix is not printed
 	Mode   Mode   `json:"mode,omitempty"`
+}
+
+// String implements string
+func (dp *DisplayProps) String() string {
+	return fmt.Sprintf(
+		"(%s) %s: %s",
+		dp.Mode,
+		dp.Prefix,
+		dp.Suffix,
+	)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
A following up of #1617 and related to #1208

- Support `plain`/`text` output mode, that prints everything as plain text.
- Support custom output writer, make it possible for the `log` package to output `stdout` and `stderr` to different writers than system console

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
