### PR TITLE
cluster: render cluster name when monitoring_servers.rule_dir  is set

### DIFF
--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -416,7 +416,7 @@ func (i *MonitorInstance) initRules(ctx context.Context, e ctxt.Executor, spec *
 		return errors.Annotatef(err, "stderr: %s", string(stderr))
 	}
 
-	// rander cluster name when monitoring_servers.rule_dir is set
+	// render cluster name when monitoring_servers.rule_dir is set
 	if spec.RuleDir != "" {
 		err := i.TransferLocalConfigDir(ctx, e, spec.RuleDir, path.Join(paths.Deploy, "conf"), func(name string) bool {
 			return strings.HasSuffix(name, ".rules.yml")

--- a/pkg/cluster/spec/monitoring_test.go
+++ b/pkg/cluster/spec/monitoring_test.go
@@ -63,7 +63,7 @@ func TestLocalRuleDirs(t *testing.T) {
 	err = promInstance.initRules(ctx, e, promInstance.InstanceSpec.(*PrometheusSpec), meta.DirPaths{Deploy: deployDir}, "dummy-cluster")
 	assert.Nil(t, err)
 
-	// assert.NoFileExists(t, path.Join(deployDir, "conf", "dummy.rules.yml"))
+	assert.FileExists(t, path.Join(deployDir, "conf", "dummy.rules.yml"))
 	fs, err := os.ReadDir(localDir)
 	assert.Nil(t, err)
 	for _, f := range fs {

--- a/pkg/cluster/spec/monitoring_test.go
+++ b/pkg/cluster/spec/monitoring_test.go
@@ -63,7 +63,7 @@ func TestLocalRuleDirs(t *testing.T) {
 	err = promInstance.initRules(ctx, e, promInstance.InstanceSpec.(*PrometheusSpec), meta.DirPaths{Deploy: deployDir}, "dummy-cluster")
 	assert.Nil(t, err)
 
-	assert.NoFileExists(t, path.Join(deployDir, "conf", "dummy.rules.yml"))
+	//assert.NoFileExists(t, path.Join(deployDir, "conf", "dummy.rules.yml"))
 	fs, err := os.ReadDir(localDir)
 	assert.Nil(t, err)
 	for _, f := range fs {

--- a/pkg/cluster/spec/monitoring_test.go
+++ b/pkg/cluster/spec/monitoring_test.go
@@ -63,7 +63,7 @@ func TestLocalRuleDirs(t *testing.T) {
 	err = promInstance.initRules(ctx, e, promInstance.InstanceSpec.(*PrometheusSpec), meta.DirPaths{Deploy: deployDir}, "dummy-cluster")
 	assert.Nil(t, err)
 
-	//assert.NoFileExists(t, path.Join(deployDir, "conf", "dummy.rules.yml"))
+	// assert.NoFileExists(t, path.Join(deployDir, "conf", "dummy.rules.yml"))
 	fs, err := os.ReadDir(localDir)
 	assert.Nil(t, err)
 	for _, f := range fs {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1628 

### What is changed and how it works?

render cluster name when monitoring_servers.rule_dir  is set

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has persistent data change

Side effects


Related changes


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
