### PR TITLE
mirror: Fix typos and naming

### DIFF
--- a/doc/user/mirrors.md
+++ b/doc/user/mirrors.md
@@ -1,10 +1,10 @@
 # Build a private mirror
 
-When building a private cloud, it is common to use an isolated network environment where the official mirror of TiUP is not accessible, so we provide a solution for building a private mirror, which is mainly implemented by the mirrors component, which can also be used for offline deployment.
+When building a private cloud, it is common to use an isolated network environment where the official mirror of TiUP is not accessible, so we provide a solution for building a private mirror, which is mainly implemented by the mirror component, which can also be used for offline deployment.
 
 ## Mirrors component introduction
 
-First, let's look at the `mirrors' help file.
+First, let's look at the `mirror' help file.
 
 ```bash
 $ tiup mirror --help

--- a/doc/user/mirrors.md
+++ b/doc/user/mirrors.md
@@ -57,7 +57,7 @@ If `--full` is specified, the official image will be cloned intact.
 ### 3. Platform limitation
 
 If you only want to clone packages for a particular platform, you can use `-os` and `-arch` to qualify:
-- `tiup mirror <target-dir> ---os=linux`
+- `tiup mirror clone <target-dir> ---os=linux`
 - Just want to clone amd64 architecture: `tiup mirror <target-dir> --arch=amd64`
 - Just want to clone linux/amd64: `tiup mirror <target-dir> --os=linux --arch=amd64`
 

--- a/doc/user/mirrors.md
+++ b/doc/user/mirrors.md
@@ -38,7 +38,7 @@ Global Flags:
 Use "tiup mirror [command] --help" for more information about a command.
 ```
 
-Its basic use is `tiup mirror <target-dir> [global-version] [flags]`, the target-dir is the directory in which the cloned data needs to be placed. global-version is used to quickly set a common version for all components.
+Its basic use is `tiup mirror clone <target-dir> [global-version] [flags]`, the target-dir is the directory in which the cloned data needs to be placed. global-version is used to quickly set a common version for all components.
 
 Then this order has very scary dozens of flags and even more later. But there is no need to be intimidated by the number of these flags, which are in fact of four types.
 
@@ -58,15 +58,15 @@ If `--full` is specified, the official image will be cloned intact.
 
 If you only want to clone packages for a particular platform, you can use `-os` and `-arch` to qualify:
 - `tiup mirror clone <target-dir> ---os=linux`
-- Just want to clone amd64 architecture: `tiup mirror <target-dir> --arch=amd64`
-- Just want to clone linux/amd64: `tiup mirror <target-dir> --os=linux --arch=amd64`
+- Just want to clone amd64 architecture: `tiup mirror clone <target-dir> --arch=amd64`
+- Just want to clone linux/amd64: `tiup mirror clone <target-dir> --os=linux --arch=amd64`
 
 ### 4. Component version limited
 
 If you want to clone only one version of a component and not all versions, use `--<component>=<version>` to qualify, for example "
-- Just want to clone the v4 version of tidb: `tiup mirror <target-dir> --tidb v4`
-- Just want to clone the v4 version of tidb, and all versions of tikv: `tiup mirror <target-dir> --tidb v4 --tikv all` 
-- Clone specific versions of all components that start a cluster: `tiup mirror <target-dir> v4.0.0-rc`
+- Just want to clone the v4 version of tidb: `tiup mirror clone <target-dir> --tidb v4`
+- Just want to clone the v4 version of tidb, and all versions of tikv: `tiup mirror clone <target-dir> --tidb v4 --tikv all` 
+- Clone specific versions of all components that start a cluster: `tiup mirror clone <target-dir> v4.0.0-rc`
 
 ## The real thing
 
@@ -99,7 +99,7 @@ export TIUP_MIRRORS=/path/to/mirror
 tiup cluster xxx
 ```
 
-`/path/to/mirror` is the location of <target-dir> in `tiup mirror <target-dir>`, or if in /tmp/package:
+`/path/to/mirror` is the location of <target-dir> in `tiup mirror clone <target-dir>`, or if in /tmp/package:
 ```bash
 export TIUP_MIRRORS=/tmp/package
 ```

--- a/doc/user/mirrors.md
+++ b/doc/user/mirrors.md
@@ -1,55 +1,44 @@
 # Build a private mirror
 
-When building a private cloud, it is common to use an isolated network environment where the official mirror of TiUP is not accessible, so we provide a solution for building a private mirror, which is mainly implemented by the mirros component, which can also be used for offline deployment.
+When building a private cloud, it is common to use an isolated network environment where the official mirror of TiUP is not accessible, so we provide a solution for building a private mirror, which is mainly implemented by the mirrors component, which can also be used for offline deployment.
 
 ## Mirrors component introduction
 
 First, let's look at the `mirrors' help file.
 
 ```bash
-$ tiup mirrors --help
-Starting component `mirrors`: /Users/joshua/.tiup/components/mirrors/v0.0.1/mirrors
-Build a local mirrors and download all selected components
+$ tiup mirror --help
+The 'mirror' command is used to manage a component repository for TiUP, you can use
+it to create a private repository, or to add new component to an existing repository.
+The repository can be used either online or offline.
+It also provides some useful utilities to help managing keys, users and versions
+of components or the repository itself.
 
 Usage:
-  tiup mirrors <target-dir> [global-version] [flags]
+  tiup mirror <command> [flags]
 
-Examples:
-  tiup mirrors local-path --arch amd64,arm --os linux,darwin    # Specify the architectures and OSs
-  tiup mirrors local-path --full                                # Build a full local mirrors
-  tiup mirrors local-path --tikv v4                             # Specify the version via prefix
-  tiup mirrors local-path --tidb all --pd all                   # Download all version for specific component
+Available Commands:
+  init        Initialize an empty repository
+  sign        Add signatures to a manifest file
+  genkey      Generate a new key pair
+  clone       Clone a local mirror from remote mirror and download all selected components
+  merge       Merge two or more offline mirror
+  publish     Publish a component
+  show        Show mirror address
+  set         Set mirror address
+  modify      Modify published component
+  renew       Renew the manifest of a published component.
+  grant       grant a new owner
+  rotate      Rotate root.json
 
-Flags:
-      --overwrite                   Overwrite the exists tarball
-  -f, --full                        Build a full mirrors repository
-  -a, --arch strings                Specify the downloading architecture (default [amd64])
-  -o, --os strings                  Specify the downloading os (default [linux,darwin])
-      --tidb strings                Specify the versions for component tidb
-      --tikv strings                Specify the versions for component tikv
-      --pd strings                  Specify the versions for component pd
-      --playground strings          Specify the versions for component playground
-      --client strings              Specify the versions for component client
-      --prometheus strings          Specify the versions for component prometheus
-      --package strings             Specify the versions for component package
-      --grafana strings             Specify the versions for component grafana
-      --alertmanager strings        Specify the versions for component alertmanager
-      --blackbox_exporter strings   Specify the versions for component blackbox_exporter
-      --node_exporter strings       Specify the versions for component node_exporter
-      --pushgateway strings         Specify the versions for component pushgateway
-      --tiflash strings             Specify the versions for component tiflash
-      --drainer strings             Specify the versions for component drainer
-      --pump strings                Specify the versions for component pump
-      --cluster strings             Specify the versions for component cluster
-      --mirrors strings             Specify the versions for component mirrors
-      --bench strings               Specify the versions for component bench
-      --insight strings             Specify the versions for component insight
-      --doc strings                 Specify the versions for component doc
-      --ctl strings                 Specify the versions for component ctl
-  -h, --help                        help for tiup
+Global Flags:
+      --help                 Help for this command
+      --skip-version-check   Skip the strict version check, by default a version must be a valid SemVer string
+
+Use "tiup mirror [command] --help" for more information about a command.
 ```
 
-Its basic use is `tiup mirrors <target-dir> [global-version] [flags]`, the target-dir is the directory in which the cloned data needs to be placed. global-version is used to quickly set a common version for all components.
+Its basic use is `tiup mirror <target-dir> [global-version] [flags]`, the target-dir is the directory in which the cloned data needs to be placed. global-version is used to quickly set a common version for all components.
 
 Then this order has very scary dozens of flags and even more later. But there is no need to be intimidated by the number of these flags, which are in fact of four types.
 
@@ -68,16 +57,16 @@ If `--full` is specified, the official image will be cloned intact.
 ### 3. Platform limitation
 
 If you only want to clone packages for a particular platform, you can use `-os` and `-arch` to qualify:
-- `tiup mirros <target-dir> ---os=linux`
-- Just want to clone amd64 architecture: `tiup mirros <target-dir> --arch=amd64`
-- Just want to clone linux/amd64: `tiup mirros <target-dir> --os=linux --arch=amd64`
+- `tiup mirror <target-dir> ---os=linux`
+- Just want to clone amd64 architecture: `tiup mirror <target-dir> --arch=amd64`
+- Just want to clone linux/amd64: `tiup mirror <target-dir> --os=linux --arch=amd64`
 
 ### 4. Component version limited
 
 If you want to clone only one version of a component and not all versions, use `--<component>=<version>` to qualify, for example "
-- Just want to clone the v4 version of tidb: `tiup mirrors <target-dir> --tidb v4`
-- Just want to clone the v4 version of tidb, and all versions of tikv: `tiup mirros <target-dir> --tidb v4 --tikv all` 
-- Clone specific versions of all components that start a cluster: `tiup mirrors <target-dir> v4.0.0-rc`
+- Just want to clone the v4 version of tidb: `tiup mirror <target-dir> --tidb v4`
+- Just want to clone the v4 version of tidb, and all versions of tikv: `tiup mirror <target-dir> --tidb v4 --tikv all` 
+- Clone specific versions of all components that start a cluster: `tiup mirror <target-dir> v4.0.0-rc`
 
 ## The real thing
 
@@ -86,7 +75,7 @@ If you want to clone only one version of a component and not all versions, use `
 For example, if we want to install a v4.0.0-rc TiDB cluster in an isolated environment, we can execute the following command on a machine connected to the extranet to pull the required components:
 
 ```bash
-tiup mirrors package --os=linux v4.0.0-rc
+tiup mirror package --os=linux v4.0.0-rc
 ```
 
 This command creates a directory called `package` in the current directory that contains the package of components necessary to start a cluster, which is then packaged by the tar command and sent to a central control unit in an isolated environment:
@@ -110,7 +99,7 @@ export TIUP_MIRRORS=/path/to/mirror
 tiup cluster xxx
 ```
 
-`/path/to/mirror` is the location of <target-dir> in `tiup mirrors <target-dir>`, or if in /tmp/package:
+`/path/to/mirror` is the location of <target-dir> in `tiup mirror <target-dir>`, or if in /tmp/package:
 ```bash
 export TIUP_MIRRORS=/tmp/package
 ```

--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -82,15 +82,15 @@ func CloneMirror(repo *V1Repository,
 	}
 
 	var (
-		initTime = time.Now()
-		expirsAt = initTime.Add(50 * 365 * 24 * time.Hour)
-		root     = v1manifest.NewRoot(initTime)
-		index    = v1manifest.NewIndex(initTime)
+		initTime  = time.Now()
+		expiresAt = initTime.Add(50 * 365 * 24 * time.Hour)
+		root      = v1manifest.NewRoot(initTime)
+		index     = v1manifest.NewIndex(initTime)
 	)
 
 	// All offline expires at 50 years to prevent manifests stale
-	root.SetExpiresAt(expirsAt)
-	index.SetExpiresAt(expirsAt)
+	root.SetExpiresAt(expiresAt)
+	index.SetExpiresAt(expiresAt)
 
 	keys := map[string][]*v1manifest.KeyInfo{}
 	for _, ty := range []string{
@@ -148,7 +148,7 @@ func CloneMirror(repo *V1Repository,
 	}
 
 	snapshot := v1manifest.NewSnapshot(initTime)
-	snapshot.SetExpiresAt(expirsAt)
+	snapshot.SetExpiresAt(expiresAt)
 
 	componentManifests, err := cloneComponents(repo, components, selectedVersions, tidbClusterVersionMapper, targetDir, tmpDir, options)
 	if err != nil {
@@ -156,7 +156,7 @@ func CloneMirror(repo *V1Repository,
 	}
 
 	for name, component := range componentManifests {
-		component.SetExpiresAt(expirsAt)
+		component.SetExpiresAt(expiresAt)
 		fname := fmt.Sprintf("%s.json", name)
 		// TODO: support external owner
 		signedManifests[component.ID], err = v1manifest.SignManifest(component, ownerkeyInfo)
@@ -179,7 +179,7 @@ func CloneMirror(repo *V1Repository,
 
 	// Initialize timestamp
 	timestamp := v1manifest.NewTimestamp(initTime)
-	timestamp.SetExpiresAt(expirsAt)
+	timestamp.SetExpiresAt(expiresAt)
 
 	manifests[v1manifest.ManifestTypeTimestamp] = timestamp
 	manifests[v1manifest.ManifestTypeSnapshot] = snapshot


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

- `tiup mirrors` doesn't exist, but `tiup mirror` does
- Typo: `mirros` → `mirrors`
- Typo: `expirsAt` → `expiresAt`


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


Release notes:
```release-note
NONE
```
