### PR TITLE
cluster: fix malformed commands in local executor

### DIFF
--- a/pkg/cluster/executor/local.go
+++ b/pkg/cluster/executor/local.go
@@ -82,7 +82,7 @@ func (l *Local) Execute(ctx context.Context, cmd string, sudo bool, timeout ...t
 	command.Stdout = stdout
 	command.Stderr = stderr
 
-	err := command.Run()
+	err = command.Run()
 
 	zap.L().Info("LocalCommand",
 		zap.String("cmd", cmd),

--- a/pkg/cluster/executor/local.go
+++ b/pkg/cluster/executor/local.go
@@ -41,11 +41,14 @@ var _ ctxt.Executor = &Local{}
 
 // Execute implements Executor interface.
 func (l *Local) Execute(ctx context.Context, cmd string, sudo bool, timeout ...time.Duration) ([]byte, []byte, error) {
+	// change wd to default home
+	cmd = fmt.Sprintf("cd; %s", cmd)
+
 	// try to acquire root permission
 	if l.Sudo || sudo {
-		cmd = fmt.Sprintf("/usr/bin/sudo -H -u root bash -c 'cd; %s'", cmd)
+		cmd = fmt.Sprintf("/usr/bin/sudo -H -u root bash -c \"%s\"", strings.ReplaceAll(cmd, "\"", "\\\""))
 	} else {
-		cmd = fmt.Sprintf("/usr/bin/sudo -H -u %s bash -c 'cd; %s'", l.Config.User, cmd)
+		cmd = fmt.Sprintf("/usr/bin/sudo -H -u %s bash -c \"%s\"", l.Config.User, strings.ReplaceAll(cmd, "\"", "\\\""))
 	}
 
 	// set a basic PATH in case it's empty on login
@@ -67,7 +70,7 @@ func (l *Local) Execute(ctx context.Context, cmd string, sudo bool, timeout ...t
 		defer cancel()
 	}
 
-	command := exec.CommandContext(ctx, "/bin/sh", "-c", cmd)
+	command := exec.CommandContext(ctx, "/bin/bash", "-c", cmd)
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -117,7 +120,7 @@ func (l *Local) Transfer(ctx context.Context, src, dst string, download bool, li
 		cmd = fmt.Sprintf("/usr/bin/sudo -H -u root bash -c \"cp %[1]s %[2]s && chown %[3]s:$(id -g -n %[3]s) %[2]s\"", src, dst, l.Config.User)
 	}
 
-	command := exec.Command("/bin/sh", "-c", cmd)
+	command := exec.Command("/bin/bash", "-c", cmd)
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	command.Stdout = stdout

--- a/pkg/cluster/executor/local.go
+++ b/pkg/cluster/executor/local.go
@@ -43,11 +43,16 @@ var _ ctxt.Executor = &Local{}
 func (l *Local) Execute(ctx context.Context, cmd string, sudo bool, timeout ...time.Duration) ([]byte, []byte, error) {
 	// change wd to default home
 	cmd = fmt.Sprintf("cd; %s", cmd)
+	// get current user name
+	user, err := user.Current()
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// try to acquire root permission
 	if l.Sudo || sudo {
 		cmd = fmt.Sprintf("/usr/bin/sudo -H -u root bash -c \"%s\"", strings.ReplaceAll(cmd, "\"", "\\\""))
-	} else {
+	} else if l.Config.User != user.Name {
 		cmd = fmt.Sprintf("/usr/bin/sudo -H -u %s bash -c \"%s\"", l.Config.User, strings.ReplaceAll(cmd, "\"", "\\\""))
 	}
 

--- a/pkg/cluster/executor/local_test.go
+++ b/pkg/cluster/executor/local_test.go
@@ -86,8 +86,8 @@ func TestLocalExecuteWithQuotes(t *testing.T) {
 	defer os.RemoveAll(deployDir)
 
 	cmds := []string{
-		fmt.Sprintf(`find %s -type f -exec sed -i "s/\${DS_.*-CLUSTER}/hello/g" {} \;`, deployDir),
-		fmt.Sprintf(`find %s -type f -exec sed -i "s/DS_.*-CLUSTER/hello/g" {} \;`, deployDir),
+		fmt.Sprintf(`find %s -type f -exec sed -i 's/\${DS_.*-CLUSTER}/hello/g' {} \;`, deployDir),
+		fmt.Sprintf(`find %s -type f -exec sed -i 's/DS_.*-CLUSTER/hello/g' {} \;`, deployDir),
 		`ls '/tmp'`,
 	}
 	for _, cmd := range cmds {

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -268,12 +268,12 @@ func (i *GrafanaInstance) initDashboards(ctx context.Context, e ctxt.Executor, s
 
 	// Deal with the cluster name
 	for _, cmd := range []string{
-		`find %s -type f -exec sed -i "s/\${DS_.*-CLUSTER}/%s/g" {} \;`,
-		`find %s -type f -exec sed -i "s/DS_.*-CLUSTER/%s/g" {} \;`,
-		`find %s -type f -exec sed -i "s/\${DS_LIGHTNING}/%s/g" {} \;`,
-		`find %s -type f -exec sed -i "s/DS_LIGHTNING/%s/g" {} \;`,
-		`find %s -type f -exec sed -i "s/test-cluster/%s/g" {} \;`,
-		`find %s -type f -exec sed -i "s/Test-Cluster/%s/g" {} \;`,
+		`find %s -type f -exec sed -i 's/\${DS_.*-CLUSTER}/%s/g' {} \;`,
+		`find %s -type f -exec sed -i 's/DS_.*-CLUSTER/%s/g' {} \;`,
+		`find %s -type f -exec sed -i 's/\${DS_LIGHTNING}/%s/g' {} \;`,
+		`find %s -type f -exec sed -i 's/DS_LIGHTNING/%s/g' {} \;`,
+		`find %s -type f -exec sed -i 's/test-cluster/%s/g' {} \;`,
+		`find %s -type f -exec sed -i 's/Test-Cluster/%s/g' {} \;`,
 	} {
 		cmd := fmt.Sprintf(cmd, dashboardsDir, clusterName)
 		_, stderr, err := e.Execute(ctx, cmd, false)

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -404,7 +404,7 @@ func (i *MonitorInstance) installRules(ctx context.Context, e ctxt.Executor, dep
 		`find %[1]s -type f -name "*.rules.yml" -delete`,
 		`find %[2]s/dm-master/conf -type f -name "*.rules.yml" -exec cp {} %[1]s \;`,
 		"rm -rf %[2]s",
-		`find %[1]s -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i "s/ENV_LABELS_ENV/%[3]s/g" {} \;`,
+		`find %[1]s -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i 's/ENV_LABELS_ENV/%[3]s/g' {} \;`,
 	}
 	_, stderr, err = e.Execute(ctx, fmt.Sprintf(strings.Join(cmds, " && "), targetDir, tmp, clusterName), false)
 	if err != nil {
@@ -420,7 +420,7 @@ func (i *MonitorInstance) initRules(ctx context.Context, e ctxt.Executor, spec *
 		"mkdir -p %[1]s/conf",
 		`find %[1]s/conf -type f -name "*.rules.yml" -delete`,
 		`find %[1]s/bin/prometheus -maxdepth 1 -type f -name "*.rules.yml" -exec cp {} %[1]s/conf/ \;`,
-		`find %[1]s/conf -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i -e "s/ENV_LABELS_ENV/%[2]s/g" {} \;`,
+		`find %[1]s/conf -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i -e 's/ENV_LABELS_ENV/%[2]s/g' {} \;`,
 	}
 
 	_, stderr, err := e.Execute(ctx, fmt.Sprintf(strings.Join(cmds, " && "), paths.Deploy, clusterName), false)
@@ -438,8 +438,8 @@ func (i *MonitorInstance) initRules(ctx context.Context, e ctxt.Executor, spec *
 		}
 		// only need to render the cluster name
 		cmds = []string{
-			`find %[1]s/conf -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i -e "s/env: [^ ]*/env: %[2]s/g" {} \;`,
-			`find %[1]s/conf -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i -e "s/cluster: [^ ]*,/cluster: %[2]s,/g" {} \;`,
+			`find %[1]s/conf -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i -e 's/env: [^ ]*/env: %[2]s/g' {} \;`,
+			`find %[1]s/conf -maxdepth 1 -type f -name "*.rules.yml" -exec sed -i -e 's/cluster: [^ ]*,/cluster: %[2]s,/g' {} \;`,
 		}
 		_, stderr, err := e.Execute(ctx, fmt.Sprintf(strings.Join(cmds, " && "), paths.Deploy, clusterName), false)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1268 

### What is changed and how it works?
Adjust commands to use `'` for `sed` instead of `"` and properly escape `"` in commands.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
