### PR TITLE
cluster: return error when found multiple nodes with the same ip:port

### DIFF
--- a/pkg/cluster/api/binlog.go
+++ b/pkg/cluster/api/binlog.go
@@ -140,11 +140,11 @@ func (c *BinlogClient) nodeID(ctx context.Context, addr, ty string) (string, err
 
 	switch len(targetNodes) {
 	case 0:
-		return "", errors.Errorf("found multiple %s nodes with the same ip:port, found nodes: %s", ty, targetNodes)
+		return "", errors.Errorf("%s node id for address %s not found, found address: %s", ty, addr, addrs)
 	case 1:
 		return targetNodes[0], nil
 	default:
-		return "", errors.Errorf("%s node id for address %s not found, found address: %s", ty, addr, addrs)
+		return "", errors.Errorf("found multiple %s nodes with the same ip:port, found nodes: %s", ty, targetNodes)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #1854

I think that when there are multiple nodes with the same ip:port, an error should be returned and the client should check.

![image](https://user-images.githubusercontent.com/39378935/164914183-1e67fa86-32dc-4512-8934-e240b9df4ef2.png)


![image](https://user-images.githubusercontent.com/39378935/164914171-51212442-6690-4264-be39-5638f087f82f.png)



Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
