### PR TITLE
cluster: use initial_commit_ts in drainer config file instead of start script

### DIFF
--- a/embed/templates/scripts/run_drainer.sh.tpl
+++ b/embed/templates/scripts/run_drainer.sh.tpl
@@ -29,5 +29,4 @@ exec bin/drainer \
     --pd-urls="{{template "PDList" .Endpoints}}" \
     --data-dir="{{.DataDir}}" \
     --log-file="{{.LogDir}}/drainer.log" \
-    --config=conf/drainer.toml \
-    --initial-commit-ts={{.CommitTs}} 2>> "{{.LogDir}}/drainer_stderr.log"
+    --config=conf/drainer.toml 2>> "{{.LogDir}}/drainer_stderr.log"

--- a/pkg/cluster/ansible/service.go
+++ b/pkg/cluster/ansible/service.go
@@ -196,7 +196,8 @@ func parseDirs(ctx context.Context, user string, ins spec.InstanceSpec, sshTimeo
 			if strings.Contains(line, "--initial-commit-ts=") {
 				tsArg := strings.Split(line, " ")[4] // 4 whitespaces ahead
 				tmpTs, _ := strconv.Atoi(strings.TrimPrefix(tsArg, "--initial-commit-ts="))
-				newIns.CommitTS = int64(tmpTs)
+				newIns.Config = make(map[string]interface{})
+				newIns.Config["initial_commit_ts"] = int64(tmpTs)
 			}
 		}
 		return newIns, nil

--- a/pkg/cluster/spec/drainer.go
+++ b/pkg/cluster/spec/drainer.go
@@ -38,7 +38,7 @@ type DrainerSpec struct {
 	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
 	DataDir         string                 `yaml:"data_dir,omitempty"`
 	LogDir          string                 `yaml:"log_dir,omitempty"`
-	CommitTS        int64                  `yaml:"commit_ts" default:"-1" validate:"commit_ts:editable"`
+	CommitTS        int64                  `yaml:"commit_ts,omitempty" validate:"commit_ts:editable"` // do not use it anymore, exist for compatibility
 	Offline         bool                   `yaml:"offline,omitempty"`
 	NumaNode        string                 `yaml:"numa_node,omitempty" validate:"numa_node:editable"`
 	Config          map[string]interface{} `yaml:"config,omitempty" validate:"config:ignore"`
@@ -167,8 +167,6 @@ func (i *DrainerInstance) InitConfig(
 		paths.Data[0],
 		paths.Log,
 	).WithPort(spec.Port).WithNumaNode(spec.NumaNode).AppendEndpoints(topo.Endpoints(deployUser)...)
-
-	cfg.WithCommitTs(spec.CommitTS)
 
 	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_drainer_%s_%d.sh", i.GetHost(), i.GetPort()))
 

--- a/pkg/cluster/spec/drainer.go
+++ b/pkg/cluster/spec/drainer.go
@@ -38,7 +38,7 @@ type DrainerSpec struct {
 	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
 	DataDir         string                 `yaml:"data_dir,omitempty"`
 	LogDir          string                 `yaml:"log_dir,omitempty"`
-	CommitTS        int64                  `yaml:"commit_ts,omitempty" validate:"commit_ts:editable"` // do not use it anymore, exist for compatibility
+	CommitTS        *int64                 `yaml:"commit_ts,omitempty" validate:"commit_ts:editable"` // do not use it anymore, exist for compatibility
 	Offline         bool                   `yaml:"offline,omitempty"`
 	NumaNode        string                 `yaml:"numa_node,omitempty" validate:"numa_node:editable"`
 	Config          map[string]interface{} `yaml:"config,omitempty" validate:"config:ignore"`

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -355,7 +355,7 @@ func (s *Specification) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	// --initial-commit-ts should not be recorded at run_drainer.sh #1682 
-	s.remove_commit_ts()
+	s.removeCommitTS()
 
 	return s.Validate()
 }
@@ -861,7 +861,7 @@ func setHostArch(field reflect.Value, hostArch map[string]string) error {
 }
 
 // when upgrade form old tiup-cluster, replace spec.CommitTS with spec.Config["initial_commit_ts"]
-func (s *Specification) remove_commit_ts() {
+func (s *Specification) removeCommitTS() {
 	_, ok1 := s.ServerConfigs.Drainer["initial_commit_ts"]
 	for _, spec := range s.Drainers {
 		_, ok2 := spec.Config["initial_commit_ts"]

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -354,7 +354,7 @@ func (s *Specification) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 
-	// --initial-commit-ts should not be recorded at run_drainer.sh #1682 
+	// --initial-commit-ts should not be recorded at run_drainer.sh #1682
 	s.removeCommitTS()
 
 	return s.Validate()
@@ -865,12 +865,12 @@ func (s *Specification) removeCommitTS() {
 	_, ok1 := s.ServerConfigs.Drainer["initial_commit_ts"]
 	for _, spec := range s.Drainers {
 		_, ok2 := spec.Config["initial_commit_ts"]
-		if !ok1 && !ok2 && spec.CommitTS != -1 {
+		if !ok1 && !ok2 && spec.CommitTS != nil && *spec.CommitTS != -1 {
 			if spec.Config == nil {
 				spec.Config = make(map[string]interface{})
 			}
-			spec.Config["initial_commit_ts"] = spec.CommitTS
+			spec.Config["initial_commit_ts"] = *spec.CommitTS
 		}
-		spec.CommitTS = 0
+		spec.CommitTS = nil
 	}
 }

--- a/pkg/cluster/template/scripts/drainer.go
+++ b/pkg/cluster/template/scripts/drainer.go
@@ -31,7 +31,6 @@ type DrainerScript struct {
 	DataDir   string
 	LogDir    string
 	NumaNode  string
-	CommitTs  int64
 	Endpoints []*PDScript
 }
 
@@ -44,7 +43,6 @@ func NewDrainerScript(nodeID, ip, deployDir, dataDir, logDir string) *DrainerScr
 		DeployDir: deployDir,
 		DataDir:   dataDir,
 		LogDir:    logDir,
-		CommitTs:  -1,
 	}
 }
 
@@ -57,12 +55,6 @@ func (c *DrainerScript) WithPort(port int) *DrainerScript {
 // WithNumaNode set NumaNode field of DrainerScript
 func (c *DrainerScript) WithNumaNode(numa string) *DrainerScript {
 	c.NumaNode = numa
-	return c
-}
-
-// WithCommitTs set CommitTs field of DrainerScript
-func (c *DrainerScript) WithCommitTs(ts int64) *DrainerScript {
-	c.CommitTs = ts
 	return c
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- close #1682 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
