### PR TITLE
tiup/playground: refactor RunComponent

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -133,10 +133,8 @@ the latest stable version will be downloaded from the repository.`,
 						break
 					}
 				}
-				if len(transparentParams) > 0 {
-					if transparentParams[0] == "--" {
-						transparentParams = transparentParams[1:]
-					}
+				if len(transparentParams) > 0 && transparentParams[0] == "--" {
+					transparentParams = transparentParams[1:]
 				}
 
 				teleCommand = fmt.Sprintf("%s %s", cmd.CommandPath(), componentSpec)
@@ -229,7 +227,8 @@ func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
 		// use exit code from component
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			code = exitErr.ExitCode()
 		} else {
 			fmt.Fprintln(os.Stderr, color.RedString("Error: %v", err))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"syscall"
 	"time"
@@ -27,7 +28,7 @@ import (
 	"github.com/google/uuid"
 	perrs "github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/environment"
-	"github.com/pingcap/tiup/pkg/exec"
+	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/localdata"
 	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
 	"github.com/pingcap/tiup/pkg/repository"
@@ -132,8 +133,14 @@ the latest stable version will be downloaded from the repository.`,
 						break
 					}
 				}
+				if len(transparentParams) > 0 {
+					if transparentParams[0] == "--" {
+						transparentParams = transparentParams[1:]
+					}
+				}
+
 				teleCommand = fmt.Sprintf("%s %s", cmd.CommandPath(), componentSpec)
-				return exec.RunComponent(env, tag, componentSpec, binPath, transparentParams)
+				return tiupexec.RunComponent(env, tag, componentSpec, binPath, transparentParams)
 			}
 			return cmd.Help()
 		},
@@ -221,8 +228,13 @@ func Execute() {
 
 	err := rootCmd.Execute()
 	if err != nil {
-		fmt.Println(color.RedString("Error: %v", err))
-		code = 1
+		// use exit code from component
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			code = exitErr.ExitCode()
+		} else {
+			fmt.Fprintln(os.Stderr, color.RedString("Error: %v", err))
+			code = 1
+		}
 	}
 
 	teleReport := new(telemetry.Report)

--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/components/playground/instance"
-	"github.com/pingcap/tiup/pkg/environment"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 )
@@ -199,21 +198,11 @@ http_port = %d
 		fmt.Sprintf("cfg:default.paths.logs=%s", path.Join(dir, "log")),
 	}
 
-	env := environment.GlobalEnv()
-	params := &tiupexec.PrepareCommandParams{
-		Ctx:         ctx,
-		Component:   "grafana",
-		Version:     utils.Version(g.version),
-		InstanceDir: dir,
-		Args:        args,
-		Env:         env,
-	}
-	cmd, err := instance.PrepareCommandForPlayground(params, dir)
-	if err != nil {
+	var binPath string
+	if binPath, err = tiupexec.PrepareBinary("grafana", utils.Version(g.version), binPath); err != nil {
 		return err
 	}
-	cmd.Stdout = nil
-	cmd.Stderr = nil
+	cmd := instance.PrepareCommand(ctx, binPath, args, nil, dir)
 
 	g.cmd = cmd
 

--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -205,12 +205,10 @@ http_port = %d
 		Component:   "grafana",
 		Version:     utils.Version(g.version),
 		InstanceDir: dir,
-		WD:          dir,
 		Args:        args,
-		SysProcAttr: instance.SysProcAttr,
 		Env:         env,
 	}
-	cmd, err := tiupexec.PrepareCommand(params)
+	cmd, err := instance.PrepareCommandForPlayground(params, dir)
 	if err != nil {
 		return err
 	}

--- a/components/playground/instance/drainer.go
+++ b/components/playground/instance/drainer.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -84,10 +85,11 @@ func (d *Drainer) Start(ctx context.Context, version utils.Version) error {
 	}
 
 	var err error
-	if d.Process, err = NewComponentProcess(ctx, d.Dir, d.BinPath, "drainer", version, args...); err != nil {
+	if d.BinPath, err = tiupexec.PrepareBinary("drainer", version, d.BinPath); err != nil {
 		return err
 	}
-	logIfErr(d.Process.SetOutputFile(d.LogFile()))
+	d.Process = &process{cmd: PrepareCommand(ctx, d.BinPath, args, nil, d.Dir)}
 
+	logIfErr(d.Process.SetOutputFile(d.LogFile()))
 	return d.Process.Start()
 }

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
+	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -98,11 +99,12 @@ func (inst *PDInstance) Start(ctx context.Context, version utils.Version) error 
 	}
 
 	var err error
-	if inst.Process, err = NewComponentProcess(ctx, inst.Dir, inst.BinPath, "pd", version, args...); err != nil {
+	if inst.BinPath, err = tiupexec.PrepareBinary("pd", version, inst.BinPath); err != nil {
 		return err
 	}
-	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
+	inst.Process = &process{cmd: PrepareCommand(ctx, inst.BinPath, args, nil, inst.Dir)}
 
+	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
 	return inst.Process.Start()
 }
 

--- a/components/playground/instance/process.go
+++ b/components/playground/instance/process.go
@@ -101,10 +101,8 @@ func NewComponentProcessWithEnvs(ctx context.Context, dir, binPath, component st
 		Version:      version,
 		BinPath:      binPath,
 		InstanceDir:  dir,
-		WD:           dir,
 		Args:         arg,
 		EnvVariables: make([]string, 0),
-		SysProcAttr:  SysProcAttr,
 		Env:          env,
 	}
 	for k, v := range envs {
@@ -112,7 +110,7 @@ func NewComponentProcessWithEnvs(ctx context.Context, dir, binPath, component st
 		params.EnvVariables = append(params.EnvVariables, pair)
 	}
 
-	cmd, err := tiupexec.PrepareCommand(params)
+	cmd, err := PrepareCommandForPlayground(params, dir)
 	if err != nil {
 		return nil, err
 	}
@@ -123,4 +121,15 @@ func NewComponentProcessWithEnvs(ctx context.Context, dir, binPath, component st
 // NewComponentProcess create a Process instance.
 func NewComponentProcess(ctx context.Context, dir, binPath, component string, version utils.Version, arg ...string) (Process, error) {
 	return NewComponentProcessWithEnvs(ctx, dir, binPath, component, version, nil, arg...)
+}
+
+// PrepareCommandForPlayground call PrepareCommand and set SysProcAttr
+func PrepareCommandForPlayground(p *tiupexec.PrepareCommandParams, dir string) (*exec.Cmd, error) {
+	cmd, err := tiupexec.PrepareCommand(p)
+	if err != nil {
+		return nil, err
+	}
+	cmd.Dir = dir
+	cmd.SysProcAttr = SysProcAttr
+	return cmd, nil
 }

--- a/components/playground/instance/process.go
+++ b/components/playground/instance/process.go
@@ -2,7 +2,6 @@ package instance
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -86,7 +85,7 @@ func (p *process) Cmd() *exec.Cmd {
 }
 
 // NewComponentProcessWithEnvs create a Process instance with given environment variables.
-func NewComponentProcessWithEnvs(ctx context.Context, dir, binPath, component string, version utils.Version, envs map[string]string, arg ...string) (Process, error) {
+func NewComponentProcessWithEnvs(ctx context.Context, dir, binPath, component string, version utils.Version, envs []string, arg ...string) (Process, error) {
 	if dir == "" {
 		panic("dir must be set")
 	}
@@ -96,24 +95,19 @@ func NewComponentProcessWithEnvs(ctx context.Context, dir, binPath, component st
 
 	env := environment.GlobalEnv()
 	params := &tiupexec.PrepareCommandParams{
-		Ctx:          ctx,
-		Component:    component,
-		Version:      version,
-		BinPath:      binPath,
-		InstanceDir:  dir,
-		Args:         arg,
-		EnvVariables: make([]string, 0),
-		Env:          env,
+		Ctx:         ctx,
+		Component:   component,
+		Version:     version,
+		BinPath:     binPath,
+		InstanceDir: dir,
+		Args:        arg,
+		Env:         env,
 	}
-	for k, v := range envs {
-		pair := fmt.Sprintf("%s=%s", k, v)
-		params.EnvVariables = append(params.EnvVariables, pair)
-	}
-
 	cmd, err := PrepareCommandForPlayground(params, dir)
 	if err != nil {
 		return nil, err
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	return &process{cmd: cmd}, nil
 }

--- a/components/playground/instance/pump.go
+++ b/components/playground/instance/pump.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -103,11 +104,12 @@ func (p *Pump) Start(ctx context.Context, version utils.Version) error {
 	}
 
 	var err error
-	if p.Process, err = NewComponentProcess(ctx, p.Dir, p.BinPath, "pump", version, args...); err != nil {
+	if p.BinPath, err = tiupexec.PrepareBinary("pump", version, p.BinPath); err != nil {
 		return err
 	}
-	logIfErr(p.Process.SetOutputFile(p.LogFile()))
+	p.Process = &process{cmd: PrepareCommand(ctx, p.BinPath, args, nil, p.Dir)}
 
+	logIfErr(p.Process.SetOutputFile(p.LogFile()))
 	return p.Process.Start()
 }
 

--- a/components/playground/instance/ticdc.go
+++ b/components/playground/instance/ticdc.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 	"golang.org/x/mod/semver"
 )
@@ -71,11 +72,12 @@ func (c *TiCDC) Start(ctx context.Context, version utils.Version) error {
 	}
 
 	var err error
-	if c.Process, err = NewComponentProcess(ctx, c.Dir, c.BinPath, "cdc", version, args...); err != nil {
+	if c.BinPath, err = tiupexec.PrepareBinary("cdc", version, c.BinPath); err != nil {
 		return err
 	}
-	logIfErr(c.Process.SetOutputFile(c.LogFile()))
+	c.Process = &process{cmd: PrepareCommand(ctx, c.BinPath, args, nil, c.Dir)}
 
+	logIfErr(c.Process.SetOutputFile(c.LogFile()))
 	return c.Process.Start()
 }
 

--- a/components/playground/instance/ticdc.go
+++ b/components/playground/instance/ticdc.go
@@ -83,7 +83,7 @@ func (c *TiCDC) Start(ctx context.Context, version utils.Version) error {
 
 // Component return component name.
 func (c *TiCDC) Component() string {
-	return "ticdc"
+	return "cdc"
 }
 
 // LogFile return the log file.

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -71,11 +72,12 @@ func (inst *TiDBInstance) Start(ctx context.Context, version utils.Version) erro
 	}
 
 	var err error
-	if inst.Process, err = NewComponentProcess(ctx, inst.Dir, inst.BinPath, "tidb", version, args...); err != nil {
+	if inst.BinPath, err = tiupexec.PrepareBinary("tidb", version, inst.BinPath); err != nil {
 		return err
 	}
-	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
+	inst.Process = &process{cmd: PrepareCommand(ctx, inst.BinPath, args, nil, inst.Dir)}
 
+	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
 	return inst.Process.Start()
 }
 

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
+	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -70,13 +71,14 @@ func (inst *TiKVInstance) Start(ctx context.Context, version utils.Version) erro
 		fmt.Sprintf("--log-file=%s", inst.LogFile()),
 	}
 
-	var err error
 	envs := []string{"MALLOC_CONF=prof:true,prof_active:false"}
-	if inst.Process, err = NewComponentProcessWithEnvs(ctx, inst.Dir, inst.BinPath, "tikv", version, envs, args...); err != nil {
+	var err error
+	if inst.BinPath, err = tiupexec.PrepareBinary("tikv", version, inst.BinPath); err != nil {
 		return err
 	}
-	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
+	inst.Process = &process{cmd: PrepareCommand(ctx, inst.BinPath, args, envs, inst.Dir)}
 
+	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
 	return inst.Process.Start()
 }
 

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -71,8 +71,7 @@ func (inst *TiKVInstance) Start(ctx context.Context, version utils.Version) erro
 	}
 
 	var err error
-	envs := make(map[string]string)
-	envs["MALLOC_CONF"] = "prof:true,prof_active:false"
+	envs := []string{"MALLOC_CONF=prof:true,prof_active:false"}
 	if inst.Process, err = NewComponentProcessWithEnvs(ctx, inst.Dir, inst.BinPath, "tikv", version, envs, args...); err != nil {
 		return err
 	}

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/components/playground/instance"
-	"github.com/pingcap/tiup/pkg/environment"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 )
@@ -136,19 +135,11 @@ scrape_configs:
 		fmt.Sprintf("--storage.tsdb.path=%s", filepath.Join(dir, "data")),
 	}
 
-	env := environment.GlobalEnv()
-	params := &tiupexec.PrepareCommandParams{
-		Ctx:         ctx,
-		Component:   "prometheus",
-		Version:     utils.Version(version),
-		InstanceDir: dir,
-		Args:        args,
-		Env:         env,
-	}
-	cmd, err := instance.PrepareCommandForPlayground(params, dir)
-	if err != nil {
+	var binPath string
+	if binPath, err = tiupexec.PrepareBinary("prometheus", utils.Version(version), binPath); err != nil {
 		return nil, err
 	}
+	cmd := instance.PrepareCommand(ctx, binPath, args, nil, dir)
 
 	m.port = port
 	m.cmd = cmd

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -142,12 +142,10 @@ scrape_configs:
 		Component:   "prometheus",
 		Version:     utils.Version(version),
 		InstanceDir: dir,
-		WD:          dir,
 		Args:        args,
-		SysProcAttr: instance.SysProcAttr,
 		Env:         env,
 	}
-	cmd, err := tiupexec.PrepareCommand(params)
+	cmd, err := instance.PrepareCommandForPlayground(params, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/components/playground/ngmonitoring.go
+++ b/components/playground/ngmonitoring.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/components/playground/instance"
 	"github.com/pingcap/tiup/pkg/environment"
-	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -75,19 +74,8 @@ func newNGMonitoring(ctx context.Context, version string, host, dir string, pds 
 	if err != nil {
 		return nil, err
 	}
-	params := &tiupexec.PrepareCommandParams{
-		Ctx:         ctx,
-		Component:   "prometheus",
-		BinPath:     filepath.Join(binDir, "ng-monitoring-server"),
-		Version:     utils.Version(version),
-		InstanceDir: dir,
-		Args:        args,
-		Env:         env,
-	}
-	cmd, err := instance.PrepareCommandForPlayground(params, dir)
-	if err != nil {
-		return nil, err
-	}
+
+	cmd := instance.PrepareCommand(ctx, filepath.Join(binDir, "ng-monitoring-server"), args, nil, dir)
 
 	m.port = port
 	m.cmd = cmd

--- a/components/playground/ngmonitoring.go
+++ b/components/playground/ngmonitoring.go
@@ -81,12 +81,10 @@ func newNGMonitoring(ctx context.Context, version string, host, dir string, pds 
 		BinPath:     filepath.Join(binDir, "ng-monitoring-server"),
 		Version:     utils.Version(version),
 		InstanceDir: dir,
-		WD:          dir,
 		Args:        args,
-		SysProcAttr: instance.SysProcAttr,
 		Env:         env,
 	}
-	cmd, err := tiupexec.PrepareCommand(params)
+	cmd, err := instance.PrepareCommandForPlayground(params, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -417,8 +417,12 @@ func (p *Playground) sanitizeComponentConfig(cid string, cfg *instance.Config) e
 }
 
 func (p *Playground) startInstance(ctx context.Context, inst instance.Instance) error {
-	fmt.Printf("Start %s instance\n", inst.Component())
-	err := inst.Start(ctx, utils.Version(p.bootOptions.Version))
+	version, err := environment.GlobalEnv().V1Repository().ResolveComponentVersion(inst.Component(), p.bootOptions.Version)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Start %s instance:%s\n", inst.Component(), version)
+	err = inst.Start(ctx, version)
 	if err != nil {
 		return err
 	}

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -621,6 +621,9 @@ func (p *Playground) addInstance(componentID string, cfg instance.Config) (ins i
 
 	id := p.allocID(componentID)
 	dir := filepath.Join(dataDir, fmt.Sprintf("%s-%d", componentID, id))
+	if err = os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
 	// look more like listen ip?
 	host := p.bootOptions.Host
 	if cfg.Host != "" {

--- a/pkg/environment/env.go
+++ b/pkg/environment/env.go
@@ -204,9 +204,6 @@ func (env *Environment) SelectInstalledVersion(component string, ver utils.Versi
 		if vi.Yanked {
 			continue
 		}
-		if (string(ver) == utils.NightlyVersionAlias) != utils.Version(v).IsNightly() {
-			continue
-		}
 		versions = append(versions, v)
 	}
 	// Reverse sort: v5.0.0-rc,v5.0.0-nightly-20210305,v4.0.11
@@ -219,6 +216,10 @@ func (env *Environment) SelectInstalledVersion(component string, ver utils.Versi
 	if ver.IsEmpty() || string(ver) == utils.NightlyVersionAlias {
 		var selected utils.Version
 		for _, v := range versions {
+			// only select nightly for nightly
+			if (string(ver) == utils.NightlyVersionAlias) != utils.Version(v).IsNightly() {
+				continue
+			}
 			if semver.Prerelease(v) == "" {
 				return utils.Version(v), nil
 			}

--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -150,15 +150,14 @@ func cleanDataDir(rm bool, dir string) {
 
 // PrepareCommandParams for PrepareCommand.
 type PrepareCommandParams struct {
-	Ctx          context.Context
-	Component    string
-	Version      utils.Version
-	BinPath      string
-	Tag          string
-	InstanceDir  string
-	Args         []string
-	EnvVariables []string
-	Env          *environment.Environment
+	Ctx         context.Context
+	Component   string
+	Version     utils.Version
+	BinPath     string
+	Tag         string
+	InstanceDir string
+	Args        []string
+	Env         *environment.Environment
 }
 
 // PrepareCommand will download necessary component and returns a *exec.Cmd
@@ -225,7 +224,6 @@ func PrepareCommand(p *PrepareCommandParams) (*exec.Cmd, error) {
 		fmt.Sprintf("%s=%s", localdata.EnvNameInstanceDataDir, p.InstanceDir),
 	}
 	envs = append(envs, os.Environ()...)
-	envs = append(envs, p.EnvVariables...)
 
 	// init the command
 	c := exec.CommandContext(p.Ctx, binPath, p.Args...)

--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -43,66 +43,56 @@ func RunComponent(env *environment.Environment, tag, spec, binPath string, args 
 		cmdCheckUpdate(component, version, 2)
 	}
 
+	binPath, _ = prepareBinary(component, version, binPath)
+
 	// Clean data if current instance is a temporary
 	clean := tag == "" && os.Getenv(localdata.EnvNameInstanceDataDir) == ""
-
-	p, err := launchComponent(component, version, binPath, tag, args, env)
-	// If the process has been launched, we must save the process info to meta directory
-	if err == nil || (p != nil && p.Pid != 0) {
-		defer cleanDataDir(clean, p.Dir)
-		metaFile := filepath.Join(p.Dir, localdata.MetaFilename)
-		file, err := os.OpenFile(metaFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.ModePerm)
-		if err == nil {
-			defer file.Close()
-			encoder := json.NewEncoder(file)
-			encoder.SetIndent("", "    ")
-			_ = encoder.Encode(p)
+	// p, err := launchComponent(component, version, binPath, tag, args, env)
+	instanceDir := os.Getenv(localdata.EnvNameInstanceDataDir)
+	if instanceDir == "" {
+		// Generate a tag for current instance if the tag doesn't specified
+		if tag == "" {
+			tag = utils.Base62Tag()
 		}
+		instanceDir = env.LocalPath(localdata.DataParentDir, tag)
 	}
+	defer cleanDataDir(clean, instanceDir)
+
+	params := &PrepareCommandParams{
+		Component:   component,
+		Version:     version,
+		BinPath:     binPath,
+		Tag:         tag,
+		InstanceDir: instanceDir,
+		Args:        args,
+		Env:         env,
+	}
+	c, err := PrepareCommand(params)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to start component `%s`\n", component)
 		return err
 	}
 
-	ch := make(chan error)
-	var sig syscall.Signal
+	fmt.Fprintf(os.Stderr, "Starting component `%s`: %s\n", component, strings.Join(append([]string{binPath}, c.Args...), " "))
+	err = c.Start()
+	if err != nil {
+		return errors.Annotatef(err, "Failed to start component `%s`", component)
+	}
+	// If the process has been launched, we must save the process info to meta directory
+	saveProcessInfo(params, c)
+
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
-
-	defer func() {
-		for err := range ch {
-			if err != nil {
-				errs := err.Error()
-				if strings.Contains(errs, "signal") ||
-					(sig == syscall.SIGINT && strings.Contains(errs, "exit status 1")) {
-					continue
-				}
-				fmt.Fprintf(os.Stderr, "Component `%s` exit with error: %s\n", component, errs)
-				return
+	go func() {
+		for s := range sc {
+			sig := s.(syscall.Signal)
+			fmt.Fprintf(os.Stderr, "Got signal %v (Component: %v ; PID: %v)\n", s, component, c.Process.Pid)
+			if sig != syscall.SIGINT {
+				_ = syscall.Kill(c.Process.Pid, sig)
 			}
 		}
 	}()
 
-	go func() {
-		defer close(ch)
-		ch <- p.Cmd.Wait()
-	}()
-
-	select {
-	case s := <-sc:
-		sig = s.(syscall.Signal)
-		fmt.Fprintf(os.Stderr, "Got signal %v (Component: %v ; PID: %v)\n", s, component, p.Pid)
-		if component == "tidb" {
-			return syscall.Kill(p.Pid, syscall.SIGKILL)
-		}
-		if sig != syscall.SIGINT {
-			return syscall.Kill(p.Pid, sig)
-		}
-		return nil
-
-	case err := <-ch:
-		return errors.Annotatef(err, "run `%s` (wd:%s) failed", p.Exec, p.Dir)
-	}
+	return c.Wait()
 }
 
 func cleanDataDir(rm bool, dir string) {
@@ -131,29 +121,6 @@ func PrepareCommand(p *PrepareCommandParams) (*exec.Cmd, error) {
 	env := p.Env
 	profile := env.Profile()
 	binPath := p.BinPath
-
-	if binPath != "" {
-		tmp, err := filepath.Abs(binPath)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		binPath = tmp
-	} else {
-		selectVer, err := env.DownloadComponentIfMissing(p.Component, p.Version)
-		if err != nil {
-			return nil, err
-		}
-
-		// playground && cluster version must greater than v1.0.0
-		if (p.Component == "playground" || p.Component == "cluster") && semver.Compare(selectVer.String(), "v1.0.0") < 0 {
-			return nil, errors.Errorf("incompatible component version, please use `tiup update %s` to upgrade to the latest version", p.Component)
-		}
-
-		binPath, err = env.BinaryPath(p.Component, selectVer)
-		if err != nil {
-			return nil, err
-		}
-	}
 	installPath := filepath.Dir(binPath)
 
 	if err := os.MkdirAll(p.InstanceDir, 0755); err != nil {
@@ -206,54 +173,6 @@ func PrepareCommand(p *PrepareCommandParams) (*exec.Cmd, error) {
 	return c, nil
 }
 
-func launchComponent(component string, version utils.Version, binPath string, tag string, args []string, env *environment.Environment) (*localdata.Process, error) {
-	instanceDir := os.Getenv(localdata.EnvNameInstanceDataDir)
-	if instanceDir == "" {
-		// Generate a tag for current instance if the tag doesn't specified
-		if tag == "" {
-			tag = utils.Base62Tag()
-		}
-		instanceDir = env.LocalPath(localdata.DataParentDir, tag)
-	}
-
-	if len(args) > 0 {
-		if args[0] == "--" {
-			args = args[1:]
-		}
-	}
-
-	params := &PrepareCommandParams{
-		Component:   component,
-		Version:     version,
-		BinPath:     binPath,
-		Tag:         tag,
-		InstanceDir: instanceDir,
-		Args:        args,
-		Env:         env,
-	}
-	c, err := PrepareCommand(params)
-	if err != nil {
-		return nil, err
-	}
-
-	p := &localdata.Process{
-		Component:   component,
-		CreatedTime: time.Now().Format(time.RFC3339),
-		Exec:        c.Args[0],
-		Args:        args,
-		Dir:         instanceDir,
-		Env:         c.Env,
-		Cmd:         c,
-	}
-
-	fmt.Fprintf(os.Stderr, "Starting component `%s`: %s\n", component, strings.Join(append([]string{p.Exec}, p.Args...), " "))
-	err = p.Cmd.Start()
-	if p.Cmd.Process != nil {
-		p.Pid = p.Cmd.Process.Pid
-	}
-	return p, err
-}
-
 func cmdCheckUpdate(component string, version utils.Version, timeoutSec int) {
 	fmt.Fprintf(os.Stderr, "tiup is checking updates for component %s ...", component)
 	updateC := make(chan string)
@@ -265,26 +184,66 @@ func cmdCheckUpdate(component string, version utils.Version, timeoutSec int) {
 
 	go func() {
 		var updateInfo string
-		if version.IsEmpty() {
-			latestV, _, err := environment.GlobalEnv().V1Repository().LatestStableVersion(component, false)
-			if err != nil {
-				return
-			}
-			selectVer, _ := environment.GlobalEnv().SelectInstalledVersion(component, version)
+		latestV, _, err := environment.GlobalEnv().V1Repository().LatestStableVersion(component, false)
+		if err != nil {
+			return
+		}
+		selectVer, _ := environment.GlobalEnv().SelectInstalledVersion(component, version)
 
-			if semver.Compare(selectVer.String(), latestV.String()) < 0 {
-				updateInfo = fmt.Sprint(color.YellowString(`
+		if semver.Compare(selectVer.String(), latestV.String()) < 0 {
+			updateInfo = fmt.Sprint(color.YellowString(`
 Found %[1]s newer version:
    The latest version:         %[2]s
    Local installed version:    %[3]s
    Update current component:   tiup update %[1]s
    Update all components:      tiup update --all
 `,
-					component, latestV.String(), selectVer.String()))
-			}
+				component, latestV.String(), selectVer.String()))
 		}
 		updateC <- updateInfo
 	}()
 
 	fmt.Fprintln(os.Stderr, <-updateC)
+}
+
+func prepareBinary(component string, version utils.Version, binPath string) (string, error) {
+	if binPath != "" {
+		tmp, err := filepath.Abs(binPath)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		binPath = tmp
+	} else {
+		selectVer, err := environment.GlobalEnv().DownloadComponentIfMissing(component, version)
+		if err != nil {
+			return "", err
+		}
+
+		binPath, err = environment.GlobalEnv().BinaryPath(component, selectVer)
+		if err != nil {
+			return "", err
+		}
+	}
+	return binPath, nil
+}
+
+func saveProcessInfo(p *PrepareCommandParams, c *exec.Cmd) {
+	info := &localdata.Process{
+		Component:   p.Component,
+		CreatedTime: time.Now().Format(time.RFC3339),
+		Pid:         c.Process.Pid,
+		Exec:        c.Args[0],
+		Args:        c.Args,
+		Dir:         p.InstanceDir,
+		Env:         c.Env,
+		Cmd:         c,
+	}
+	metaFile := filepath.Join(info.Dir, localdata.MetaFilename)
+	file, err := os.OpenFile(metaFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.ModePerm)
+	if err == nil {
+		defer file.Close()
+		encoder := json.NewEncoder(file)
+		encoder.SetIndent("", "    ")
+		_ = encoder.Encode(info)
+	}
 }

--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -156,12 +156,9 @@ type PrepareCommandParams struct {
 	BinPath      string
 	Tag          string
 	InstanceDir  string
-	WD           string
 	Args         []string
 	EnvVariables []string
-	SysProcAttr  *syscall.SysProcAttr
 	Env          *environment.Environment
-	CheckUpdate  bool
 }
 
 // PrepareCommand will download necessary component and returns a *exec.Cmd
@@ -236,8 +233,6 @@ func PrepareCommand(p *PrepareCommandParams) (*exec.Cmd, error) {
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-	c.Dir = p.WD
-	c.SysProcAttr = p.SysProcAttr
 
 	return c, nil
 }
@@ -265,11 +260,8 @@ func launchComponent(ctx context.Context, component string, version utils.Versio
 		BinPath:     binPath,
 		Tag:         tag,
 		InstanceDir: instanceDir,
-		WD:          "",
 		Args:        args,
-		SysProcAttr: nil,
 		Env:         env,
-		CheckUpdate: true,
 	}
 	c, err := PrepareCommand(params)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- how tiup run component is different with playground. The old PrepareCommand should be splited to two simple function
- close #1732 

### What is changed and how it works?

- refactor how tiup and playground run component
- use component exit code as tiup exit code
- make playground show version of component

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
