### PR TITLE
Update outdated doc links

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             <br />
 
             <p>This tool only supports Linux, macOS, and Windows WSL (for now)</p>
-            <p>Need help? Read the document(<a href="https://pingcap.com/docs/stable/how-to/deploy/orchestrated/tiup/">English</a>/<a href="https://pingcap.com/docs-cn/stable/how-to/deploy/orchestrated/tiup/">Chinese</a>) or <a href="https://github.com/pingcap/tiup/issues/new">file a GitHub issue</a></p>
+            <p>Need help? Read the document(<a href="https://docs.pingcap.com/tidb/stable/production-deployment-using-tiup">English</a>/<a href="https://docs.pingcap.com/zh/tidb/stable/production-deployment-using-tiup">Chinese</a>) or <a href="https://github.com/pingcap/tiup/issues/new">file a GitHub issue</a></p>
         </div>
     </div>
     <br/>


### PR DESCRIPTION
Signed-off-by: TomShawn <41534398+TomShawn@users.noreply.github.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The document links on the https://tiup.io/ page are outdated.

### What is changed and how it works?

Update the document links.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
