### PR TITLE
Remove the config 'runAsDaemon' from tiflash.toml

### DIFF
--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -240,7 +240,7 @@ func (inst *TiFlashInstance) checkConfig(deployDir, clusterManagerPath string, v
 		return errors.Trace(err)
 	}
 	defer cf2.Close()
-	if err := writeTiFlashConfig(cf, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
+	if err := writeTiFlashConfig(cf, version, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
 		inst.Host, deployDir, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/cluster/ansible/service_test.go
+++ b/pkg/cluster/ansible/service_test.go
@@ -28,9 +28,6 @@ path = "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db"
 tcp_port = 11315
 tmp_path = "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db/tmp"
 
-[application]
-runAsDaemon = true
-
 [flash]
 service_addr = "172.16.5.85:11317"
 tidb_status_addr = "172.16.5.85:11310"


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tiup/issues/1671

### What is changed and how it works?
Check the TiFlash version, remove the runAsDaemon config if TiFlash is in new version(>=v5.4.0) or the nightly version.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
