### PR TITLE
playground: fix cp error when encountered readonly files

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1115,7 +1115,7 @@ func (p *Playground) bootGrafana(ctx context.Context, env *environment.Environme
 	dataDir := p.dataDir
 	grafanaDir := filepath.Join(dataDir, "grafana")
 
-	cmd := exec.Command("cp", "-r", installPath, grafanaDir)
+	cmd := exec.Command("cp", "-Rfp", installPath, grafanaDir)
 	err = cmd.Run()
 	if err != nil {
 		return nil, errors.AddStack(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

tiup playground cannot start due to copying Grafana files failed

### What is changed and how it works?

Ignore errors and continue! Besides, `-f` will try to resolve read-only files by removing them first.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix playground start error in MacOS
```
