### PR TITLE
cluster: check add CPU frequency check output

### DIFF
--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -224,11 +224,26 @@ func checkCPU(opt *CheckOptions, cpuInfo *sysinfo.CPU) []*CheckResult {
 	}
 
 	// check for CPU frequency governor
-	if cpuInfo.Governor != "" && cpuInfo.Governor != "performance" {
-		results = append(results, &CheckResult{
-			Name: CheckNameCPUGovernor,
-			Err:  fmt.Errorf("CPU frequency governor is %s, should use performance", cpuInfo.Governor),
-		})
+	if cpuInfo.Governor != "" {
+		if cpuInfo.Governor != "performance" {
+			results = append(results, &CheckResult{
+				Name: CheckNameCPUGovernor,
+				Err:  fmt.Errorf("CPU frequency governor is %s, should use performance", cpuInfo.Governor),
+			})
+		} else {
+			results = append(results, &CheckResult{
+				Name: CheckNameCPUGovernor,
+				Msg:  fmt.Sprintf("CPU frequency governor is %s", cpuInfo.Governor),
+			})
+		}
+	} else {
+		if cpuInfo.Governor == "" {
+			results = append(results, &CheckResult{
+				Name: CheckNameCPUGovernor,
+				Err:  fmt.Errorf("Unable to determine current CPU frequency governor policy"),
+				Warn: true,
+			})
+		}
 	}
 
 	return results

--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -237,13 +237,11 @@ func checkCPU(opt *CheckOptions, cpuInfo *sysinfo.CPU) []*CheckResult {
 			})
 		}
 	} else {
-		if cpuInfo.Governor == "" {
-			results = append(results, &CheckResult{
-				Name: CheckNameCPUGovernor,
-				Err:  fmt.Errorf("Unable to determine current CPU frequency governor policy"),
-				Warn: true,
-			})
-		}
+		results = append(results, &CheckResult{
+			Name: CheckNameCPUGovernor,
+			Err:  fmt.Errorf("Unable to determine current CPU frequency governor policy"),
+			Warn: true,
+		})
 	}
 
 	return results


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1636 

```
Currently tiup cluster check does not support checking io scheduler settings, please submit a new issue to support him.
The problem of cpufreq check result output will be completed in this issue.
```

### What is changed and how it works?

add CPU frequency check output

```
# Physical server
192.168.1.1  cpu-governor  Pass    CPU frequency governor is performance

# VM or Cloud Host
192.168.1.1  cpu-governor  Warn    Unable to determine current CPU frequency governor policy

# Fail
192.168.1.1  cpu-governor  Fail       CPU frequency governor is powersave, should use performance
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 ```shell
./tiup-cluster check ~/topology.yaml
```
*test with VM*
![image](https://user-images.githubusercontent.com/39378935/145538216-66d57a86-890e-4a11-9930-9d08a894aeae.png)


Code changes

 - Has exported function/method change

Side effects



Related changes


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
