### PR TITLE
cluster: scale-out topology cannot inherit the global configuration

### DIFF
--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -78,7 +78,7 @@ func (m *Manager) CheckCluster(clusterOrTopoName, scaleoutTopo string, opt Check
 			topo.MonitoredOptions = currTopo.MonitoredOptions
 			topo.ServerConfigs = currTopo.ServerConfigs
 
-			if err := spec.ParseTopologyYaml(scaleoutTopo, &topo); err != nil {
+			if err := spec.ParseTopologyYaml(scaleoutTopo, &topo, true); err != nil {
 				return err
 			}
 			spec.ExpandRelativeDir(&topo)

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -88,7 +88,7 @@ func (m *Manager) ScaleOut(
 		// The no tispark master error is ignored, as if the tispark master is removed from the topology
 		// file for some reason (manual edit, for example), it is still possible to scale-out it to make
 		// the whole topology back to normal state.
-		if err := spec.ParseTopologyYaml(topoFile, newPart); err != nil &&
+		if err := spec.ParseTopologyYaml(topoFile, newPart, true); err != nil &&
 			!errors.Is(perrs.Cause(err), spec.ErrNoTiSparkMaster) {
 			return err
 		}

--- a/pkg/cluster/spec/parse_topology.go
+++ b/pkg/cluster/spec/parse_topology.go
@@ -69,8 +69,8 @@ func ParseTopologyYaml(file string, out Topology, ignoreGlobal ...bool) error {
 		return err
 	}
 
+	// keep the global config in out
 	if len(ignoreGlobal) > 0 && ignoreGlobal[0] {
-		// // keep the global config in out
 		var newTopo map[string]interface{}
 		if err := yaml.Unmarshal(yamlFile, &newTopo); err != nil {
 			return err

--- a/pkg/cluster/spec/parse_topology.go
+++ b/pkg/cluster/spec/parse_topology.go
@@ -56,7 +56,8 @@ To generate a sample topology file:
 }
 
 // ParseTopologyYaml read yaml content from `file` and unmarshal it to `out`
-func ParseTopologyYaml(file string, out Topology) error {
+// ignoreGlobal ignore global variables in file, only ignoreGlobal with a index of 0 is effective
+func ParseTopologyYaml(file string, out Topology, ignoreGlobal ...bool) error {
 	suggestionProps := map[string]string{
 		"File": file,
 	}
@@ -68,22 +69,22 @@ func ParseTopologyYaml(file string, out Topology) error {
 		return err
 	}
 
-	// if {
-	// 	// // keep the global config in out
-	// 	var newTopo map[string]interface{}
-	// 	if err := yaml.Unmarshal(yamlFile, &newTopo); err != nil {
-	// 		return err
-	// 	}
-	// 	for k := range newTopo {
-	// 		switch k {
-	// 		case "global",
-	// 			"monitored",
-	// 			"server_configs":
-	// 			delete(newTopo, k)
-	// 		}
-	// 	}
-	// 	yamlFile, _ = yaml.Marshal(newTopo)
-	// }
+	if len(ignoreGlobal) > 0 && ignoreGlobal[0] {
+		// // keep the global config in out
+		var newTopo map[string]interface{}
+		if err := yaml.Unmarshal(yamlFile, &newTopo); err != nil {
+			return err
+		}
+		for k := range newTopo {
+			switch k {
+			case "global",
+				"monitored",
+				"server_configs":
+				delete(newTopo, k)
+			}
+		}
+		yamlFile, _ = yaml.Marshal(newTopo)
+	}
 
 	if err = yaml.UnmarshalStrict(yamlFile, out); err != nil {
 		return ErrTopologyParseFailed.

--- a/pkg/cluster/spec/parse_topology.go
+++ b/pkg/cluster/spec/parse_topology.go
@@ -68,6 +68,23 @@ func ParseTopologyYaml(file string, out Topology) error {
 		return err
 	}
 
+	// if {
+	// 	// // keep the global config in out
+	// 	var newTopo map[string]interface{}
+	// 	if err := yaml.Unmarshal(yamlFile, &newTopo); err != nil {
+	// 		return err
+	// 	}
+	// 	for k := range newTopo {
+	// 		switch k {
+	// 		case "global",
+	// 			"monitored",
+	// 			"server_configs":
+	// 			delete(newTopo, k)
+	// 		}
+	// 	}
+	// 	yamlFile, _ = yaml.Marshal(newTopo)
+	// }
+
 	if err = yaml.UnmarshalStrict(yamlFile, out); err != nil {
 		return ErrTopologyParseFailed.
 			Wrap(err, "Failed to parse topology file %s", file).

--- a/pkg/cluster/spec/parse_topology_test.go
+++ b/pkg/cluster/spec/parse_topology_test.go
@@ -61,6 +61,16 @@ func (s *topoSuite) TestParseTopologyYaml(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
+func (s *topoSuite) TestParseTopologyYamlIgnoreGlobal(c *check.C) {
+	file := filepath.Join("testdata", "topology_err.yaml")
+	topo := Specification{}
+	err := ParseTopologyYaml(file, &topo, true)
+	if topo.GlobalOptions.DeployDir == "/tidb/deploy" {
+		c.Error("Can not Ignore Global variables")
+	}
+	c.Assert(err, check.IsNil)
+}
+
 func (s *topoSuite) TestRelativePath(c *check.C) {
 	// test relative path
 	withTempFile(`

--- a/pkg/cluster/spec/parse_topology_test.go
+++ b/pkg/cluster/spec/parse_topology_test.go
@@ -66,7 +66,7 @@ func (s *topoSuite) TestParseTopologyYamlIgnoreGlobal(c *check.C) {
 	topo := Specification{}
 	err := ParseTopologyYaml(file, &topo, true)
 	if topo.GlobalOptions.DeployDir == "/tidb/deploy" {
-		c.Error("Can not Ignore Global variables")
+		c.Error("Can not ignore global variables")
 	}
 	c.Assert(err, check.IsNil)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1697 

### What is changed and how it works?

scale-out topology cannot inherit the global configuration

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)


Code changes

 - Has interface methods change

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
