### PR TITLE
cluster/deploy: adjust hint to add --init

### DIFF
--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -411,7 +411,7 @@ func (m *Manager) Deploy(
 		return err
 	}
 
-	hint := color.New(color.Bold).Sprintf("%s start %s", tui.OsArgs0(), name)
+	hint := color.New(color.Bold).Sprintf("%s start %s --init", tui.OsArgs0(), name)
 	m.logger.Infof("Cluster `%s` deployed successfully, you can start it with command: `%s`", name, hint)
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Adjust the hint displayed after deploy to add `--init` argument.

