### PR TITLE
playground: Fix "--tag" argument for subcommands.

### DIFF
--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -309,7 +309,7 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 	defaultOptions := &BootOptions{}
 
 	rootCmd.Flags().String(mode, defaultMode, "TiUP playground mode: 'tidb', 'tikv-slim'")
-	rootCmd.Flags().StringVarP(&tag, "tag", "T", "", "Specify a tag for playground")
+	rootCmd.PersistentFlags().StringVarP(&tag, "tag", "T", "", "Specify a tag for playground") // Use `PersistentFlags()` to make it available to subcommands.
 	rootCmd.Flags().Bool(withoutMonitor, false, "Don't start prometheus and grafana component")
 	rootCmd.Flags().Bool(withMonitor, true, "Start prometheus and grafana component")
 	_ = rootCmd.Flags().MarkDeprecated(withMonitor, "Please use --without-monitor to control whether to disable monitor.")


### PR DESCRIPTION
Issue Number: #1997

Signed-off-by: pingyu <yuping@pingcap.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1997 .

### What is changed and how it works?
Use `rootCmd.PersistentFlags()` to add the "--tag" argument, other than `rootCmd.Flags()`, which is invisible to subcommands. Refer to https://github.com/spf13/cobra/blob/main/user_guide.md#persistent-flags.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```
bin/tiup-playground display --tag clst21-up
Pid     Role      Uptime
---     ----      ------
743313  pd        125h42m51.503041111s
743345  tikv      125h42m51.372436142s
743346  tikv-cdc  125h42m51.363139055s
```

Code changes
- No.

Side effects
- No.

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix "--tag" argument for playground subcommands.
```
