### PR TITLE
tiup/mirror: add ability to change owner of a component

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -431,7 +431,7 @@ func newTransferOwnerCmd() *cobra.Command {
 
 			// update owner info
 			return env.V1Repository().Mirror().Publish(newCompManifest, &model.PublishInfo{
-				Owner: newOwner.Name,
+				Owner: newOwnerName,
 			})
 		},
 	}

--- a/pkg/repository/model/model.go
+++ b/pkg/repository/model/model.go
@@ -197,12 +197,17 @@ func (m *model) Publish(manifest *v1manifest.Manifest, info ComponentInfo) error
 			signed := im.Signed.(*v1manifest.Index)
 			if compItem, compExist = signed.Components[componentName]; compExist {
 				// Find the owner of target component
-				o := signed.Owners[compItem.Owner]
+				var o v1manifest.Owner
+				if info.OwnerID() != "" {
+					o = signed.Owners[info.OwnerID()]
+				} else {
+					o = signed.Owners[compItem.Owner]
+				}
 				owner = &o
 				if info.Yanked() == nil &&
 					info.Hidden() == nil &&
 					info.Standalone() == nil &&
-					info.OwnerName() == "" {
+					info.OwnerID() == "" {
 					// No changes on index.json
 					return nil, nil
 				}
@@ -228,8 +233,8 @@ func (m *model) Publish(manifest *v1manifest.Manifest, info ComponentInfo) error
 			if info.Standalone() != nil {
 				compItem.Standalone = *info.Standalone()
 			}
-			if info.OwnerName() != "" {
-				compItem.Owner = info.OwnerName()
+			if info.OwnerID() != "" {
+				compItem.Owner = info.OwnerID()
 			}
 
 			signed.Components[componentName] = compItem

--- a/pkg/repository/model/publish.go
+++ b/pkg/repository/model/publish.go
@@ -30,6 +30,7 @@ type ComponentInfo interface {
 	Standalone() *bool
 	Yanked() *bool
 	Hidden() *bool
+	OwnerName() string
 }
 
 // PublishInfo implements ComponentInfo
@@ -38,6 +39,7 @@ type PublishInfo struct {
 	Stand *bool
 	Yank  *bool
 	Hide  *bool
+	Owner string
 }
 
 // TarInfo implements ComponentData
@@ -72,4 +74,9 @@ func (i *PublishInfo) Yanked() *bool {
 // Hidden implements ComponentInfo
 func (i *PublishInfo) Hidden() *bool {
 	return i.Hide
+}
+
+// OwnerName implements ComponentInfo
+func (i *PublishInfo) OwnerName() string {
+	return i.Owner
 }

--- a/pkg/repository/model/publish.go
+++ b/pkg/repository/model/publish.go
@@ -30,7 +30,7 @@ type ComponentInfo interface {
 	Standalone() *bool
 	Yanked() *bool
 	Hidden() *bool
-	OwnerName() string
+	OwnerID() string
 }
 
 // PublishInfo implements ComponentInfo
@@ -76,7 +76,7 @@ func (i *PublishInfo) Hidden() *bool {
 	return i.Hide
 }
 
-// OwnerName implements ComponentInfo
-func (i *PublishInfo) OwnerName() string {
+// OwnerID implements ComponentInfo
+func (i *PublishInfo) OwnerID() string {
 	return i.Owner
 }

--- a/server/rotate/component.go
+++ b/server/rotate/component.go
@@ -56,7 +56,7 @@ func ServeComponent(addr string, owner *v1manifest.Owner, comp *v1manifest.Compo
 	}()
 
 	manifest := &v1manifest.Manifest{Signed: comp}
-	status := newStatusRender(manifest, addr)
+	status := newStatusRender(owner.Keys, addr, uri)
 	defer status.stop()
 
 SIGLOOP:

--- a/server/rotate/component.go
+++ b/server/rotate/component.go
@@ -1,0 +1,100 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rotate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	cjson "github.com/gibson042/canonicaljson-go"
+	"github.com/gorilla/mux"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/fn"
+	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
+	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	"github.com/pingcap/tiup/pkg/utils"
+)
+
+// ServeComponent starts a temp server for receiving component signatures from owner
+func ServeComponent(addr string, owner *v1manifest.Owner, comp *v1manifest.Component) (*v1manifest.Manifest, error) {
+	r := mux.NewRouter()
+	uri := fmt.Sprintf("/rotate/%s", utils.Base62Tag())
+
+	r.Handle(uri, fn.Wrap(func() (*v1manifest.Manifest, error) {
+		return &v1manifest.Manifest{Signed: comp}, nil
+	})).Methods("GET")
+
+	sigCh := make(chan v1manifest.Signature)
+	r.Handle(uri, fn.Wrap(func(m *v1manifest.RawManifest) (*v1manifest.Manifest /* always nil */, error) {
+		for _, sig := range m.Signatures {
+			if err := verifyComponentSig(sig, owner, comp); err != nil {
+				return nil, err
+			}
+			sigCh <- sig
+		}
+		return nil, nil
+	})).Methods("POST")
+
+	srv := &http.Server{Addr: addr, Handler: r}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			logprinter.Errorf("server closed: %s", err.Error())
+		}
+		close(sigCh)
+	}()
+
+	manifest := &v1manifest.Manifest{Signed: comp}
+	status := newStatusRender(manifest, addr)
+	defer status.stop()
+
+SIGLOOP:
+	for sig := range sigCh {
+		for _, s := range manifest.Signatures {
+			if s.KeyID == sig.KeyID {
+				// Duplicate signature
+				continue SIGLOOP
+			}
+		}
+		manifest.Signatures = append(manifest.Signatures, sig)
+		status.render(manifest)
+		if len(manifest.Signatures) == len(owner.Keys) {
+			_ = srv.Shutdown(context.Background())
+			break
+		}
+	}
+
+	if len(manifest.Signatures) != len(owner.Keys) {
+		return nil, errors.New("no enough signature collected before server shutdown")
+	}
+	return manifest, nil
+}
+
+func verifyComponentSig(sig v1manifest.Signature, owner *v1manifest.Owner, comp *v1manifest.Component) error {
+	payload, err := cjson.Marshal(comp)
+	if err != nil {
+		return fn.ErrorWithStatusCode(errors.Annotate(err, "marshal component manifest"), http.StatusInternalServerError)
+	}
+
+	k := owner.Keys[sig.KeyID]
+	if k == nil {
+		// Received a signature signed by an invalid key
+		return fn.ErrorWithStatusCode(errors.New("the key is not valid"), http.StatusNotAcceptable)
+	}
+	if err := k.Verify(payload, sig.Sig); err != nil {
+		// Received an invalid signature
+		return fn.ErrorWithStatusCode(errors.New("the signature is not valid"), http.StatusNotAcceptable)
+	}
+	return nil
+}

--- a/server/rotate/root.go
+++ b/server/rotate/root.go
@@ -56,7 +56,7 @@ func ServeRoot(addr string, root *v1manifest.Root) (*v1manifest.Manifest, error)
 	}()
 
 	manifest := &v1manifest.Manifest{Signed: root}
-	status := newStatusRender(manifest, addr)
+	status := newStatusRender(root.Roles[v1manifest.ManifestTypeRoot].Keys, addr, uri)
 	defer status.stop()
 
 SIGLOOP:

--- a/server/rotate/root.go
+++ b/server/rotate/root.go
@@ -1,11 +1,22 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rotate
 
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
-	"strings"
 
 	cjson "github.com/gibson042/canonicaljson-go"
 	"github.com/gorilla/mux"
@@ -13,63 +24,22 @@ import (
 	"github.com/pingcap/fn"
 	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
 	"github.com/pingcap/tiup/pkg/repository/v1manifest"
-	"github.com/pingcap/tiup/pkg/tui/progress"
+	"github.com/pingcap/tiup/pkg/utils"
 )
 
-type statusRender struct {
-	mbar *progress.MultiBar
-	bars map[string]*progress.MultiBarItem
-}
-
-func newStatusRender(manifest *v1manifest.Manifest, addr string) *statusRender {
-	ss := strings.Split(addr, ":")
-	if strings.Trim(ss[0], " ") == "" || strings.Trim(ss[0], " ") == "0.0.0.0" {
-		addrs, _ := net.InterfaceAddrs()
-		for _, addr := range addrs {
-			if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() && ip.IP.To4() != nil {
-				ss[0] = ip.IP.To4().String()
-				break
-			}
-		}
-	}
-
-	status := &statusRender{
-		mbar: progress.NewMultiBar(fmt.Sprintf("Waiting all administrators to sign http://%s/rotate/root.json", strings.Join(ss, ":"))),
-		bars: make(map[string]*progress.MultiBarItem),
-	}
-	root := manifest.Signed.(*v1manifest.Root)
-	for key := range root.Roles[v1manifest.ManifestTypeRoot].Keys {
-		status.bars[key] = status.mbar.AddBar(fmt.Sprintf("  - Waiting key %s", key))
-	}
-	status.mbar.StartRenderLoop()
-	return status
-}
-
-func (s *statusRender) render(manifest *v1manifest.Manifest) {
-	for _, sig := range manifest.Signatures {
-		s.bars[sig.KeyID].UpdateDisplay(&progress.DisplayProps{
-			Prefix: fmt.Sprintf("  - Waiting key %s", sig.KeyID),
-			Mode:   progress.ModeDone,
-		})
-	}
-}
-
-func (s *statusRender) stop() {
-	s.mbar.StopRenderLoop()
-}
-
-// Serve starts a temp server for receiving signatures from administrators
-func Serve(addr string, root *v1manifest.Root) (*v1manifest.Manifest, error) {
+// ServeRoot starts a temp server for receiving root signatures from administrators
+func ServeRoot(addr string, root *v1manifest.Root) (*v1manifest.Manifest, error) {
 	r := mux.NewRouter()
+	uri := fmt.Sprintf("/rotate/%s", utils.Base62Tag())
 
-	r.Handle("/rotate/root.json", fn.Wrap(func() (*v1manifest.Manifest, error) {
+	r.Handle(uri, fn.Wrap(func() (*v1manifest.Manifest, error) {
 		return &v1manifest.Manifest{Signed: root}, nil
 	})).Methods("GET")
 
 	sigCh := make(chan v1manifest.Signature)
-	r.Handle("/rotate/root.json", fn.Wrap(func(m *v1manifest.RawManifest) (*v1manifest.Manifest /* always nil */, error) {
+	r.Handle(uri, fn.Wrap(func(m *v1manifest.RawManifest) (*v1manifest.Manifest /* always nil */, error) {
 		for _, sig := range m.Signatures {
-			if err := verifySig(sig, root); err != nil {
+			if err := verifyRootSig(sig, root); err != nil {
 				return nil, err
 			}
 			sigCh <- sig
@@ -111,7 +81,7 @@ SIGLOOP:
 	return manifest, nil
 }
 
-func verifySig(sig v1manifest.Signature, root *v1manifest.Root) error {
+func verifyRootSig(sig v1manifest.Signature, root *v1manifest.Root) error {
 	payload, err := cjson.Marshal(root)
 	if err != nil {
 		return fn.ErrorWithStatusCode(errors.Annotate(err, "marshal root manifest"), http.StatusInternalServerError)

--- a/server/rotate/server.go
+++ b/server/rotate/server.go
@@ -1,0 +1,65 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rotate
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/pingcap/tiup/pkg/repository/v1manifest"
+	"github.com/pingcap/tiup/pkg/tui/progress"
+)
+
+type statusRender struct {
+	mbar *progress.MultiBar
+	bars map[string]*progress.MultiBarItem
+}
+
+func newStatusRender(manifest *v1manifest.Manifest, addr string) *statusRender {
+	ss := strings.Split(addr, ":")
+	if strings.Trim(ss[0], " ") == "" || strings.Trim(ss[0], " ") == "0.0.0.0" {
+		addrs, _ := net.InterfaceAddrs()
+		for _, addr := range addrs {
+			if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() && ip.IP.To4() != nil {
+				ss[0] = ip.IP.To4().String()
+				break
+			}
+		}
+	}
+
+	status := &statusRender{
+		mbar: progress.NewMultiBar(fmt.Sprintf("Waiting all administrators to sign http://%s/rotate/root.json", strings.Join(ss, ":"))),
+		bars: make(map[string]*progress.MultiBarItem),
+	}
+	root := manifest.Signed.(*v1manifest.Root)
+	for key := range root.Roles[v1manifest.ManifestTypeRoot].Keys {
+		status.bars[key] = status.mbar.AddBar(fmt.Sprintf("  - Waiting key %s", key))
+	}
+	status.mbar.StartRenderLoop()
+	return status
+}
+
+func (s *statusRender) render(manifest *v1manifest.Manifest) {
+	for _, sig := range manifest.Signatures {
+		s.bars[sig.KeyID].UpdateDisplay(&progress.DisplayProps{
+			Prefix: fmt.Sprintf("  - Waiting key %s", sig.KeyID),
+			Mode:   progress.ModeDone,
+		})
+	}
+}
+
+func (s *statusRender) stop() {
+	s.mbar.StopRenderLoop()
+}

--- a/server/rotate/server.go
+++ b/server/rotate/server.go
@@ -27,7 +27,7 @@ type statusRender struct {
 	bars map[string]*progress.MultiBarItem
 }
 
-func newStatusRender(manifest *v1manifest.Manifest, addr string) *statusRender {
+func newStatusRender(keys map[string]*v1manifest.KeyInfo, addr, uri string) *statusRender {
 	ss := strings.Split(addr, ":")
 	if strings.Trim(ss[0], " ") == "" || strings.Trim(ss[0], " ") == "0.0.0.0" {
 		addrs, _ := net.InterfaceAddrs()
@@ -40,11 +40,10 @@ func newStatusRender(manifest *v1manifest.Manifest, addr string) *statusRender {
 	}
 
 	status := &statusRender{
-		mbar: progress.NewMultiBar(fmt.Sprintf("Waiting all administrators to sign http://%s/rotate/root.json", strings.Join(ss, ":"))),
+		mbar: progress.NewMultiBar(fmt.Sprintf("Waiting all key holders to sign http://%s%s", strings.Join(ss, ":"), uri)),
 		bars: make(map[string]*progress.MultiBarItem),
 	}
-	root := manifest.Signed.(*v1manifest.Root)
-	for key := range root.Roles[v1manifest.ManifestTypeRoot].Keys {
+	for key := range keys {
 		status.bars[key] = status.mbar.AddBar(fmt.Sprintf("  - Waiting key %s", key))
 	}
 	status.mbar.StartRenderLoop()


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Change the owner of a component.

### What is changed and how it works?
Use a process like rotating `root.json`:
 - On server side, the server admin run `tiup mirror transfer-owner` command to initialize a owner transfer process
 - The existence of new owner is checked, then open a temp HTTP server to serve the `component.json`
 - Client with the new owner's private key use `tiup mirror sign` to sign that temp URL
 - Server validate the signature received and update `component.json` along with `index.json`

The process is a pure administration operation, and could be used without the participate of old owner of the component, so that it also works if the old owner is absent for long time and can not be contacted.

The new owner must be granted before the transfer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has interface methods change

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
