### PR TITLE
ci: run integrate tests daily to update codecov stats

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,8 +4,19 @@ codecov:
     wait_for_ci: no
 
 coverage:
+  round: nearest
   range: 30..70
 
 ignore:
   - "pkg/cluster/api/dmpb"
   - "pkg/cluster/api/typeutil"
+
+flags:
+  tiup:
+    carryforward: true
+  cluster:
+    carryforward: true
+  dm:
+    carryforward: true
+  playground:
+    carryforward: true

--- a/.github/workflows/integrate-cluster-cmd.yaml
+++ b/.github/workflows/integrate-cluster-cmd.yaml
@@ -2,6 +2,9 @@
 name: integrate-cluster-cmd
 
 on:
+  schedule:
+    # times are in UTC
+    - cron: '19 21 * * *'
   pull_request:
     branches:
       - master

--- a/.github/workflows/integrate-cluster-cmd.yaml
+++ b/.github/workflows/integrate-cluster-cmd.yaml
@@ -112,4 +112,6 @@ jobs:
       - name: Upload coverage to Codecov
         working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,cluster -s ${{ env.working-directory }}/tests/tiup-cluster/cover -f '*.out'
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -F cluster -s ${{ env.working-directory }}/tests/tiup-cluster/cover -f '*.out'

--- a/.github/workflows/integrate-cluster-scale.yaml
+++ b/.github/workflows/integrate-cluster-scale.yaml
@@ -113,4 +113,6 @@ jobs:
       - name: Upload coverage to Codecov
         working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,cluster -s ${{ env.working-directory }}/tests/tiup-cluster/cover -f '*.out'
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -F cluster -s ${{ env.working-directory }}/tests/tiup-cluster/cover -f '*.out'

--- a/.github/workflows/integrate-cluster-scale.yaml
+++ b/.github/workflows/integrate-cluster-scale.yaml
@@ -2,6 +2,9 @@
 name: integrate-cluster-scale
 
 on:
+  schedule:
+    # times are in UTC
+    - cron: '19 21 * * *'
   pull_request:
     branches:
       - master

--- a/.github/workflows/integrate-dm.yaml
+++ b/.github/workflows/integrate-dm.yaml
@@ -117,4 +117,6 @@ jobs:
       - name: Upload coverage to Codecov
         working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,dm -s ${{ env.working-directory }}/tests/tiup-dm/cover -f '*.out'
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -F dm -s ${{ env.working-directory }}/tests/tiup-dm/cover -f '*.out'

--- a/.github/workflows/integrate-dm.yaml
+++ b/.github/workflows/integrate-dm.yaml
@@ -2,6 +2,9 @@
 name: integrate-dm
 
 on:
+  schedule:
+    # times are in UTC
+    - cron: '19 21 * * *'
   pull_request:
     branches:
       - master

--- a/.github/workflows/integrate-playground.yaml
+++ b/.github/workflows/integrate-playground.yaml
@@ -2,6 +2,9 @@
 name: integrate-playground
 
 on:
+  schedule:
+    # times are in UTC
+    - cron: '19 21 * * *'
   pull_request:
     branches:
       - master

--- a/.github/workflows/integrate-playground.yaml
+++ b/.github/workflows/integrate-playground.yaml
@@ -93,4 +93,6 @@ jobs:
       - name: Upload coverage to Codecov
         working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,playground -s ${{ env.working-directory }}/tests/tiup-playground/cover -f '*.out'
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -F playground -s ${{ env.working-directory }}/tests/tiup-playground/cover -f '*.out'

--- a/.github/workflows/integrate-tiup.yaml
+++ b/.github/workflows/integrate-tiup.yaml
@@ -2,6 +2,9 @@
 name: integrate-tiup
 
 on:
+  schedule:
+    # times are in UTC
+    - cron: '19 21 * * *'
   pull_request:
     branches:
       - master

--- a/.github/workflows/integrate-tiup.yaml
+++ b/.github/workflows/integrate-tiup.yaml
@@ -75,7 +75,9 @@ jobs:
       - name: Upload coverage to Codecov
         working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F integrate,tiup -s ${{ env.working-directory }}/tests/tiup/cover -f '*.out'
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -F tiup -s ${{ env.working-directory }}/tests/tiup/cover -f '*.out'
 
   unit-test:
     runs-on: ubuntu-latest
@@ -105,4 +107,6 @@ jobs:
       - name: Upload coverage to Codecov
         working-directory: ${{ env.working-directory }}
         run: |
-          curl -s https://codecov.io/bash | bash -s - -F unittest -s cover -f '*.out'
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -F unittest -s cover -f '*.out'

--- a/.github/workflows/release-tiup.yaml
+++ b/.github/workflows/release-tiup.yaml
@@ -16,6 +16,11 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: git ref
+        required: true
 
 jobs:
   release:
@@ -42,7 +47,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.inputs.git-ref || github.event.pull_request.head.sha }}
           path: go/src/github.com/${{ github.repository }}
           fetch-depth: 0
 

--- a/tests/tiup-cluster/test_scale_core_tls.sh
+++ b/tests/tiup-cluster/test_scale_core_tls.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/scale_core.sh
 
-echo "test scaling of core components in cluster for version v4.0.12 w/ TLS, via easy ssh"
-scale_core v4.0.12 true false
+echo "test scaling of core components in cluster for version v5.3.0 w/ TLS, via easy ssh"
+scale_core v5.3.0 true false

--- a/tests/tiup-cluster/test_scale_tools_tls.sh
+++ b/tests/tiup-cluster/test_scale_tools_tls.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/scale_tools.sh
 
-echo "test scaling of tools components in cluster for version v4.0.12 w/ TLS, via easy ssh"
-scale_tools v4.0.12 true false
+echo "test scaling of tools components in cluster for version v5.3.0 w/ TLS, via easy ssh"
+scale_tools v5.3.0 true false

--- a/tests/tiup-cluster/test_upgrade_tls.sh
+++ b/tests/tiup-cluster/test_upgrade_tls.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-old_version=${old_version-v3.0.20}
-version=${version-v4.0.12}
+old_version=${old_version-v4.0.15}
+version=${version-v5.3.0}
 
 source script/upgrade.sh
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Run integrate tests daily to update codecov stats, as we don't run full tests after merge, the codecov reports are missing some stats.
