### PR TITLE
cluster: try to disable swap when `check --apply`

### DIFF
--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -637,10 +637,10 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder) (s
 		// in the sysctl check
 		// t.Sysctl(host, "vm.swappiness", "0")
 		t.Shell(host,
-			fmt.Sprintf("swapoff -a"),
+			"swapoff -a",
 			"", true,
 		)
-		msg = fmt.Sprint("will try to disable swap, please also check /etc/fstab manually")
+		msg = "will try to disable swap, please also check /etc/fstab manually"
 	default:
 		msg = fmt.Sprintf("%s, auto fixing not supported", res)
 	}

--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -637,7 +637,7 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder) (s
 		// in the sysctl check
 		// t.Sysctl(host, "vm.swappiness", "0")
 		t.Shell(host,
-			"swapoff -a",
+			"swapoff -a || exit 0", // ignore failure
 			"", true,
 		)
 		msg = "will try to disable swap, please also check /etc/fstab manually"

--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -632,6 +632,15 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder) (s
 			"",
 			true)
 		msg = fmt.Sprintf("will try to %s, please check again after reboot", color.HiBlueString("disable THP"))
+	case operator.CheckNameSwap:
+		// not applying swappiness setting here, it should be fixed
+		// in the sysctl check
+		// t.Sysctl(host, "vm.swappiness", "0")
+		t.Shell(host,
+			fmt.Sprintf("swapoff -a"),
+			"", true,
+		)
+		msg = fmt.Sprint("will try to disable swap, please also check /etc/fstab manually")
 	default:
 		msg = fmt.Sprintf("%s, auto fixing not supported", res)
 	}

--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -297,6 +297,7 @@ func checkMem(opt *CheckOptions, memInfo *sysinfo.Memory) []*CheckResult {
 	if memInfo.Swap > 0 {
 		results = append(results, &CheckResult{
 			Name: CheckNameSwap,
+			Warn: true,
 			Err:  fmt.Errorf("swap is enabled, please disable it for best performance"),
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1767 

### What is changed and how it works?
Support disabling swap (as described in doc) by setting `vm.swappiness = 0` and `swapoff` to ensure all data already in the swap memory are swapped out.
