### PR TITLE
cdc rolling upgrade remove status check to prevent false detection.

### DIFF
--- a/pkg/cluster/api/cdcapi.go
+++ b/pkg/cluster/api/cdcapi.go
@@ -195,7 +195,7 @@ func (c *CDCOpenAPIClient) GetAllCaptures() (result []*Capture, err error) {
 		}
 		return nil
 	}, utils.RetryOption{
-		Timeout: 20 * time.Second,
+		Timeout: 10 * time.Second,
 	})
 	return result, err
 }

--- a/pkg/cluster/api/cdcapi.go
+++ b/pkg/cluster/api/cdcapi.go
@@ -260,7 +260,7 @@ func (c *CDCOpenAPIClient) GetStatus() (result ServerStatus, err error) {
 		}
 		return nil
 	}, utils.RetryOption{
-		Timeout: 20 * time.Second,
+		Timeout: 10 * time.Second,
 	})
 
 	return result, err

--- a/pkg/cluster/spec/cdc.go
+++ b/pkg/cluster/spec/cdc.go
@@ -237,16 +237,11 @@ func (i *CDCInstance) PreRestart(ctx context.Context, topo Topology, apiTimeoutS
 		return nil
 	}
 
-	if i.Status(ctx, 5*time.Second, tlsCfg) == "Down" {
-		logger.Debugf("cdc pre-restart skipped, instance is down, trigger hard restart, addr: %s", address)
-		return nil
-	}
-
 	start := time.Now()
 	client := api.NewCDCOpenAPIClient(ctx, []string{address}, 5*time.Second, tlsCfg)
 	captures, err := client.GetAllCaptures()
 	if err != nil {
-		logger.Warnf("cdc pre-restart failed, cannot get all captures, trigger hard restart, addr: %s, elapsed: %+v", address, time.Since(start))
+		logger.Warnf("cdc pre-restart skipped, cannot get all captures, trigger hard restart, addr: %s, elapsed: %+v", address, time.Since(start))
 		return nil
 	}
 

--- a/pkg/cluster/spec/cdc.go
+++ b/pkg/cluster/spec/cdc.go
@@ -306,13 +306,8 @@ func (i *CDCInstance) PostRestart(ctx context.Context, topo Topology, tlsCfg *tl
 
 	start := time.Now()
 	address := i.GetAddr()
-	if i.Status(ctx, 5*time.Second, tlsCfg) == "Down" {
-		logger.Debugf("cdc post-restart skipped, instance is down, addr: %s, elapsed: %+v", address, time.Since(start))
-		return nil
-	}
 
 	client := api.NewCDCOpenAPIClient(ctx, []string{address}, 5*time.Second, tlsCfg)
-
 	err := client.IsCaptureAlive()
 	if err != nil {
 		logger.Debugf("cdc post-restart finished, get capture status failed, addr: %s, err: %+v, elapsed: %+v", address, err, time.Since(start))


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

cdc `prerestart` and `postrestart` method, remove status check, since after the instance restart, it would cost a few seconds to be available.

* this prevent false detect that a new start cdc instance is down, since it will be available just a few seconds later, around 3 ~ 5s seconds.
* When all cdc instance is down, for `upgrade` / `scale-in`, this would cost a little longer time to guarantee that the instance is down now, which is acceptable.
* adjust the timout for get capture open api to 10s, this should be long enough.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

* Deploy 2 cdc capture, restart the first one, the second one should perform the `prerestart` and `postrestart` as expected.

Code changes

Side effects

Related changes

Release notes:
<!--
-->
```release-note
NONE
```
