### PR TITLE
cluster: enable data-dir for versions above v5.0.3

### DIFF
--- a/pkg/cluster/spec/spec_test.go
+++ b/pkg/cluster/spec/spec_test.go
@@ -742,6 +742,9 @@ cdc_servers:
 		"v5.0.0-rc":    {false, false, false},
 		"v5.1.0-alpha": {true, true, false},
 		"v5.2.0-alpha": {true, true, false},
+		"v6.0.0-alpha": {true, true, true},
+		"v6.1.0":       {true, true, true},
+		"v99.0.0":      {true, true, true},
 	}
 
 	checkByVersion := func(version string) {
@@ -751,9 +754,9 @@ cdc_servers:
 
 		wanted := expected[version]
 
-		c.Assert(cfg.ConfigFileEnabled, Equals, wanted.configSupported)
-		c.Assert(cfg.DataDirEnabled, Equals, wanted.dataDirSupported)
-		c.Assert(len(cfg.DataDir) != 0, Equals, wanted.dataDir)
+		c.Assert(cfg.ConfigFileEnabled, Equals, wanted.configSupported, Commentf(version))
+		c.Assert(cfg.DataDirEnabled, Equals, wanted.dataDirSupported, Commentf(version))
+		c.Assert(len(cfg.DataDir) != 0, Equals, wanted.dataDir, Commentf(version))
 	}
 
 	for k := range expected {

--- a/pkg/cluster/template/scripts/cdc.go
+++ b/pkg/cluster/template/scripts/cdc.go
@@ -124,26 +124,24 @@ func (c *CDCScript) AppendEndpoints(ends ...*PDScript) *CDCScript {
 
 // PatchByVersion update fields by cluster version
 func (c *CDCScript) PatchByVersion(clusterVersion, dataDir string) *CDCScript {
-	// for those version, cdc does not support --data-dir
-	ignore := map[string]struct{}{
-		"v5.0.0-rc":    {},
-		"v5.1.0-alpha": {},
-		"v5.2.0-alpha": {},
-	}
-
 	// config support since v4.0.13, ignore v5.0.0-rc
 	// the same to data-dir, but we treat it as --sort-dir
 	if semver.Compare(clusterVersion, "v4.0.13") >= 0 && clusterVersion != "v5.0.0-rc" {
 		c = c.WithConfigFileEnabled().WithDataDir(dataDir)
 	}
 
-	// cdc support --data-dir since v4.0.14 and v5.0.3, but not the ignore above
+	// cdc support --data-dir since v4.0.14 and v5.0.3
 	if semver.Major(clusterVersion) == "v4" && semver.Compare(clusterVersion, "v4.0.14") >= 0 {
 		c = c.WithDataDirEnabled()
 	}
 
-	if semver.Major(clusterVersion) == "v5" && semver.Compare(clusterVersion, "v5.0.3") >= 0 {
-		if _, ok := ignore[clusterVersion]; !ok {
+	// for those version above v5.0.3, cdc does not support --data-dir
+	ignoreVersion := map[string]struct{}{
+		"v5.1.0-alpha": {},
+		"v5.2.0-alpha": {},
+	}
+	if semver.Compare(clusterVersion, "v5.0.3") >= 0 {
+		if _, ok := ignoreVersion[clusterVersion]; !ok {
 			c = c.WithDataDirEnabled()
 		}
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix cdc data-dir is not enable properly  for v6.0.0

Cc https://github.com/pingcap/tiflow/issues/5142

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Related changes

 - Need to cherry-pick to the release branch

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix cdc data-dir is not enable properly for v6.0.0
```
