### PR TITLE
playground: fix ineffectiveness of ticdc.config

### DIFF
--- a/components/playground/instance/ticdc.go
+++ b/components/playground/instance/ticdc.go
@@ -63,6 +63,9 @@ func (c *TiCDC) Start(ctx context.Context, version utils.Version) error {
 	}
 	clusterVersion := string(version)
 	if tidbver.TiCDCSupportConfigFile(clusterVersion) {
+		if c.ConfigPath != "" {
+			args = append(args, fmt.Sprintf("--config=%s", c.ConfigPath))
+		}
 		if tidbver.TiCDCSupportDataDir(clusterVersion) {
 			args = append(args, fmt.Sprintf("--data-dir=%s", filepath.Join(c.Dir, "data")))
 		} else {


### PR DESCRIPTION
Issue Number: #1977

Signed-off-by: pingyu <yuping@pingcap.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#1977 

### What is changed and how it works?
Add "--config=" to arguments of TiCDC.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. Prepare `cdc.toml`:
```
log-level = "debug"
```
2. Start playground
```
tiup-playground nightly --db 1 --tiflash 0 --kv 1 --kv.config etc/tikv-v2.toml --pd 1 --pd.config etc/pd.toml --ticdc 1 --ticdc.config etc/cdc.toml
```

3. Check log level of "cdc.log"
```sh
> cat cdc-0/ticdc.log
...
[2022/07/09 17:32:48.124 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:48.124 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:48.124 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:48.124 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:49.125 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:49.125 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:49.125 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:49.125 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:50.126 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:50.126 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
[2022/07/09 17:32:50.126 +08:00] [DEBUG] [etcd_worker.go:178] ["Etcd progress notification"] [revision=1284165]
...
```

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 TBD


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
fix ineffectiveness of "ticdc.config" of playground
```
