### PR TITLE
Add Amazon Linux 2 as supported OS

### DIFF
--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -165,6 +165,14 @@ func checkOSInfo(opt *CheckOptions, osInfo *sysinfo.OS) *CheckResult {
 
 	// check OS vendor
 	switch osInfo.Vendor {
+	case "amzn":
+		// Amazon Linux 2 is based on CentOS 7 and is recommended for
+		// AWS Graviton 2 (ARM64) deployments.
+		if ver, _ := strconv.ParseFloat(osInfo.Version, 64); ver < 2 || ver >= 3 {
+			result.Err = fmt.Errorf("%s %s not supported, use version 2 please",
+				osInfo.Name, osInfo.Release)
+			return result
+		}
 	case "centos", "redhat", "rhel":
 		// check version
 		// CentOS 8 is known to be not working, and we don't have plan to support it


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Mark Amazon Linux 2 as supported

- https://aws.amazon.com/blogs/startups/achieve-better-price-to-performance-for-tidb-graviton2-processors/
- https://aws.amazon.com/ec2/graviton/
- https://aws.amazon.com/amazon-linux-2/


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Release notes:
```release-note
Amazon Linux is no longer marked as unsupported
```

```
$ cat /etc/os-release 
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
HOME_URL="https://amazonlinux.com/"
```

```
$ rpm -E %{rhel}
7
```


```
ip-**********.eu-central-1.compute.internal  os-version    Fail    os vendor amzn not supported
```