### PR TITLE
mirror: support custom key-dir when rotate root.json

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -444,6 +444,7 @@ func newTransferOwnerCmd() *cobra.Command {
 // the `mirror rotate` sub command
 func newMirrorRotateCmd() *cobra.Command {
 	addr := "0.0.0.0:8080"
+	keyDir := ""
 
 	cmd := &cobra.Command{
 		Use:   "rotate",
@@ -451,6 +452,16 @@ func newMirrorRotateCmd() *cobra.Command {
 		Long:  "Rotate root.json make it possible to modify root.json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			teleCommand = cmd.CommandPath()
+
+			e, err := environment.InitEnv(repoOpts, repository.MirrorOptions{KeyDir: keyDir})
+			if err != nil {
+				if errors.Is(perrs.Cause(err), v1manifest.ErrLoadManifest) {
+					log.Warnf("Please check for root manifest file, you may download one from the repository mirror, or try `tiup mirror set` to force reset it.")
+				}
+				return err
+			}
+			environment.SetGlobalEnv(e)
+
 			root, err := editLatestRootManifest()
 			if err != nil {
 				return err
@@ -465,6 +476,7 @@ func newMirrorRotateCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&addr, "addr", "", addr, "listen address:port when starting the temp server for rotating")
+	cmd.Flags().StringVarP(&keyDir, "key-dir", "", keyDir, "specify the directory where stores the private keys")
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,7 @@ the latest stable version will be downloaded from the repository.`,
 			teleCommand = cmd.CommandPath()
 			switch cmd.Name() {
 			case "init",
+				"rotate",
 				"set":
 				if cmd.HasParent() && cmd.Parent().Name() == "mirror" {
 					// skip environment init
@@ -93,7 +94,7 @@ the latest stable version will be downloaded from the repository.`,
 				}
 				fallthrough
 			default:
-				e, err := environment.InitEnv(repoOpts)
+				e, err := environment.InitEnv(repoOpts, repository.MirrorOptions{})
 				if err != nil {
 					if errors.Is(perrs.Cause(err), v1manifest.ErrLoadManifest) {
 						log.Warnf("Please check for root manifest file, you may download one from the repository mirror, or try `tiup mirror set` to force reset it.")
@@ -198,7 +199,7 @@ the latest stable version will be downloaded from the repository.`,
 		},
 	}
 
-	// useless, exist to generate help infomation
+	// useless, exist to generate help information
 	rootCmd.Flags().String("binary", "", "Print binary path of a specific version of a component `<component>[:version]`\n"+
 		"and the latest version installed will be selected if no version specified")
 	rootCmd.Flags().StringP("tag", "T", "", "[Deprecated] Specify a tag for component instance")

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -120,7 +120,7 @@ func init() {
 			env, err = tiupmeta.InitEnv(repository.Options{
 				GOOS:   "linux",
 				GOARCH: "amd64",
-			})
+			}, repository.MirrorOptions{})
 			if err != nil {
 				return err
 			}

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -91,7 +91,7 @@ please backup your data before process.`,
 			env, err = tiupmeta.InitEnv(repository.Options{
 				GOOS:   "linux",
 				GOARCH: "amd64",
-			})
+			}, repository.MirrorOptions{})
 			if err != nil {
 				return err
 			}

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -218,7 +218,7 @@ Examples:
 				return err
 			}
 
-			env, err := environment.InitEnv(repository.Options{})
+			env, err := environment.InitEnv(repository.Options{}, repository.MirrorOptions{})
 			if err != nil {
 				return err
 			}

--- a/pkg/environment/env.go
+++ b/pkg/environment/env.go
@@ -81,7 +81,7 @@ type Environment struct {
 }
 
 // InitEnv creates a new Environment object configured using env vars and defaults.
-func InitEnv(options repository.Options) (*Environment, error) {
+func InitEnv(options repository.Options, mOpt repository.MirrorOptions) (*Environment, error) {
 	if env := GlobalEnv(); env != nil {
 		return env, nil
 	}
@@ -92,7 +92,7 @@ func InitEnv(options repository.Options) (*Environment, error) {
 	// Initialize the repository
 	// Replace the mirror if some sub-commands use different mirror address
 	mirrorAddr := Mirror()
-	mirror := repository.NewMirror(mirrorAddr, repository.MirrorOptions{})
+	mirror := repository.NewMirror(mirrorAddr, mOpt)
 	if err := mirror.Open(); err != nil {
 		return nil, err
 	}

--- a/pkg/repository/model/model.go
+++ b/pkg/repository/model/model.go
@@ -134,10 +134,22 @@ func (m *model) Rotate(manifest *v1manifest.Manifest) error {
 			return err
 		}
 
+		// write new 'root.json' file with verion prefix
 		manifestFilename := fmt.Sprintf("%d.root.json", root.Version)
 		if err := m.txn.WriteManifest(manifestFilename, manifest); err != nil {
 			return err
 		}
+		/* not yet update the 'root.json' without version prefix, as we don't
+		 * have a '1.root.json', so the 'root.json' is playing the role of initial
+		 * '1.root.json', clients are updating to the latest 'n.root.json' no
+		 * matter older ones are expired or not
+		 * maybe we could update the 'root.json' some day when we have many many
+		 * versions of root.json available and the updating process from old clients
+		 * are causing performance issues
+		 */
+		// if err := m.txn.WriteManifest("root.json", manifest); err != nil {
+		// 	return err
+		// }
 
 		fi, err := m.txn.Stat(manifestFilename)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add `--key-dir` argument to `mirror rotate` subcommand

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
