### PR TITLE
playground: make playground tag has higher priority than tiup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,17 +142,25 @@ the latest stable version will be downloaded from the repository.`,
 				return nil
 			case "--binpath":
 				if len(args) < 2 {
-					return fmt.Errorf("flag needs an argument: %s", args[0])
+					return fmt.Errorf("flag %s needs an argument", args[0])
 				}
 				binPath = args[1]
 				args = args[2:]
 			case "--tag", "-T":
 				if len(args) < 2 {
-					return fmt.Errorf("flag needs an argument: %s", args[0])
+					return fmt.Errorf("flag %s needs an argument", args[0])
 				}
 				tag = args[1]
 				args = args[2:]
 			}
+
+			// component may use tag from environment variable. as workaround, make tiup set the same tag
+			for i := 0; i < len(args)-1; i++ {
+				if args[i] == "--tag" || args[i] == "-T" {
+					tag = args[i+1]
+				}
+			}
+
 			if len(args) < 1 {
 				return cmd.Help()
 			}

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -164,24 +164,21 @@ Examples:
 			if tiupHome == "" {
 				tiupHome, _ = getAbsolutePath(filepath.Join("~", localdata.ProfileDirName))
 			}
-			if tiupDataDir == "" {
-				if tag == "" {
-					dataDir = filepath.Join(tiupHome, localdata.DataParentDir, utils.Base62Tag())
-				} else {
-					dataDir = filepath.Join(tiupHome, localdata.DataParentDir, tag)
-				}
-				if dataDir == "" {
-					return errors.Errorf("cannot read environment variable %s nor %s", localdata.EnvNameInstanceDataDir, localdata.EnvNameHome)
-				}
+			switch {
+			case tag != "":
+				dataDir = filepath.Join(tiupHome, localdata.DataParentDir, tag)
 				err := os.MkdirAll(dataDir, os.ModePerm)
 				if err != nil {
 					return err
 				}
-			} else {
+			case tiupDataDir != "":
 				dataDir = tiupDataDir
+				tag = dataDir[strings.LastIndex(dataDir, "/")+1:]
+			default:
+				tag = utils.Base62Tag()
+				dataDir = filepath.Join(tiupHome, localdata.DataParentDir, tag)
 			}
-			instanceName := dataDir[strings.LastIndex(dataDir, "/")+1:]
-			fmt.Printf("\033]0;TiUP Playground: %s\a", instanceName)
+			fmt.Printf("\033]0;TiUP Playground: %s\a", tag)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- on #1831 , we parser flag of tiup rootCmd manually, if user use `tiup playground --tag xxx`, tiup cannot Identify the flag and generate a random flag and pass it to playground.

### What is changed and how it works?

- make playground tag has higher priority than tiup
- make tiup scan the whole args insted of args[0]


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
