### PR TITLE
cluster: display support concurrent access to node status

### DIFF
--- a/components/dm/spec/logic.go
+++ b/components/dm/spec/logic.go
@@ -453,15 +453,14 @@ func (topo *Specification) IterInstance(fn func(instance Instance), concurrency 
 		for _, inst := range comp.Instances() {
 			wg.Add(1)
 			workerPool <- struct{}{}
-			{
-				go func(inst Instance) {
-					defer func() {
-						<-workerPool
-						wg.Done()
-					}()
-					fn(inst)
-				}(inst)
-			}
+			go func(inst Instance) {
+				defer func() {
+					<-workerPool
+					wg.Done()
+				}()
+				fn(inst)
+			}(inst)
+
 		}
 	}
 	wg.Wait()

--- a/components/dm/spec/logic.go
+++ b/components/dm/spec/logic.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
@@ -440,12 +441,30 @@ func (topo *Specification) IterComponent(fn func(comp Component)) {
 }
 
 // IterInstance iterates all instances in component starting order
-func (topo *Specification) IterInstance(fn func(instance Instance)) {
+func (topo *Specification) IterInstance(fn func(instance Instance), concurrency ...int) {
+	maxWorkers := 1
+	wg := sync.WaitGroup{}
+	if len(concurrency) > 0 && concurrency[0] > 1 {
+		maxWorkers = concurrency[0]
+	}
+	workerPool := make(chan struct{}, maxWorkers)
+
 	for _, comp := range topo.ComponentsByStartOrder() {
 		for _, inst := range comp.Instances() {
-			fn(inst)
+			wg.Add(1)
+			workerPool <- struct{}{}
+			{
+				go func(inst Instance) {
+					defer func() {
+						<-workerPool
+						wg.Done()
+					}()
+					fn(inst)
+				}(inst)
+			}
 		}
 	}
+	wg.Wait()
 }
 
 // IterHost iterates one instance for each host

--- a/components/dm/spec/logic.go
+++ b/components/dm/spec/logic.go
@@ -453,9 +453,13 @@ func (topo *Specification) IterInstance(fn func(instance Instance), concurrency 
 		for _, inst := range comp.Instances() {
 			wg.Add(1)
 			workerPool <- struct{}{}
-			go fn(inst)
-			<-workerPool
-			wg.Done()
+			go func(inst Instance) {
+				defer func() {
+					<-workerPool
+					wg.Done()
+				}()
+				fn(inst)
+			}(inst)
 		}
 	}
 	wg.Wait()

--- a/components/dm/spec/logic.go
+++ b/components/dm/spec/logic.go
@@ -453,14 +453,9 @@ func (topo *Specification) IterInstance(fn func(instance Instance), concurrency 
 		for _, inst := range comp.Instances() {
 			wg.Add(1)
 			workerPool <- struct{}{}
-			go func(inst Instance) {
-				defer func() {
-					<-workerPool
-					wg.Done()
-				}()
-				fn(inst)
-			}(inst)
-
+			go fn(inst)
+			<-workerPool
+			wg.Done()
 		}
 	}
 	wg.Wait()

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/fatih/color"
 	perrs "github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/checkpoint"
 	"github.com/pingcap/tiup/pkg/cluster/api"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
@@ -535,7 +536,8 @@ func (m *Manager) GetClusterTopology(name string, opt operator.Options) ([]InstI
 		if status == "-" || (opt.ShowUptime && since == "-") {
 			e, found := ctxt.GetInner(ctx).GetExecutor(ins.GetHost())
 			if found {
-				active, _ := operator.GetServiceStatus(ctx, e, ins.ServiceName())
+				nctx := checkpoint.NewContext(ctx)
+				active, _ := operator.GetServiceStatus(nctx, e, ins.ServiceName())
 				if status == "-" {
 					if parts := strings.Split(strings.TrimSpace(active), " "); len(parts) > 2 {
 						if parts[1] == "active" {

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -366,7 +366,7 @@ func (m *Manager) DisplayTiKVLabels(name string, opt operator.Options) error {
 				masterActive = append(masterActive, instAddr)
 			}
 		}
-	})
+	}, opt.Concurrency)
 
 	var (
 		labelInfoArr  []api.LabelInfo
@@ -486,7 +486,7 @@ func (m *Manager) GetClusterTopology(name string, opt operator.Options) ([]InstI
 			masterActive = append(masterActive, instAddr)
 		}
 		masterStatus[ins.ID()] = status
-	})
+	}, opt.Concurrency)
 
 	var dashboardAddr string
 	if t, ok := topo.(*spec.Specification); ok {
@@ -569,7 +569,7 @@ func (m *Manager) GetClusterTopology(name string, opt operator.Options) ([]InstI
 			Port:          ins.GetPort(),
 			Since:         since,
 		})
-	})
+	}, opt.Concurrency)
 
 	// Sort by role,host,ports
 	sort.Slice(clusterInstInfos, func(i, j int) bool {

--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/AstroProfundis/sysinfo"
 	"github.com/pingcap/tidb-insight/collector/insight"
+	"github.com/pingcap/tiup/pkg/checkpoint"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/module"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -846,7 +847,7 @@ func CheckJRE(ctx context.Context, e ctxt.Executor, host string, topo *spec.Spec
 
 		// check if java cli is available
 		// the checkpoint part of context can't be shared between goroutines
-		stdout, stderr, err := e.Execute(ctx, "java -version", false)
+		stdout, stderr, err := e.Execute(checkpoint.NewContext(ctx), "java -version", false)
 		if err != nil {
 			results = append(results, &CheckResult{
 				Name: CheckNameCommand,

--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/AstroProfundis/sysinfo"
 	"github.com/pingcap/tidb-insight/collector/insight"
-	"github.com/pingcap/tiup/pkg/checkpoint"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/module"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
@@ -496,7 +495,7 @@ func CheckServices(ctx context.Context, e ctxt.Executor, host, service string, d
 
 	// check if the service exist before checking its status, ignore when non-exist
 	stdout, _, err := e.Execute(
-		checkpoint.NewContext(ctx),
+		ctx,
 		fmt.Sprintf(
 			"systemctl list-unit-files --type service | grep -i %s.service | wc -l", service),
 		true)
@@ -543,7 +542,7 @@ func CheckSELinux(ctx context.Context, e ctxt.Executor) *CheckResult {
 		Command: "grep -E '^\\s*SELINUX=enforcing' /etc/selinux/config 2>/dev/null | wc -l",
 		Sudo:    true,
 	})
-	stdout, stderr, err := m.Execute(checkpoint.NewContext(ctx), e)
+	stdout, stderr, err := m.Execute(ctx, e)
 	if err != nil {
 		result.Err = fmt.Errorf("%w %s", err, stderr)
 		return result
@@ -819,7 +818,7 @@ func CheckTHP(ctx context.Context, e ctxt.Executor) *CheckResult {
 		Command: fmt.Sprintf(`if [ -d %[1]s ]; then cat %[1]s/{enabled,defrag}; fi`, "/sys/kernel/mm/transparent_hugepage"),
 		Sudo:    true,
 	})
-	stdout, stderr, err := m.Execute(checkpoint.NewContext(ctx), e)
+	stdout, stderr, err := m.Execute(ctx, e)
 	if err != nil {
 		result.Err = fmt.Errorf("%w %s", err, stderr)
 		return result
@@ -847,7 +846,7 @@ func CheckJRE(ctx context.Context, e ctxt.Executor, host string, topo *spec.Spec
 
 		// check if java cli is available
 		// the checkpoint part of context can't be shared between goroutines
-		stdout, stderr, err := e.Execute(checkpoint.NewContext(ctx), "java -version", false)
+		stdout, stderr, err := e.Execute(ctx, "java -version", false)
 		if err != nil {
 			results = append(results, &CheckResult{
 				Name: CheckNameCommand,
@@ -892,7 +891,7 @@ func CheckJRE(ctx context.Context, e ctxt.Executor, host string, topo *spec.Spec
 func CheckDirPermission(ctx context.Context, e ctxt.Executor, user, path string) []*CheckResult {
 	var results []*CheckResult
 
-	_, stderr, err := e.Execute(checkpoint.NewContext(ctx),
+	_, stderr, err := e.Execute(ctx,
 		fmt.Sprintf(
 			"/usr/bin/sudo -u %[1]s touch %[2]s/.tiup_cluster_check_file && rm -f %[2]s/.tiup_cluster_check_file",
 			user,
@@ -923,7 +922,7 @@ func CheckDirIsExist(ctx context.Context, e ctxt.Executor, path string) []*Check
 		return results
 	}
 
-	req, _, _ := e.Execute(checkpoint.NewContext(ctx),
+	req, _, _ := e.Execute(ctx,
 		fmt.Sprintf(
 			"[ -e %s ] && echo 1",
 			path,

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -740,15 +740,14 @@ func (s *Specification) IterInstance(fn func(instance Instance), concurrency ...
 		for _, inst := range comp.Instances() {
 			wg.Add(1)
 			workerPool <- struct{}{}
-			{
-				go func(inst Instance) {
-					defer func() {
-						<-workerPool
-						wg.Done()
-					}()
-					fn(inst)
-				}(inst)
-			}
+			go func(inst Instance) {
+				defer func() {
+					<-workerPool
+					wg.Done()
+				}()
+				fn(inst)
+			}(inst)
+
 		}
 	}
 	wg.Wait()

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -740,9 +740,13 @@ func (s *Specification) IterInstance(fn func(instance Instance), concurrency ...
 		for _, inst := range comp.Instances() {
 			wg.Add(1)
 			workerPool <- struct{}{}
-			go fn(inst)
-			<-workerPool
-			wg.Done()
+			go func(inst Instance) {
+				defer func() {
+					<-workerPool
+					wg.Done()
+				}()
+				fn(inst)
+			}(inst)
 		}
 	}
 	wg.Wait()

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/creasty/defaults"
@@ -158,7 +159,7 @@ type Topology interface {
 	ComponentsByStartOrder() []Component
 	ComponentsByStopOrder() []Component
 	ComponentsByUpdateOrder() []Component
-	IterInstance(fn func(instance Instance))
+	IterInstance(fn func(instance Instance), concurrency ...int)
 	GetMonitoredOptions() *MonitoredOptions
 	// count how many time a path is used by instances in cluster
 	CountDir(host string, dir string) int
@@ -727,12 +728,30 @@ func (s *Specification) IterComponent(fn func(comp Component)) {
 }
 
 // IterInstance iterates all instances in component starting order
-func (s *Specification) IterInstance(fn func(instance Instance)) {
+func (s *Specification) IterInstance(fn func(instance Instance), concurrency ...int) {
+	maxWorkers := 1
+	wg := sync.WaitGroup{}
+	if len(concurrency) > 0 && concurrency[0] > 1 {
+		maxWorkers = concurrency[0]
+	}
+	workerPool := make(chan struct{}, maxWorkers)
+
 	for _, comp := range s.ComponentsByStartOrder() {
 		for _, inst := range comp.Instances() {
-			fn(inst)
+			wg.Add(1)
+			workerPool <- struct{}{}
+			{
+				go func(inst Instance) {
+					defer func() {
+						<-workerPool
+						wg.Done()
+					}()
+					fn(inst)
+				}(inst)
+			}
 		}
 	}
+	wg.Wait()
 }
 
 // IterHost iterates one instance for each host

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -740,14 +740,9 @@ func (s *Specification) IterInstance(fn func(instance Instance), concurrency ...
 		for _, inst := range comp.Instances() {
 			wg.Add(1)
 			workerPool <- struct{}{}
-			go func(inst Instance) {
-				defer func() {
-					<-workerPool
-					wg.Done()
-				}()
-				fn(inst)
-			}(inst)
-
+			go fn(inst)
+			<-workerPool
+			wg.Done()
 		}
 	}
 	wg.Wait()

--- a/pkg/cluster/spec/spec_manager_test.go
+++ b/pkg/cluster/spec/spec_manager_test.go
@@ -101,7 +101,7 @@ func (t *TestTopology) ComponentsByUpdateOrder() []Component {
 	return nil
 }
 
-func (t *TestTopology) IterInstance(fn func(instance Instance)) {
+func (t *TestTopology) IterInstance(fn func(instance Instance), concurrency ...int) {
 }
 
 func (t *TestTopology) GetMonitoredOptions() *MonitoredOptions {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

display support concurrent access to node status

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
