### PR TITLE
playground: use test-cluster as dashboard name

### DIFF
--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -145,7 +145,7 @@ func makeSureDir(fname string) error {
 	return os.MkdirAll(filepath.Dir(fname), 0755)
 }
 
-var clusterName string = "playground"
+var clusterName = "Test-Cluster"
 
 // dir should contains files untar the grafana.
 // return not error iff the Cmd is started successfully.


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

For now it is complicated to update the Dashboard JSON, for example:
https://github.com/tikv/tikv/issues/12796

One of the major changes need to take is that, playground initializes the datasource as "playground", so that the Grafana exported Dashboard JSON (containing Datasource as `${DS-PLAYGROUND}` instead of `${DS-TEST-CLUSTER}`) cannot be used by TiUP later again.

### What is changed and how it works?

Change name to `Test-Cluster`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
