### PR TITLE
fix scale-out check failed with 'no pd found' message 

### DIFF
--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -953,7 +953,7 @@ func CheckDirIsExist(ctx context.Context, e ctxt.Executor, path string) []*Check
 }
 
 // CheckTimeZone performs checks if time zone is the same
-func CheckTimeZone(ctx context.Context, topo *spec.Specification, host string, rawData []byte) []*CheckResult {
+func CheckTimeZone(ctx context.Context, currtopo *spec.Specification, topo *spec.Specification, host string, rawData []byte) []*CheckResult {
 	var results []*CheckResult
 	var insightInfo, pd0insightInfo insight.InsightInfo
 	if err := json.Unmarshal(rawData, &insightInfo); err != nil {
@@ -963,17 +963,17 @@ func CheckTimeZone(ctx context.Context, topo *spec.Specification, host string, r
 		})
 	}
 
-	if len(topo.PDServers) < 1 {
+	if len(currtopo.PDServers) < 1 {
 		return append(results, &CheckResult{
 			Name: CheckNameTimeZone,
 			Err:  fmt.Errorf("no pd found"),
 		})
 	}
 	// skip compare with itself
-	if topo.PDServers[0].Host == host {
+	if currtopo.PDServers[0].Host == host {
 		return nil
 	}
-	pd0stdout, _, _ := ctxt.GetInner(ctx).GetOutputs(topo.PDServers[0].Host)
+	pd0stdout, _, _ := ctxt.GetInner(ctx).GetOutputs(currtopo.PDServers[0].Host)
 	if err := json.Unmarshal(pd0stdout, &pd0insightInfo); err != nil {
 		return append(results, &CheckResult{
 			Name: CheckNameTimeZone,

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -417,9 +417,10 @@ func (b *Builder) Limit(host, domain, limit, item, value string) *Builder {
 }
 
 // CheckSys checks system information of deploy server
-func (b *Builder) CheckSys(host, dir, checkType string, topo *spec.Specification, opt *operator.CheckOptions) *Builder {
+func (b *Builder) CheckSys(host, dir, checkType string, currtopo *spec.Specification, topo *spec.Specification, opt *operator.CheckOptions) *Builder {
 	b.tasks = append(b.tasks, &CheckSys{
 		host:     host,
+		currtopo: currtopo,
 		topo:     topo,
 		opt:      opt,
 		checkDir: dir,

--- a/pkg/cluster/task/check.go
+++ b/pkg/cluster/task/check.go
@@ -48,6 +48,7 @@ const (
 // CheckSys performs checks of system information
 type CheckSys struct {
 	host     string
+	currtopo *spec.Specification
 	topo     *spec.Specification
 	opt      *operator.CheckOptions
 	check    string // check type name
@@ -157,7 +158,7 @@ func (c *CheckSys) Execute(ctx context.Context) error {
 		// check partition mount options for data_dir
 		storeResults(ctx, c.host, operator.CheckDirIsExist(ctx, e, c.checkDir))
 	case CheckTypeTimeZone:
-		storeResults(ctx, c.host, operator.CheckTimeZone(ctx, c.topo, c.host, stdout))
+		storeResults(ctx, c.host, operator.CheckTimeZone(ctx, c.currtopo, c.topo, c.host, stdout))
 	}
 
 	return nil


### PR DESCRIPTION
## Bug Report

Please answer these questions before submitting your issue. Thanks!

1. What did you do?
<!--If possible, provide a recipe for reproducing the error.-->
1. download tiup:curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
2.tiup cluster deploy test v6.1.0 test.yaml
3.tiup cluster check test scale-out.yaml --cluster

2. What did you expect to see?
Node           Check         Result  Message
xxx.xxx.xxx.xxx  timezone      True    


3. What did you see instead?
Node           Check         Result  Message
xxx.xxx.xxx.xxx  timezone      Fail    no pd found

4. What version of TiUP are you using (`tiup --version`)?
v1.10.2