### PR TITLE
cluster: add significant warning destroying a cluster

### DIFF
--- a/pkg/cluster/manager/destroy.go
+++ b/pkg/cluster/manager/destroy.go
@@ -52,11 +52,15 @@ func (m *Manager) DestroyCluster(name string, gOpt operator.Options, destroyOpt 
 	}
 
 	if !skipConfirm {
-		if err := tui.PromptForConfirmOrAbortError(
-			"This operation will destroy %s %s cluster %s and its data.\nDo you want to continue? [y/N]:",
-			m.sysName,
-			color.HiYellowString(base.Version),
-			color.HiYellowString(name)); err != nil {
+		m.logger.Warnf(color.HiRedString(tui.ASCIIArtWarning))
+		if err := tui.PromptForAnswerOrAbortError(
+			"Yes, I know my cluster and data will be deleted.",
+			fmt.Sprintf("This operation will destroy %s %s cluster %s and its data.",
+				m.sysName,
+				color.HiYellowString(base.Version),
+				color.HiYellowString(name),
+			)+"\nAre you sure to continue?",
+		); err != nil {
 			return err
 		}
 		m.logger.Infof("Destroying cluster...")

--- a/tests/tiup-cluster/script/upgrade.sh
+++ b/tests/tiup-cluster/script/upgrade.sh
@@ -48,5 +48,5 @@ EOEX
 
     tiup-cluster _test $name writable
 
-    yes | tiup-cluster destroy $name
+    tiup-cluster --yes destroy $name
 }

--- a/tests/tiup-dm/test_upgrade.sh
+++ b/tests/tiup-dm/test_upgrade.sh
@@ -38,4 +38,4 @@ tiup-dm exec $name -N "$ipprefix.104:8261" --command "grep '31s' /home/tidb/depl
 ./script/task/run.sh
 
 
-yes | tiup-dm destroy $name
+tiup-dm --yes destroy $name


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1722 

### What is changed and how it works?
Add a significant warning when the users tries to destroy a cluster. It requires the user to input a long sentence to confirm (instead of a simple "Y/y" letter) so it's highly not possible for the user to destroy a cluster by mistake.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
![图片](https://user-images.githubusercontent.com/596538/149127679-56dc7bbf-d0c7-4cfc-aeab-e1276b9a7171.png)

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
