### PR TITLE
cluster: support alertmanager configuration Listen Host

### DIFF
--- a/embed/templates/scripts/run_alertmanager.sh.tpl
+++ b/embed/templates/scripts/run_alertmanager.sh.tpl
@@ -26,4 +26,4 @@ exec bin/alertmanager/alertmanager \
     --cluster.peer="{{$am.IP}}:{{$am.ClusterPort}}" \
 {{- end}}
 {{- end}}
-    --cluster.listen-address="{{.IP}}:{{.ClusterPort}}"
+    --cluster.listen-address="{{.ListenHost}}:{{.ClusterPort}}"

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -43,6 +43,7 @@ type AlertmanagerSpec struct {
 	Arch            string               `yaml:"arch,omitempty"`
 	OS              string               `yaml:"os,omitempty"`
 	ConfigFilePath  string               `yaml:"config_file,omitempty" validate:"config_file:editable"`
+	ListenHost      string               `yaml:"listen_host,omitempty" validate:"listen_host:editable"`
 }
 
 // Role returns the component role of the instance
@@ -144,7 +145,7 @@ func (i *AlertManagerInstance) InitConfig(
 	enableTLS := gOpts.TLSEnabled
 	// Transfer start script
 	spec := i.InstanceSpec.(*AlertmanagerSpec)
-	cfg := scripts.NewAlertManagerScript(spec.Host, paths.Deploy, paths.Data[0], paths.Log, enableTLS).
+	cfg := scripts.NewAlertManagerScript(spec.Host, spec.ListenHost, paths.Deploy, paths.Data[0], paths.Log, enableTLS).
 		WithWebPort(spec.WebPort).WithClusterPort(spec.ClusterPort).WithNumaNode(spec.NumaNode).
 		AppendEndpoints(AlertManagerEndpoints(alertmanagers, deployUser, enableTLS))
 

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -35,6 +35,7 @@ type AlertmanagerSpec struct {
 	IgnoreExporter  bool                 `yaml:"ignore_exporter,omitempty"`
 	WebPort         int                  `yaml:"web_port" default:"9093"`
 	ClusterPort     int                  `yaml:"cluster_port" default:"9094"`
+	ListenHost      string               `yaml:"listen_host,omitempty" validate:"listen_host:editable"`
 	DeployDir       string               `yaml:"deploy_dir,omitempty"`
 	DataDir         string               `yaml:"data_dir,omitempty"`
 	LogDir          string               `yaml:"log_dir,omitempty"`
@@ -43,7 +44,6 @@ type AlertmanagerSpec struct {
 	Arch            string               `yaml:"arch,omitempty"`
 	OS              string               `yaml:"os,omitempty"`
 	ConfigFilePath  string               `yaml:"config_file,omitempty" validate:"config_file:editable"`
-	ListenHost      string               `yaml:"listen_host,omitempty" validate:"listen_host:editable"`
 }
 
 // Role returns the component role of the instance

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -773,6 +773,7 @@ func AlertManagerEndpoints(alertmanager []*AlertmanagerSpec, user string, enable
 
 		script := scripts.NewAlertManagerScript(
 			spec.Host,
+			spec.ListenHost,
 			deployDir,
 			dataDir,
 			logDir,

--- a/pkg/cluster/template/scripts/alertmanager.go
+++ b/pkg/cluster/template/scripts/alertmanager.go
@@ -25,6 +25,7 @@ import (
 // AlertManagerScript represent the data to generate AlertManager start script
 type AlertManagerScript struct {
 	IP          string
+	ListenHost  string
 	WebPort     int
 	ClusterPort int
 	DeployDir   string
@@ -36,9 +37,13 @@ type AlertManagerScript struct {
 }
 
 // NewAlertManagerScript returns a AlertManagerScript with given arguments
-func NewAlertManagerScript(ip, deployDir, dataDir, logDir string, enableTLS bool) *AlertManagerScript {
+func NewAlertManagerScript(ip, listenHost, deployDir, dataDir, logDir string, enableTLS bool) *AlertManagerScript {
+	if listenHost == "" {
+		listenHost = ip
+	}
 	return &AlertManagerScript{
 		IP:          ip,
+		ListenHost:  listenHost,
 		WebPort:     9093,
 		ClusterPort: 9094,
 		DeployDir:   deployDir,


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #1633 

### What is changed and how it works?
support alertmanager configuration Listen Host

add new field listen_host to Alertmanager
```
alertmanager_servers:
  # # The ip address of the Alertmanager Server.
  - host: 172.16.7.147
    listen_host: 0.0.0.0
    # # SSH port of the server.
    ssh_port: 22
```

if set listen_host: 0.0.0.0 
*run script*
```shell
cat run_alertmanager.sh 
#!/bin/bash
set -e

DEPLOY_DIR=/home/tidb-deploy/alertmanager-9093
cd "${DEPLOY_DIR}" || exit 1

# WARNING: This file was auto-generated. Do not edit!
#          All your edit might be overwritten!

exec > >(tee -i -a "/home/tidb-deploy/alertmanager-9093/log/alertmanager.log")
exec 2>&1
exec bin/alertmanager/alertmanager \
    --config.file="conf/alertmanager.yml" \
    --storage.path="/home/tidb-data/alertmanager-9093" \
    --data.retention=120h \
    --log.level="info" \
    --web.listen-address="172.16.7.147:9093" \
    --web.external-url="http://172.16.7.147:9093" \
    --cluster.peer="0.0.0.0:9094" \
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
 

Code changes

 - Has exported function/method change
 - Has interface methods change
 - Has persistent data change

Side effects


Related changes

 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
