### PR TITLE
dm: add dm hosts to node_exporter list

### DIFF
--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -271,6 +271,7 @@ func (i *MonitorInstance) InitConfig(
 		for i := 0; i < servers.Len(); i++ {
 			master := reflect.Indirect(servers.Index(i))
 			host, port := master.FieldByName("Host").String(), master.FieldByName("Port").Int()
+			uniqueHosts.Insert(host)
 			cfig.AddDMMaster(host, uint64(port))
 		}
 	}
@@ -279,6 +280,7 @@ func (i *MonitorInstance) InitConfig(
 		for i := 0; i < servers.Len(); i++ {
 			worker := reflect.Indirect(servers.Index(i))
 			host, port := worker.FieldByName("Host").String(), worker.FieldByName("Port").Int()
+			uniqueHosts.Insert(host)
 			cfig.AddDMWorker(host, uint64(port))
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1653 

### What is changed and how it works?
Add hosts of DM nodes to the host list so that prometheus config will be rendered with them as `node_exporter` targets.
