### PR TITLE
pkg/utils: fix get free port from ipv6 host

### DIFF
--- a/pkg/utils/freeport.go
+++ b/pkg/utils/freeport.go
@@ -16,6 +16,7 @@ package utils
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -36,14 +37,15 @@ func GetFreePort(host string, priority int) (int, error) {
 
 // MustGetFreePort asks the kernel for a free open port that is ready to use, if fail, panic
 func MustGetFreePort(host string, priority int) int {
-	if port, err := GetFreePort(host, priority); err == nil {
-		return port
+	port, err := GetFreePort(host, priority)
+	if err != nil {
+		panic(fmt.Sprintf("can't get a free port: %v", err))
 	}
-	panic("can't get a free port")
+	return port
 }
 
 func getPort(host string, port int) (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", host, port))
+	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`tiup playground` can not specify an ipv6 host.


### What is changed and how it works?
Use the correct function to join host port.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix playground cannot specify ipv6 host
```
