### PR TITLE
cluster: Ignore the nightly version when judging whether the TiFlash version supports TLS

### DIFF
--- a/pkg/cluster/manager/basic.go
+++ b/pkg/cluster/manager/basic.go
@@ -29,6 +29,8 @@ import (
 	"github.com/pingcap/tiup/pkg/meta"
 	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/tui"
+	"github.com/pingcap/tiup/pkg/utils"
+	"golang.org/x/mod/semver"
 )
 
 // EnableCluster enable/disable the service in a cluster
@@ -280,4 +282,18 @@ func getMonitorHosts(topo spec.Topology) (map[string]hostInfo, set.StringSet) {
 	})
 
 	return uniqueHosts, noAgentHosts
+}
+
+// checkTiFlashWithTLS check tiflash vserson
+func checkTiFlashWithTLS(topo spec.Topology, version string) error {
+	if clusterSpec, ok := topo.(*spec.Specification); ok {
+		if clusterSpec.GlobalOptions.TLSEnabled {
+			if (semver.Compare(version, "v4.0.5") < 0 &&
+				len(clusterSpec.TiFlashServers) > 0) &&
+				version != utils.NightlyVersionAlias {
+				return fmt.Errorf("TiFlash %s is not supported in TLS enabled cluster", version)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/tui"
 	"github.com/pingcap/tiup/pkg/utils"
-	"golang.org/x/mod/semver"
 )
 
 // DeployOptions contains the options for scale out.
@@ -88,12 +87,9 @@ func (m *Manager) Deploy(
 	if err := spec.ParseTopologyYaml(topoFile, topo); err != nil {
 		return err
 	}
-	if clusterSpec, ok := topo.(*spec.Specification); ok {
-		if clusterSpec.GlobalOptions.TLSEnabled &&
-			semver.Compare(clusterVersion, "v4.0.5") < 0 &&
-			len(clusterSpec.TiFlashServers) > 0 {
-			return fmt.Errorf("TiFlash %s is not supported in TLS enabled cluster", clusterVersion)
-		}
+
+	if err := checkTiFlashWithTLS(topo, clusterVersion); err != nil {
+		return err
 	}
 
 	instCnt := 0

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/tui"
 	"github.com/pingcap/tiup/pkg/utils"
-	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
 )
 
@@ -93,12 +92,8 @@ func (m *Manager) ScaleOut(
 			return err
 		}
 
-		if clusterSpec, ok := topo.(*spec.Specification); ok {
-			if clusterSpec.GlobalOptions.TLSEnabled &&
-				semver.Compare(base.Version, "v4.0.5") < 0 &&
-				len(clusterSpec.TiFlashServers) > 0 {
-				return fmt.Errorf("TiFlash %s is not supported in TLS enabled cluster", base.Version)
-			}
+		if err := checkTiFlashWithTLS(topo, base.Version); err != nil {
+			return err
 		}
 
 		if newPartTopo, ok := newPart.(*spec.Specification); ok {

--- a/pkg/cluster/manager/tls.go
+++ b/pkg/cluster/manager/tls.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/tui"
-	"golang.org/x/mod/semver"
 )
 
 // TLS set cluster enable/disable encrypt communication by tls
@@ -129,13 +128,11 @@ func (m *Manager) TLS(name string, gOpt operator.Options, enable, cleanCertifica
 // checkTLSEnv check tiflash vserson and show confirm
 func checkTLSEnv(topo spec.Topology, clusterName, version string, skipConfirm bool) error {
 	// check tiflash version
-	if clusterSpec, ok := topo.(*spec.Specification); ok {
-		if clusterSpec.GlobalOptions.TLSEnabled {
-			if semver.Compare(version, "v4.0.5") < 0 && len(clusterSpec.TiFlashServers) > 0 {
-				return fmt.Errorf("TiFlash %s is not supported in TLS enabled cluster", version)
-			}
-		}
+	if err := checkTiFlashWithTLS(topo, version); err != nil {
+		return err
+	}
 
+	if clusterSpec, ok := topo.(*spec.Specification); ok {
 		if len(clusterSpec.PDServers) != 1 {
 			return errorx.EnsureStackTrace(fmt.Errorf("Having multiple PD nodes is not supported when enable/disable TLS")).
 				WithProperty(tui.SuggestionFromString("Please `scale-in` PD nodes to one and try again."))


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #1733 

### What is changed and how it works?
 Ignore the nightly version when judging whether the TiFlash version supports TLS

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```shell
./tiup-cluster deploy test nightly ~/topology.yaml
./tiup-cluster start test 

# enable TLS
./tiup-cluster tls test enable 
```


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
