### PR TITLE
There is no `Oracle Linux 2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ TiUP Changelog
 ### Improvements
 
 - Check for inactive Prometheus service before `reload` in `tiup-cluster` ([#1775](https://github.com/pingcap/tiup/pull/1775), [@nexustar](https://github.com/nexustar))
-- Mark Oracle Linux 2 as supported OS in `check` result of `tiup-cluster` ([#1786](https://github.com/pingcap/tiup/pull/1786), [@srstack](https://github.com/srstack))
+- Mark Oracle Linux as supported OS in `check` result of `tiup-cluster` ([#1786](https://github.com/pingcap/tiup/pull/1786), [@srstack](https://github.com/srstack))
 
 ## [1.9.1] 2022-02-24
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This pull request updates the CHANGELOG for TiUP 1.9.2 


### What is changed and how it works?
This pull request updates Oracle Linux version, there is no `Oracle Linux 2` because Oracle Linux uses the same version semantics as Red Hat Enterprise Linux.

https://docs.oracle.com/en/operating-systems/oracle-linux/index.html
