### PR TITLE
cluster: skip dir conflict if node marked ignore_exporter

### DIFF
--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -173,6 +173,14 @@ func CheckClusterDirConflict(clusterList map[string]Metadata, clusterName string
 				continue
 			}
 
+			// ignore conflict in the case when both sides are monitor and either one of them
+			// is marked as ignore exporter.
+			if strings.HasPrefix(d1.dirKind, "monitor") &&
+				strings.HasPrefix(d2.dirKind, "monitor") &&
+				(d1.instance.IgnoreMonitorAgent() || d2.instance.IgnoreMonitorAgent()) {
+				continue
+			}
+
 			if d1.dir == d2.dir && d1.dir != "" {
 				properties := map[string]string{
 					"ThisDirKind":    d1.dirKind,
@@ -229,6 +237,7 @@ func CheckClusterDirOverlap(entries []DirEntry) error {
 				if d1.instance.IsImported() && d2.instance.IsImported() {
 					continue
 				}
+
 				// overlap is allowed in the case one side is imported and the other is monitor,
 				// we assume that the monitor is deployed with the first instance in that host,
 				// it implies that the monitor is imported too.

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -611,6 +611,16 @@ It conflicts to a directory in the existing cluster:
 
 Please change to use another directory or another host.`)
 
+	// no dir conflict error if one of the instance is marked as ignore_exporter
+	err = yaml.Unmarshal([]byte(`
+tidb_servers:
+  - host: 172.16.5.138
+    ignore_exporter: true
+`), &topo3)
+	c.Assert(err, IsNil)
+	err = CheckClusterDirConflict(clsList, "topo", &topo3)
+	c.Assert(err, IsNil)
+
 	// component with different port has no dir conflict
 	topo4 := Specification{}
 	err = yaml.Unmarshal([]byte(`


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If both clusters have the same monitor deploy dir set in their topology files, scaling out one with `ignore_exporter: true` to a shared host still reporting an directory conflict error.

### What is changed and how it works?
Ignore dir conflict error if both sides are monitor directories and one of them is marked as `ignore_exporter`.

This is a following up of #1492 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
