### PR TITLE
Support specifying TiSpark version in TiUP cluster

### DIFF
--- a/embed/templates/config/spark3-defaults.conf.tpl
+++ b/embed/templates/config/spark3-defaults.conf.tpl
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+
+# Example:
+#spark.eventLog.dir: "hdfs://namenode:8021/directory"
+# spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"
+
+{{- define "PDList"}}
+  {{- range $idx, $pd := .}}
+    {{- if eq $idx 0}}
+      {{- $pd}}
+    {{- else -}}
+      ,{{$pd}}
+    {{- end}}
+  {{- end}}
+{{- end}}
+
+{{ range $k, $v := .CustomFields}}
+{{ $k }}   {{ $v }}
+{{- end }}
+spark.sql.extensions   org.apache.spark.sql.TiExtensions
+
+{{- if .TiSparkMasters}}
+spark.master   spark://{{.TiSparkMasters}}
+{{- end}}
+
+spark.tispark.pd.addresses {{template "PDList" .Endpoints}}
+
+spark.sql.catalog.tidb_catalog  org.apache.spark.sql.catalyst.catalog.TiCatalog
+
+spark.sql.catalog.tidb_catalog.pd.addresses  {{template "PDList" .Endpoints}}

--- a/pkg/cluster/manager/builder.go
+++ b/pkg/cluster/manager/builder.go
@@ -156,15 +156,8 @@ func buildScaleOutTask(
 		envInitTasks = append(envInitTasks, t)
 	})
 
-	// Get versions info from TiSparkMasters
+	// Get versions info from mergedTopo
 	var sparkVersion, tiSparkVersion, scalaVersion string
-	//mergedTopo.IterInstance(func(inst spec.Instance) {
-	//	if i, ok := inst.(*spec.TiSparkMasterInstance); ok {
-	//		sparkVersion, tiSparkVersion, scalaVersion = i.GetOrUpdateVersion()
-	//		m.logger.Infof("builder: spark version: `%s` ,tispark version : `%s`, scala version : `%s`", sparkVersion, tiSparkVersion, scalaVersion)
-	//	}
-	//})
-
 	if topo, ok := mergedTopo.(*spec.Specification); ok {
 		if len(topo.TiSparkMasters) > 0 {
 			sparkVersion, tiSparkVersion, scalaVersion = topo.TiSparkMasters[0].GetVersion()

--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -26,9 +26,7 @@ import (
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/cluster/task"
-	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/meta"
-	"github.com/pingcap/tiup/pkg/repository"
 	"github.com/pingcap/tiup/pkg/tui"
 	"github.com/pingcap/tiup/pkg/utils"
 	"golang.org/x/mod/semver"
@@ -145,15 +143,7 @@ func (m *Manager) Upgrade(name string, clusterVersion string, opt operator.Optio
 				// copy dependency component if needed
 				switch inst.ComponentName() {
 				case spec.ComponentTiSpark:
-					env := environment.GlobalEnv()
-					sparkVer, _, err := env.V1Repository().WithOptions(repository.Options{
-						GOOS:   inst.OS(),
-						GOARCH: inst.Arch(),
-					}).LatestStableVersion(spec.ComponentSpark, false)
-					if err != nil {
-						return err
-					}
-					tb = tb.DeploySpark(inst, sparkVer.String(), "" /* default srcPath */, deployDir)
+					// Skip TiSpark when upgrade
 				default:
 					tb = tb.CopyComponent(
 						inst.ComponentName(),

--- a/pkg/cluster/spec/bindversion.go
+++ b/pkg/cluster/spec/bindversion.go
@@ -38,7 +38,10 @@ func TiDBComponentVersion(comp, version string) string {
 // ComponentSubDir maps a component with version to a subdir if needed
 func ComponentSubDir(comp, version string) string {
 	if comp == ComponentSpark {
-		return fmt.Sprintf("spark-%s-bin-hadoop2.7", strings.TrimLeft(version, "v"))
+		if version < "v3.1.0" {
+			return fmt.Sprintf("spark-%s-bin-hadoop2.7", strings.TrimLeft(version, "v"))
+		}
+		return fmt.Sprintf("spark-%s-bin-hadoop3.2", strings.TrimLeft(version, "v"))
 	}
 	return ""
 }

--- a/pkg/cluster/spec/spec_test.go
+++ b/pkg/cluster/spec/spec_test.go
@@ -99,6 +99,8 @@ pd_servers:
 cdc_servers:
   - host: 172.16.5.233
     data_dir: "cdc-data"
+tispark_masters:
+  - host: 172.16.5.233
 `), &topo)
 	c.Assert(err, IsNil)
 	c.Assert(topo.GlobalOptions.User, Equals, "test1")
@@ -113,6 +115,9 @@ cdc_servers:
 	c.Assert(topo.CDCServers[0].SSHPort, Equals, 220)
 	c.Assert(topo.CDCServers[0].DeployDir, Equals, "test-deploy/cdc-8300")
 	c.Assert(topo.CDCServers[0].DataDir, Equals, "cdc-data")
+
+	c.Assert(topo.TiSparkMasters[0].SSHPort, Equals, 220)
+	c.Assert(topo.TiSparkMasters[0].DeployDir, Equals, "test-deploy/tispark-master-7077")
 }
 
 func (s *metaSuiteTopo) TestDataDirAbsolute(c *C) {
@@ -853,4 +858,27 @@ tidb_servers:
 `), &topo)
 	c.Assert(err, NotNil)
 	c.Assert(strings.Contains(err.Error(), "not found"), IsTrue)
+}
+
+func (s *metaSuiteTopo) TestTiSparkVersion(c *C) {
+	topo := Specification{}
+	err := yaml.Unmarshal([]byte(`
+global:
+  user: "test1"
+  ssh_port: 220
+  deploy_dir: "test-deploy"
+  data_dir: "test-data"
+tidb_servers:
+  - host: 172.16.5.138
+    deploy_dir: "tidb-deploy"
+tispark_masters:
+  - host: 172.16.5.233
+    spark_version: "v3.0.4"
+    tispark_version: "v3.0.0"
+`), &topo)
+	c.Assert(err, IsNil)
+
+	c.Assert(topo.TiSparkMasters[0].SparkVersion, Equals, "v3.0.4")
+	c.Assert(topo.TiSparkMasters[0].TiSparkVersion, Equals, "v3.0.0")
+	c.Assert(topo.TiSparkMasters[0].ScalaVersion, Equals, "v2.12")
 }

--- a/pkg/cluster/spec/tispark.go
+++ b/pkg/cluster/spec/tispark.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/pingcap/tiup/pkg/environment"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -31,6 +30,7 @@ import (
 	"github.com/pingcap/tiup/pkg/cluster/template/config"
 	"github.com/pingcap/tiup/pkg/cluster/template/scripts"
 	system "github.com/pingcap/tiup/pkg/cluster/template/systemd"
+	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/meta"
 	"go.uber.org/zap"
 )

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -45,6 +45,7 @@ var (
 		`followed by lower case letters, digits, underscores, or dashes. ` +
 		`Usernames may only be up to 32 characters long. ` +
 		`Groupnames may only be up to 16 characters long.`)
+	ErrSingleTiSparkVersion = errors.New("tiSpark_version and spark_version need to be set together or not set together")
 )
 
 // Linux username and groupname must start with a lower case letter or an underscore,
@@ -910,6 +911,13 @@ func (s *Specification) validateTiSparkSpec() error {
 			}
 			cnt[w.Host]++
 		}
+	}
+
+	// Set both sparkVersion and tiSparkVersion or none of them should be set
+	sparkVersion := s.TiSparkMasters[0].SparkVersion
+	tiSparkVersion := s.TiSparkMasters[0].TiSparkVersion
+	if (sparkVersion == "" && tiSparkVersion != "") || (sparkVersion != "" && tiSparkVersion == "") {
+		return ErrSingleTiSparkVersion
 	}
 
 	return nil

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -432,6 +432,19 @@ tispark_workers:
 `), &topo)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "the host 172.16.5.139 is duplicated: multiple TiSpark workers on the same host is not supported by Spark")
+
+	err = yaml.Unmarshal([]byte(`
+pd_servers:
+  - host: 172.16.5.138
+    peer_port: 1234
+tispark_masters:
+  - host: 172.16.5.138
+    spark_version: "v3.0.4"
+tispark_workers:
+  - host: 172.16.5.138
+`), &topo)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "tiSpark_version and spark_version need to be set together or not set together")
 }
 
 func (s *metaSuiteTopo) TestTLSEnabledValidation(c *C) {

--- a/pkg/cluster/template/config/tispark.go
+++ b/pkg/cluster/template/config/tispark.go
@@ -15,12 +15,12 @@ package config
 
 import (
 	"bytes"
-	"github.com/pingcap/tiup/pkg/utils"
 	"os"
 	"path/filepath"
 	"text/template"
 
 	"github.com/pingcap/tiup/embed"
+	"github.com/pingcap/tiup/pkg/utils"
 )
 
 // TiSparkConfig represent the data to generate TiSpark configs

--- a/pkg/cluster/template/systemd/tispark.go
+++ b/pkg/cluster/template/systemd/tispark.go
@@ -30,7 +30,7 @@ type TiSparkConfig struct {
 	DeployDir   string
 	JavaHome    string
 	// Takes one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always.
-	// The Template set as always if this is not setted.
+	// The Template set as always if this is not set.
 	Restart string
 }
 

--- a/pkg/utils/semver.go
+++ b/pkg/utils/semver.go
@@ -79,6 +79,12 @@ func (v Version) String() string {
 	return string(v)
 }
 
+// GetStringWithoutV returns version without v
+func (v Version) GetStringWithoutV() string {
+	version := string(v)
+	return version[1:]
+}
+
 type ver struct {
 	Major, Minor, Patch int
 	Prerelease          []string

--- a/pkg/utils/semver_test.go
+++ b/pkg/utils/semver_test.go
@@ -32,6 +32,8 @@ func (s *TestSemverSuite) TestVersion(c *C) {
 	c.Assert(Version("").IsNightly(), IsFalse)
 	c.Assert(Version("nightly").IsNightly(), IsTrue)
 	c.Assert(Version("v1.2.3").String(), Equals, "v1.2.3")
+	c.Assert(Version("v1.2.3").GetStringWithoutV(), Equals, "1.2.3")
+
 }
 
 func (s *TestSemverSuite) TestConstraint(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Support specifying tispark version.
This pr should not be merged before upload spark & tispark to mirror 

### What is changed and how it works?
- Support specifying TiSpark version
   - Add spark_version, tispark_version and scala_version in TiSparkMasterSpec
   - valid version: spark_version and tispark_version should be set together or not be set together
   - Transfer spark_version, tispark_version, and scala_version to TiSparkInstance(both master and worker)
   - Get version info and download spark & tispark
   - Choose the TiSpark jar  to deploy
   - Get version info from mergedtopo when scale-out
- Generate different configs for different tispark_version
- Skip  TiSpark when upgrade

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Manual test (add detailed scripts or steps below)
 - spark_version 3.0.3 tispark version 3.0.0 scala version 2.12 (success)
 - spark_version 3.0.3 tispark version 3.0.0 (success)
 - spark_version 2.4.3 tispark version 2.4.1 (success)
 - no paratemer (success)
 - spark_version 3.0.3 tispark version 3.0.0 scala version 2.11 (fail because no jar found)
 - spark_version 3.0.3 (fail because tispark version not set)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change


Related changes

 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
