### PR TITLE
remove preceding spaces from commands so they are not omitted from shell history

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,11 +25,11 @@
 
                 <p>Run the following in your terminal, and follow the instructions:</p>
                 <p><br /></p>
-                <pre><code> curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh </code></pre>
+                <pre><code>curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh </code></pre>
                 <br />
 
                 <p>After installation, start a local cluster:</p>
-                <pre><code> tiup playground </code></pre>
+                <pre><code>tiup playground </code></pre>
                 <br />
 
                 <p>This tool only supports Linux, macOS, and Windows WSL (for now)</p>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
                 <br />
 
                 <p>After installation, start a local cluster:</p>
-                <pre><code>tiup playground </code></pre>
+                <pre><code>tiup playground</code></pre>
                 <br />
 
                 <p>This tool only supports Linux, macOS, and Windows WSL (for now)</p>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 
                 <p>Run the following in your terminal, and follow the instructions:</p>
                 <p><br /></p>
-                <pre><code>curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh </code></pre>
+                <pre><code>curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh</code></pre>
                 <br />
 
                 <p>After installation, start a local cluster:</p>


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If you precede a command with a space in bash (and other shells?) it won't put it in the history, so it's more difficult to see the work you've done to set up an environment when the tiup install step is not visible!

### What is changed and how it works?

Leading spaces are removed from `<code>` blocks in index.html.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
