### PR TITLE
cluster: support init root password

### DIFF
--- a/components/bench/Makefile
+++ b/components/bench/Makefile
@@ -77,8 +77,7 @@ tidy:
 clean:
 	@# Target: run the build cleanup steps
 	@rm -rf bin
-	@rm -rf cover
-	@rm -rf tests/*/{bin/*.test,logs,cover/*.out}
+	@rm -rf tests/*/{bin/*.test,logs}
 
 test: failpoint-enable run-tests failpoint-disable
 	@# Target: run tests with failpoint enabled
@@ -91,7 +90,7 @@ run-tests: unit-test
 # Run tests
 unit-test:
 	@# Target: run the code coverage test phase
-	mkdir -p cover
+	mkdir -p ../../cover
 	TIUP_HOME=$(shell pwd)/../../tests/tiup $(GOTEST) ./... -covermode=count -coverprofile ../../cover/cov.unit-test.out
 
 race: failpoint-enable

--- a/components/bench/Makefile
+++ b/components/bench/Makefile
@@ -91,7 +91,7 @@ run-tests: unit-test
 unit-test:
 	@# Target: run the code coverage test phase
 	mkdir -p ../../cover
-	TIUP_HOME=$(shell pwd)/../../tests/tiup $(GOTEST) ./... -covermode=count -coverprofile ../../cover/cov.unit-test.out
+	TIUP_HOME=$(shell pwd)/../../tests/tiup $(GOTEST) ./... -covermode=count -coverprofile ../../cover/cov.unit-test.bench.out
 
 race: failpoint-enable
 	@# Target: run race check with failpoint enabled

--- a/components/client/Makefile
+++ b/components/client/Makefile
@@ -77,8 +77,7 @@ tidy:
 clean:
 	@# Target: run the build cleanup steps
 	@rm -rf bin
-	@rm -rf cover
-	@rm -rf tests/*/{bin/*.test,logs,cover/*.out}
+	@rm -rf tests/*/{bin/*.test,logs}
 
 test: failpoint-enable run-tests failpoint-disable
 	@# Target: run tests with failpoint enabled
@@ -91,7 +90,7 @@ run-tests: unit-test
 # Run tests
 unit-test:
 	@# Target: run the code coverage test phase
-	mkdir -p cover
+	mkdir -p ../../cover
 	TIUP_HOME=$(shell pwd)/../../tests/tiup $(GOTEST) ./... -covermode=count -coverprofile ../../cover/cov.unit-test.out
 
 race: failpoint-enable

--- a/components/client/Makefile
+++ b/components/client/Makefile
@@ -91,7 +91,7 @@ run-tests: unit-test
 unit-test:
 	@# Target: run the code coverage test phase
 	mkdir -p ../../cover
-	TIUP_HOME=$(shell pwd)/../../tests/tiup $(GOTEST) ./... -covermode=count -coverprofile ../../cover/cov.unit-test.out
+	TIUP_HOME=$(shell pwd)/../../tests/tiup $(GOTEST) ./... -covermode=count -coverprofile ../../cover/cov.unit-test.client.out
 
 race: failpoint-enable
 	@# Target: run race check with failpoint enabled

--- a/components/cluster/command/start.go
+++ b/components/cluster/command/start.go
@@ -73,7 +73,7 @@ func newStartCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&initPasswd, "init-passwd", false, "Initialize a secure root password for the database")
+	cmd.Flags().BoolVar(&initPasswd, "init", false, "Initialize a secure root password for the database")
 	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only start specified nodes")
 
@@ -88,7 +88,7 @@ func initPassword(clusterName string) (string, error) {
 	tcpProxy := proxy.GetTCPProxy()
 
 	// generate password
-	pwd, err := rand.Password(16)
+	pwd, err := rand.Password(18)
 	if err != nil {
 		return pwd, err
 	}

--- a/components/cluster/command/start.go
+++ b/components/cluster/command/start.go
@@ -65,7 +65,8 @@ func newStartCmd() *cobra.Command {
 					log.Errorf("failed to set root password of TiDB database to '%s'", pwd)
 					return err
 				}
-				log.Warnf("The root password of TiDB database has been changed to '%s'.", color.HiYellowString(pwd))
+				log.Warnf("The root password of TiDB database has been changed.")
+				fmt.Printf("The new password is: '%s'.", color.HiYellowString(pwd)) // use fmt to avoid printing to audit log
 				log.Warnf("Copy and record it to somewhere safe, %s, and will not be stored.", color.HiRedString("it is only displayed once"))
 				log.Warnf("The generated password %s.", color.HiRedString("could NOT be get and shown again"))
 			}

--- a/components/cluster/command/test.go
+++ b/components/cluster/command/test.go
@@ -15,7 +15,6 @@ package command
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 
@@ -70,13 +69,6 @@ func newTestCmd() *cobra.Command {
 	}
 
 	return cmd
-}
-
-func createDB(endpoint string) (db *sql.DB, err error) {
-	dsn := fmt.Sprintf("root:@tcp(%s)/?charset=utf8mb4,utf8&multiStatements=true", endpoint)
-	db, err = sql.Open("mysql", dsn)
-
-	return
 }
 
 // To check if test.ti_cluster has data

--- a/embed/templates/scripts/run_tidb.sh.tpl
+++ b/embed/templates/scripts/run_tidb.sh.tpl
@@ -27,6 +27,9 @@ exec env GODEBUG=madvdontneed=1 bin/tidb-server \
     --host="{{.ListenHost}}" \
     --advertise-address="{{.AdvertiseAddr}}" \
     --store="tikv" \
+{{- if .SupportSecboot}}
+    --initialize-insecure \
+{{- end}}
     --path="{{template "PDList" .Endpoints}}" \
     --log-slow-query="{{.LogDir}}/tidb_slow_query.log" \
     --config=conf/tidb.toml \

--- a/examples
+++ b/examples
@@ -1,1 +1,1 @@
-embed/templates/examples
+embed/examples

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/r3labs/diff/v2 v2.14.0
 	github.com/relex/aini v1.5.0
 	github.com/sergi/go-diff v1.2.0
+	github.com/sethvargo/go-password v0.2.0
 	github.com/shirou/gopsutil v3.21.8+incompatible
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -483,6 +483,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
+github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
 github.com/shirou/gopsutil v3.21.8+incompatible h1:sh0foI8tMRlCidUJR+KzqWYWxrkuuPIGiO6Vp+KXdCU=
 github.com/shirou/gopsutil v3.21.8+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=

--- a/pkg/cluster/spec/tidb.go
+++ b/pkg/cluster/spec/tidb.go
@@ -138,11 +138,6 @@ func (i *TiDBInstance) InitConfig(
 
 	enableTLS := topo.GlobalOptions.TLSEnabled
 	spec := i.InstanceSpec.(*TiDBSpec)
-	// check if the tidb version has --initialize-insecure support
-	hasSecbootSupport := false
-	if vc := semver.Compare(clusterVersion, "v5.3.0"); vc >= 0 {
-		hasSecbootSupport = true
-	}
 	cfg := scripts.
 		NewTiDBScript(i.GetHost(), paths.Deploy, paths.Log).
 		WithPort(spec.Port).
@@ -151,7 +146,7 @@ func (i *TiDBInstance) InitConfig(
 		AppendEndpoints(topo.Endpoints(deployUser)...).
 		WithListenHost(i.GetListenHost()).
 		WithAdvertiseAddr(spec.Host).
-		SupportSecureBootstrap(hasSecbootSupport)
+		SupportSecureBootstrap(semver.Compare(clusterVersion, "v5.3.0") >= 0)
 	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_tidb_%s_%d.sh", i.GetHost(), i.GetPort()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err

--- a/pkg/cluster/spec/tidb.go
+++ b/pkg/cluster/spec/tidb.go
@@ -140,7 +140,7 @@ func (i *TiDBInstance) InitConfig(
 	spec := i.InstanceSpec.(*TiDBSpec)
 	// check if the tidb version has --initialize-insecure support
 	hasSecbootSupport := false
-	if vc := semver.Compare(clusterVersion, "5.3.0"); vc >= 0 {
+	if vc := semver.Compare(clusterVersion, "v5.3.0"); vc >= 0 {
 		hasSecbootSupport = true
 	}
 	cfg := scripts.

--- a/pkg/cluster/template/scripts/tidb.go
+++ b/pkg/cluster/template/scripts/tidb.go
@@ -24,15 +24,16 @@ import (
 
 // TiDBScript represent the data to generate TiDB config
 type TiDBScript struct {
-	IP            string
-	ListenHost    string
-	AdvertiseAddr string
-	Port          int
-	StatusPort    int
-	DeployDir     string
-	LogDir        string
-	NumaNode      string
-	Endpoints     []*PDScript
+	IP             string
+	ListenHost     string
+	AdvertiseAddr  string
+	Port           int
+	StatusPort     int
+	DeployDir      string
+	LogDir         string
+	NumaNode       string
+	SupportSecboot bool
+	Endpoints      []*PDScript
 }
 
 // NewTiDBScript returns a TiDBScript with given arguments
@@ -76,6 +77,12 @@ func (c *TiDBScript) WithStatusPort(port int) *TiDBScript {
 // WithNumaNode set NumaNode field of TiDBScript
 func (c *TiDBScript) WithNumaNode(numa string) *TiDBScript {
 	c.NumaNode = numa
+	return c
+}
+
+// SupportSecureBootstrap set SupportSecboot field of TiDBScript
+func (c *TiDBScript) SupportSecureBootstrap(s bool) *TiDBScript {
+	c.SupportSecboot = s
 	return c
 }
 

--- a/pkg/crypto/rand/passwd.go
+++ b/pkg/crypto/rand/passwd.go
@@ -1,0 +1,53 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rand
+
+import (
+	"github.com/sethvargo/go-password/password"
+)
+
+// charsets with some in similar shapes removed (e.g., O, o, I, l, etc.)
+const (
+	lowerLetters = "abcdefghijkmnpqrstuvwxyz"
+	upperLetters = "ABCDEFGHJKLMNPQRSTUVWXYZ"
+	digits       = "0123456789"
+	symbols      = "!@#$%^&*+-=_"
+)
+
+// Password generates a random password
+func Password(length int) (string, error) {
+	if length < 8 {
+		panic("password length muster be at least 8.")
+	}
+
+	gi := &password.GeneratorInput{
+		LowerLetters: lowerLetters,
+		UpperLetters: upperLetters,
+		Digits:       digits,
+		Symbols:      symbols,
+		Reader:       Reader,
+	}
+	g, err := password.NewGenerator(gi)
+	if err != nil {
+		return "", err
+	}
+
+	// 1/3 of the password are digits and 1/4 of it are symbols
+	numDigits := length / 3
+	numSymbols := length / 4
+	// allow repeat if the length is longer than the shortest charset
+	allowRepeat := (length >= 10)
+
+	return g.Generate(length, numDigits, numSymbols, false, allowRepeat)
+}

--- a/pkg/crypto/rand/passwd.go
+++ b/pkg/crypto/rand/passwd.go
@@ -47,7 +47,7 @@ func Password(length int) (string, error) {
 	numDigits := length / 3
 	numSymbols := length / 4
 	// allow repeat if the length is longer than the shortest charset
-	allowRepeat := (length >= 10)
+	allowRepeat := (numDigits > len(digits) || numSymbols > len(symbols))
 
 	return g.Generate(length, numDigits, numSymbols, false, allowRepeat)
 }

--- a/pkg/crypto/rand/passwd_test.go
+++ b/pkg/crypto/rand/passwd_test.go
@@ -20,7 +20,7 @@ import (
 func TestPasswd(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		l := Intn(64)
-		if l < 8 { // make suer it's greater than 8
+		if l < 8 { // make sure it's greater than 8
 			l += 8
 		}
 		t.Logf("generating random password of length %d", l)

--- a/pkg/crypto/rand/passwd_test.go
+++ b/pkg/crypto/rand/passwd_test.go
@@ -1,0 +1,36 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rand
+
+import (
+	"testing"
+)
+
+func TestPasswd(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		l := Intn(64)
+		if l < 8 { // make suer it's greater than 8
+			l += 8
+		}
+		t.Logf("generating random password of length %d", l)
+		p, e := Password(l)
+		if e != nil {
+			t.Error(e)
+		}
+		t.Log(p)
+		if len(p) != l {
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1660 

### What is changed and how it works?
An `--init` argument is added to `tiup-cluster start` subcommand, it generates a 18 chars long random password and set it to the `root@'%'` user.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
