### PR TITLE
fix: TIUP_HOME is not loaded on initializes meta

### DIFF
--- a/pkg/cluster/spec/profile.go
+++ b/pkg/cluster/spec/profile.go
@@ -59,14 +59,18 @@ var initialized = false
 // The directory will be created before return if it does not already exist.
 func Initialize(base string) error {
 	tiupData := os.Getenv(tiuplocaldata.EnvNameComponentDataDir)
-	if tiupData == "" {
+	tiupHome := os.Getenv(tiuplocaldata.EnvNameHome)
+
+	if tiupData != "" {
+		profileDir = tiupData
+	} else if tiupHome != "" {
+		profileDir = path.Join(tiupHome, tiuplocaldata.StorageParentDir, base)
+	} else {
 		homeDir, err := getHomeDir()
 		if err != nil {
 			return errors.Trace(err)
 		}
 		profileDir = path.Join(homeDir, ".tiup", tiuplocaldata.StorageParentDir, base)
-	} else {
-		profileDir = tiupData
 	}
 
 	clusterBaseDir := filepath.Join(profileDir, TiUPClusterDir)

--- a/pkg/cluster/spec/profile.go
+++ b/pkg/cluster/spec/profile.go
@@ -61,11 +61,12 @@ func Initialize(base string) error {
 	tiupData := os.Getenv(tiuplocaldata.EnvNameComponentDataDir)
 	tiupHome := os.Getenv(tiuplocaldata.EnvNameHome)
 
-	if tiupData != "" {
+	switch {
+	case tiupData != "":
 		profileDir = tiupData
-	} else if tiupHome != "" {
+	case tiupHome != "":
 		profileDir = path.Join(tiupHome, tiuplocaldata.StorageParentDir, base)
-	} else {
+	default:
 		homeDir, err := getHomeDir()
 		if err != nil {
 			return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
TIUP_HOME is not loaded on initializes meta

![zBJr7SGnlN](https://user-images.githubusercontent.com/39378935/168518466-fce9f9d3-4225-437f-94f9-3ccee69ef522.jpg)


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
