### PR TITLE
playground: don't get Pid() when there is no Process

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -987,26 +987,40 @@ func (p *Playground) terminate(sig syscall.Signal) {
 		go kill("grafana", p.grafana.cmd.Process.Pid, p.grafana.wait)
 	}
 	for _, inst := range p.tiflashs {
-		kill(inst.Component(), inst.Pid(), inst.Wait)
+		if inst.Process != nil {
+			kill(inst.Component(), inst.Pid(), inst.Wait)
+		}
 	}
 	for _, inst := range p.ticdcs {
-		kill(inst.Component(), inst.Pid(), inst.Wait)
+		if inst.Process != nil {
+			kill(inst.Component(), inst.Pid(), inst.Wait)
+		}
 	}
 	for _, inst := range p.drainers {
-		kill(inst.Component(), inst.Pid(), inst.Wait)
+		if inst.Process != nil {
+			kill(inst.Component(), inst.Pid(), inst.Wait)
+		}
 	}
 	// tidb must exit earlier then pd
 	for _, inst := range p.tidbs {
-		kill(inst.Component(), inst.Pid(), inst.Wait)
+		if inst.Process != nil {
+			kill(inst.Component(), inst.Pid(), inst.Wait)
+		}
 	}
 	for _, inst := range p.pumps {
-		kill(inst.Component(), inst.Pid(), inst.Wait)
+		if inst.Process != nil {
+			kill(inst.Component(), inst.Pid(), inst.Wait)
+		}
 	}
 	for _, inst := range p.tikvs {
-		kill(inst.Component(), inst.Pid(), inst.Wait)
+		if inst.Process != nil {
+			kill(inst.Component(), inst.Pid(), inst.Wait)
+		}
 	}
 	for _, inst := range p.pds {
-		kill(inst.Component(), inst.Pid(), inst.Wait)
+		if inst.Process != nil {
+			kill(inst.Component(), inst.Pid(), inst.Wait)
+		}
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Closes #1932 

```
> main.(*Playground).terminate() ./components/playground/playground.go:990 (hits goroutine(1):1 total:1) (PC: 0x150724e)
   985:	
   986:		if p.grafana != nil {
   987:			go kill("grafana", p.grafana.cmd.Process.Pid, p.grafana.wait)
   988:		}
   989:		for _, inst := range p.tiflashs {
=> 990:			fmt.Printf("inst: %-v\n", inst.Pid())
   991:			kill(inst.Component(), inst.Pid(), inst.Wait)
   992:		}
   993:		for _, inst := range p.ticdcs {
   994:			kill(inst.Component(), inst.Pid(), inst.Wait)
   995:		}
(dlv) p inst
*github.com/pingcap/tiup/components/playground/instance.TiFlashInstance {
	instance: github.com/pingcap/tiup/components/playground/instance.instance {
		ID: 0,
		Dir: "/home/dvaneeden/.tiup/data/T9HJm1o/tiflash-0",
		Host: "127.0.0.1",
		Port: 8123,
		StatusPort: 8234,
		ConfigPath: "",
		BinPath: "",},
	TCPPort: 9000,
	ServicePort: 3930,
	ProxyPort: 20170,
	ProxyStatusPort: 20292,
	ProxyConfigPath: "",
	pds: []*github.com/pingcap/tiup/components/playground/instance.PDInstance len: 1, cap: 1, [
		*(*"github.com/pingcap/tiup/components/playground/instance.PDInstance")(0xc000200b40),
	],
	dbs: []*github.com/pingcap/tiup/components/playground/instance.TiDBInstance len: 1, cap: 1, [
		*(*"github.com/pingcap/tiup/components/playground/instance.TiDBInstance")(0xc000172d80),
	],
	Process: github.com/pingcap/tiup/components/playground/instance.Process nil,}
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Playground no longer panics when trying to stop processes that don't actually exist
```
