### PR TITLE
playground: fix scale-out cdc command

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -525,6 +525,11 @@ func (p *Playground) commandHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Mapping command line component id to internal spec component id.
+	if cmd.ComponentID == ticdc {
+		cmd.ComponentID = spec.ComponentCDC
+	}
+
 	err = p.handleCommand(cmd, w)
 	if err != nil {
 		w.WriteHeader(403)


### PR DESCRIPTION
Signed-off-by: Henry Lonng <henry@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Try to close: #1934 


### What is changed and how it works?

The playground mix use of string literal `ticdc` and pre-defined component type `spec.ComponentCDC` and they are inconsistent.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix playground scale-out CDC node failure issue
```
