### PR TITLE
cluster: support evict leaders on stop and restore on start

### DIFF
--- a/components/cluster/command/audit.go
+++ b/components/cluster/command/audit.go
@@ -47,7 +47,6 @@ func newAuditCleanupCmd() *cobra.Command {
 		Use:   "cleanup",
 		Short: "cleanup cluster audit logs",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			if retainDays < 0 {
 				return errors.Errorf("retain-days cannot be less than 0")
 			}

--- a/components/cluster/command/start.go
+++ b/components/cluster/command/start.go
@@ -30,7 +30,10 @@ import (
 )
 
 func newStartCmd() *cobra.Command {
-	var initPasswd bool
+	var (
+		initPasswd    bool
+		restoreLeader bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "start <cluster-name>",
@@ -48,7 +51,7 @@ func newStartCmd() *cobra.Command {
 			clusterReport.ID = scrubClusterName(clusterName)
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 
-			if err := cm.StartCluster(clusterName, gOpt, func(b *task.Builder, metadata spec.Metadata) {
+			if err := cm.StartCluster(clusterName, gOpt, restoreLeader, func(b *task.Builder, metadata spec.Metadata) {
 				b.UpdateTopology(
 					clusterName,
 					tidbSpec.Path(clusterName),
@@ -80,8 +83,11 @@ func newStartCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&initPasswd, "init", false, "Initialize a secure root password for the database")
+	cmd.Flags().BoolVar(&restoreLeader, "restore-leaders", false, "Allow leaders to be scheduled to stores after start")
 	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only start specified nodes")
+
+	_ = cmd.Flags().MarkHidden("restore-leaders")
 
 	return cmd
 }

--- a/components/cluster/command/stop.go
+++ b/components/cluster/command/stop.go
@@ -18,6 +18,8 @@ import (
 )
 
 func newStopCmd() *cobra.Command {
+	var evictLeader bool
+
 	cmd := &cobra.Command{
 		Use:   "stop <cluster-name>",
 		Short: "Stop a TiDB cluster",
@@ -34,12 +36,15 @@ func newStopCmd() *cobra.Command {
 			clusterReport.ID = scrubClusterName(clusterName)
 			teleCommand = append(teleCommand, scrubClusterName(clusterName))
 
-			return cm.StopCluster(clusterName, gOpt, skipConfirm)
+			return cm.StopCluster(clusterName, gOpt, skipConfirm, evictLeader)
 		},
 	}
 
 	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only stop specified roles")
 	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only stop specified nodes")
+	cmd.Flags().BoolVar(&evictLeader, "evict-leaders", false, "Evict leaders on stores before stop")
+
+	_ = cmd.Flags().MarkHidden("evict-leaders")
 
 	return cmd
 }

--- a/components/dm/command/audit.go
+++ b/components/dm/command/audit.go
@@ -47,7 +47,6 @@ func newAuditCleanupCmd() *cobra.Command {
 		Use:   "cleanup",
 		Short: "cleanup dm audit logs",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			if retainDays < 0 {
 				return errors.Errorf("retain-days cannot be less than 0")
 			}

--- a/components/dm/command/scale_in.go
+++ b/components/dm/command/scale_in.go
@@ -142,7 +142,15 @@ func ScaleInDMCluster(
 				continue
 			}
 
-			if err := operator.StopComponent(ctx, []dm.Instance{instance}, noAgentHosts, options.OptTimeout); err != nil {
+			if err := operator.StopComponent(
+				ctx,
+				topo,
+				[]dm.Instance{instance},
+				noAgentHosts,
+				options.OptTimeout,
+				false,         /* evictLeader */
+				&tls.Config{}, /* not used as evictLeader is false */
+			); err != nil {
 				return errors.Annotatef(err, "failed to stop %s", component.Name())
 			}
 

--- a/components/dm/command/start.go
+++ b/components/dm/command/start.go
@@ -28,7 +28,7 @@ func newStartCmd() *cobra.Command {
 
 			clusterName := args[0]
 
-			return cm.StartCluster(clusterName, gOpt)
+			return cm.StartCluster(clusterName, gOpt, false)
 		},
 	}
 

--- a/components/dm/command/stop.go
+++ b/components/dm/command/stop.go
@@ -28,7 +28,7 @@ func newStopCmd() *cobra.Command {
 
 			clusterName := args[0]
 
-			return cm.StopCluster(clusterName, gOpt, skipConfirm)
+			return cm.StopCluster(clusterName, gOpt, skipConfirm, false)
 		},
 	}
 

--- a/pkg/cluster/audit/audit.go
+++ b/pkg/cluster/audit/audit.go
@@ -146,7 +146,6 @@ func GetAuditList(dir string) ([]Item, error) {
 
 // OutputAuditLog outputs audit log.
 func OutputAuditLog(dir, fileSuffix string, data []byte) error {
-
 	auditID := base52.Encode(time.Now().UnixNano() + rand.Int63n(1000))
 	if customID := os.Getenv(EnvNameAuditID); customID != "" {
 		auditID = fmt.Sprintf("%s_%s", auditID, customID)
@@ -223,7 +222,6 @@ type deleteAuditLog struct {
 
 // DeleteAuditLog  cleanup audit log
 func DeleteAuditLog(dir string, retainDays int, skipConfirm bool, displayMode string) error {
-
 	if retainDays < 0 {
 		return errors.Errorf("retainDays cannot be less than 0")
 	}

--- a/pkg/cluster/manager/builder.go
+++ b/pkg/cluster/manager/builder.go
@@ -347,7 +347,15 @@ func buildScaleOutTask(
 		})
 	} else {
 		builder.Func("Start new instances", func(ctx context.Context) error {
-			return operator.Start(ctx, newPart, operator.Options{OptTimeout: gOpt.OptTimeout, Operation: operator.ScaleOutOperation}, tlsCfg)
+			return operator.Start(ctx,
+				newPart,
+				operator.Options{
+					OptTimeout: gOpt.OptTimeout,
+					Operation:  operator.ScaleOutOperation,
+				},
+				false, /* restoreLeader */
+				tlsCfg,
+			)
 		}).
 			ParallelStep("+ Refresh components conifgs", gOpt.Force, refreshConfigTasks...).
 			ParallelStep("+ Reload prometheus and grafana", gOpt.Force,

--- a/pkg/cluster/manager/cleanup.go
+++ b/pkg/cluster/manager/cleanup.go
@@ -73,7 +73,13 @@ func (m *Manager) CleanCluster(name string, gOpt operator.Options, cleanOpt oper
 	}
 	t := b.
 		Func("StopCluster", func(ctx context.Context) error {
-			return operator.Stop(ctx, topo, operator.Options{}, tlsCfg)
+			return operator.Stop(
+				ctx,
+				topo,
+				operator.Options{},
+				false, /* eviceLeader */
+				tlsCfg,
+			)
 		}).
 		Func("CleanupCluster", func(ctx context.Context) error {
 			return operator.CleanupComponent(ctx, delFileMap)

--- a/pkg/cluster/manager/destroy.go
+++ b/pkg/cluster/manager/destroy.go
@@ -72,7 +72,13 @@ func (m *Manager) DestroyCluster(name string, gOpt operator.Options, destroyOpt 
 	}
 	t := b.
 		Func("StopCluster", func(ctx context.Context) error {
-			return operator.Stop(ctx, topo, operator.Options{Force: destroyOpt.Force}, tlsCfg)
+			return operator.Stop(
+				ctx,
+				topo,
+				operator.Options{Force: destroyOpt.Force},
+				false, /* eviceLeader */
+				tlsCfg,
+			)
 		}).
 		Func("DestroyCluster", func(ctx context.Context) error {
 			return operator.Destroy(ctx, topo, destroyOpt)

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -102,7 +102,15 @@ func StopAndDestroyInstance(ctx context.Context, cluster spec.Topology, instance
 	})
 
 	// just try to stop and destroy
-	if err := StopComponent(ctx, []spec.Instance{instance}, noAgentHosts, options.OptTimeout); err != nil {
+	if err := StopComponent(
+		ctx,
+		cluster,
+		[]spec.Instance{instance},
+		noAgentHosts,
+		options.OptTimeout,
+		false,         /* evictLeader */
+		&tls.Config{}, /* not used as evictLeader is false */
+	); err != nil {
 		if !ignoreErr {
 			return errors.Annotatef(err, "failed to stop %s", compName)
 		}

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -67,9 +67,9 @@ type Operation byte
 
 // Operation represents the kind of cluster operation
 const (
-	StartOperation Operation = iota
-	StopOperation
-	RestartOperation
+	// StartOperation Operation = iota
+	// StopOperation
+	RestartOperation Operation = iota
 	DestroyOperation
 	UpgradeOperation
 	ScaleInOperation

--- a/pkg/cluster/task/action.go
+++ b/pkg/cluster/task/action.go
@@ -48,10 +48,12 @@ func (c *ClusterOperate) Execute(ctx context.Context) error {
 		"failed to destroy tombstone",
 	}
 	switch c.op {
+	/* deprecated
 	case operator.StartOperation:
-		err = operator.Start(ctx, c.spec, c.options, c.tlsCfg)
+		err = operator.Start(ctx, c.spec, c.options, false, c.tlsCfg)
 	case operator.StopOperation:
-		err = operator.Stop(ctx, c.spec, c.options, c.tlsCfg)
+		err = operator.Stop(ctx, c.spec, c.options, false, c.tlsCfg)
+	*/
 	case operator.RestartOperation:
 		err = operator.Restart(ctx, c.spec, c.options, c.tlsCfg)
 	case operator.DestroyOperation:


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1781 

### What is changed and how it works?
- Add a hidden `--evict-leaders` argument to `tiup-cluster stop` command, to evict store leaders from an instance and wait it to complete, ignored for non-store instances. Only use it with `-N` argument to stop specific instance, if there is no place for store leaders to transfer, the operation may fail.
- Add a hidden `--restore-leaders` argument to `tiup-cluster start` command, to delete the store leader evict scheduler of an instance, so that leaders are allowed to transfer back to it. If the instance was stopped with `--evict-leaders` and started without `--restore-leaders`, the instance will be up but no leader could be transferred to it, in that case, run `start` again with `--restore-leaders` or use `pd-ctl` to delete the store leader evict scheduler.

Also comment some unused code in `pkg/cluster/task/action.go`, we're calling those functions direct in `manager`, not via a task, maybe we need to also refactor those part later to make things easier.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

