### PR TITLE
playground: Supports the TiKV-CDC component

### DIFF
--- a/.github/workflows/integrate-playground.yaml
+++ b/.github/workflows/integrate-playground.yaml
@@ -39,6 +39,7 @@ jobs:
       matrix:
         cases:
           - "test_playground"
+          - "test_kvcdc"
     env:
       working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
     steps:

--- a/components/playground/command.go
+++ b/components/playground/command.go
@@ -56,6 +56,7 @@ func buildCommands(tp CommandType, opt *BootOptions) (cmds []Command) {
 		{"tiflash", opt.TiFlash},
 		{"tidb", opt.TiDB},
 		{"ticdc", opt.TiCDC},
+		{"tikv-cdc", opt.TiKVCDC},
 		{"drainer", opt.Drainer},
 	}
 
@@ -98,6 +99,7 @@ func newScaleOut() *cobra.Command {
 	cmd.Flags().IntVarP(&opt.PD.Num, "pd", "", opt.PD.Num, "PD instance number")
 	cmd.Flags().IntVarP(&opt.TiFlash.Num, "tiflash", "", opt.TiFlash.Num, "TiFlash instance number")
 	cmd.Flags().IntVarP(&opt.TiCDC.Num, "ticdc", "", opt.TiCDC.Num, "TiCDC instance number")
+	cmd.Flags().IntVarP(&opt.TiKVCDC.Num, "kvcdc", "", opt.TiKVCDC.Num, "TiKV-CDC instance number")
 	cmd.Flags().IntVarP(&opt.Pump.Num, "pump", "", opt.Pump.Num, "Pump instance number")
 	cmd.Flags().IntVarP(&opt.Drainer.Num, "drainer", "", opt.Pump.Num, "Drainer instance number")
 
@@ -116,6 +118,7 @@ func newScaleOut() *cobra.Command {
 	cmd.Flags().StringVarP(&opt.PD.BinPath, "pd.binpath", "", opt.PD.BinPath, "PD instance binary path")
 	cmd.Flags().StringVarP(&opt.TiFlash.BinPath, "tiflash.binpath", "", opt.TiFlash.BinPath, "TiFlash instance binary path")
 	cmd.Flags().StringVarP(&opt.TiCDC.BinPath, "ticdc.binpath", "", opt.TiCDC.BinPath, "TiCDC instance binary path")
+	cmd.Flags().StringVarP(&opt.TiKVCDC.BinPath, "kvcdc.binpath", "", opt.TiKVCDC.BinPath, "TiKVCDC instance binary path")
 	cmd.Flags().StringVarP(&opt.Pump.BinPath, "pump.binpath", "", opt.Pump.BinPath, "Pump instance binary path")
 	cmd.Flags().StringVarP(&opt.Drainer.BinPath, "drainer.binpath", "", opt.Drainer.BinPath, "Drainer instance binary path")
 

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -29,6 +29,7 @@ type Config struct {
 	Host       string `yaml:"host"`
 	Port       int    `yaml:"port"`
 	UpTimeout  int    `yaml:"up_timeout"`
+	Version    string `yaml:"version"`
 }
 
 type instance struct {

--- a/components/playground/instance/tikv_cdc.go
+++ b/components/playground/instance/tikv_cdc.go
@@ -26,15 +26,14 @@ import (
 // TiKVCDC represent a TiKV-CDC instance.
 type TiKVCDC struct {
 	instance
-	version utils.Version
-	pds     []*PDInstance
+	pds []*PDInstance
 	Process
 }
 
 var _ Instance = &TiKVCDC{}
 
 // NewTiKVCDC create a TiKVCDC instance.
-func NewTiKVCDC(version utils.Version, binPath string, dir, host, configPath string, id int, pds []*PDInstance) *TiKVCDC {
+func NewTiKVCDC(binPath string, dir, host, configPath string, id int, pds []*PDInstance) *TiKVCDC {
 	tikvCdc := &TiKVCDC{
 		instance: instance{
 			BinPath:    binPath,
@@ -44,15 +43,14 @@ func NewTiKVCDC(version utils.Version, binPath string, dir, host, configPath str
 			Port:       utils.MustGetFreePort(host, 8800),
 			ConfigPath: configPath,
 		},
-		version: version,
-		pds:     pds,
+		pds: pds,
 	}
 	tikvCdc.StatusPort = tikvCdc.Port
 	return tikvCdc
 }
 
 // Start implements Instance interface.
-func (c *TiKVCDC) Start(ctx context.Context, _ utils.Version) error {
+func (c *TiKVCDC) Start(ctx context.Context, version utils.Version) error {
 	endpoints := pdEndpoints(c.pds, true)
 
 	args := []string{
@@ -68,7 +66,7 @@ func (c *TiKVCDC) Start(ctx context.Context, _ utils.Version) error {
 	args = append(args, fmt.Sprintf("--data-dir=%s", filepath.Join(c.Dir, "data")))
 
 	var err error
-	if c.BinPath, err = tiupexec.PrepareBinary("tikv-cdc", c.version, c.BinPath); err != nil {
+	if c.BinPath, err = tiupexec.PrepareBinary("tikv-cdc", version, c.BinPath); err != nil {
 		return err
 	}
 	c.Process = &process{cmd: PrepareCommand(ctx, c.BinPath, args, nil, c.Dir)}

--- a/components/playground/instance/tikv_cdc.go
+++ b/components/playground/instance/tikv_cdc.go
@@ -1,0 +1,88 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	tiupexec "github.com/pingcap/tiup/pkg/exec"
+	"github.com/pingcap/tiup/pkg/utils"
+)
+
+// TiKVCDC represent a TiKV-CDC instance.
+type TiKVCDC struct {
+	instance
+	version utils.Version
+	pds     []*PDInstance
+	Process
+}
+
+var _ Instance = &TiKVCDC{}
+
+// NewTiKVCDC create a TiKVCDC instance.
+func NewTiKVCDC(version utils.Version, binPath string, dir, host, configPath string, id int, pds []*PDInstance) *TiKVCDC {
+	tikvCdc := &TiKVCDC{
+		instance: instance{
+			BinPath:    binPath,
+			ID:         id,
+			Dir:        dir,
+			Host:       host,
+			Port:       utils.MustGetFreePort(host, 8800),
+			ConfigPath: configPath,
+		},
+		version: version,
+		pds:     pds,
+	}
+	tikvCdc.StatusPort = tikvCdc.Port
+	return tikvCdc
+}
+
+// Start implements Instance interface.
+func (c *TiKVCDC) Start(ctx context.Context, _ utils.Version) error {
+	endpoints := pdEndpoints(c.pds, true)
+
+	args := []string{
+		"server",
+		fmt.Sprintf("--addr=%s:%d", c.Host, c.Port),
+		fmt.Sprintf("--advertise-addr=%s:%d", AdvertiseHost(c.Host), c.Port),
+		fmt.Sprintf("--pd=%s", strings.Join(endpoints, ",")),
+		fmt.Sprintf("--log-file=%s", c.LogFile()),
+	}
+	if c.ConfigPath != "" {
+		args = append(args, fmt.Sprintf("--config=%s", c.ConfigPath))
+	}
+	args = append(args, fmt.Sprintf("--data-dir=%s", filepath.Join(c.Dir, "data")))
+
+	var err error
+	if c.BinPath, err = tiupexec.PrepareBinary("tikv-cdc", c.version, c.BinPath); err != nil {
+		return err
+	}
+	c.Process = &process{cmd: PrepareCommand(ctx, c.BinPath, args, nil, c.Dir)}
+
+	logIfErr(c.Process.SetOutputFile(c.LogFile()))
+	return c.Process.Start()
+}
+
+// Component return component name.
+func (c *TiKVCDC) Component() string {
+	return "tikv-cdc"
+}
+
+// LogFile return the log file.
+func (c *TiKVCDC) LogFile() string {
+	return filepath.Join(c.Dir, "tikv_cdc.log")
+}

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -60,6 +60,7 @@ type BootOptions struct {
 	TiKV    instance.Config `yaml:"tikv"`
 	TiFlash instance.Config `yaml:"tiflash"`
 	TiCDC   instance.Config `yaml:"ticdc"`
+	TiKVCDC instance.Config `yaml:"tikv_cdc"`
 	Pump    instance.Config `yaml:"pump"`
 	Drainer instance.Config `yaml:"drainer"`
 	Host    string          `yaml:"host"`
@@ -89,6 +90,7 @@ const (
 	pd      = "pd"
 	tiflash = "tiflash"
 	ticdc   = "ticdc"
+	kvcdc   = "kvcdc"
 	pump    = "pump"
 	drainer = "drainer"
 
@@ -109,6 +111,7 @@ const (
 	pdConfig      = "pd.config"
 	tiflashConfig = "tiflash.config"
 	ticdcConfig   = "ticdc.config"
+	kvcdcConfig   = "kvcdc.config"
 	pumpConfig    = "pump.config"
 	drainerConfig = "drainer.config"
 
@@ -118,8 +121,12 @@ const (
 	pdBinpath      = "pd.binpath"
 	tiflashBinpath = "tiflash.binpath"
 	ticdcBinpath   = "ticdc.binpath"
+	kvcdcBinpath   = "kvcdc.binpath"
 	pumpBinpath    = "pump.binpath"
 	drainerBinpath = "drainer.binpath"
+
+	// component version
+	kvcdcVersion = "kvcdc.version"
 )
 
 func installIfMissing(component, version string) error {
@@ -319,6 +326,7 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 	rootCmd.Flags().Int(pd, defaultOptions.PD.Num, "PD instance number")
 	rootCmd.Flags().Int(tiflash, defaultOptions.TiFlash.Num, "TiFlash instance number")
 	rootCmd.Flags().Int(ticdc, defaultOptions.TiCDC.Num, "TiCDC instance number")
+	rootCmd.Flags().Int(kvcdc, defaultOptions.TiKVCDC.Num, "TiKV-CDC instance number")
 	rootCmd.Flags().Int(pump, defaultOptions.Pump.Num, "Pump instance number")
 	rootCmd.Flags().Int(drainer, defaultOptions.Drainer.Num, "Drainer instance number")
 
@@ -338,14 +346,18 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 	rootCmd.Flags().String(pumpConfig, defaultOptions.Pump.ConfigPath, "Pump instance configuration file")
 	rootCmd.Flags().String(drainerConfig, defaultOptions.Drainer.ConfigPath, "Drainer instance configuration file")
 	rootCmd.Flags().String(ticdcConfig, defaultOptions.TiCDC.ConfigPath, "TiCDC instance configuration file")
+	rootCmd.Flags().String(kvcdcConfig, defaultOptions.TiKVCDC.ConfigPath, "TiKV-CDC instance configuration file")
 
 	rootCmd.Flags().String(dbBinpath, defaultOptions.TiDB.BinPath, "TiDB instance binary path")
 	rootCmd.Flags().String(kvBinpath, defaultOptions.TiKV.BinPath, "TiKV instance binary path")
 	rootCmd.Flags().String(pdBinpath, defaultOptions.PD.BinPath, "PD instance binary path")
 	rootCmd.Flags().String(tiflashBinpath, defaultOptions.TiFlash.BinPath, "TiFlash instance binary path")
 	rootCmd.Flags().String(ticdcBinpath, defaultOptions.TiCDC.BinPath, "TiCDC instance binary path")
+	rootCmd.Flags().String(kvcdcBinpath, defaultOptions.TiKVCDC.BinPath, "TiKV-CDC instance binary path")
 	rootCmd.Flags().String(pumpBinpath, defaultOptions.Pump.BinPath, "Pump instance binary path")
 	rootCmd.Flags().String(drainerBinpath, defaultOptions.Drainer.BinPath, "Drainer instance binary path")
+
+	rootCmd.Flags().String(kvcdcVersion, defaultOptions.TiKVCDC.Version, "TiKV-CDC instance version")
 
 	rootCmd.AddCommand(newDisplay())
 	rootCmd.AddCommand(newScaleOut())
@@ -418,6 +430,11 @@ func populateOpt(flagSet *pflag.FlagSet) (err error) {
 			if err != nil {
 				return
 			}
+		case kvcdc:
+			options.TiKVCDC.Num, err = strconv.Atoi(flag.Value.String())
+			if err != nil {
+				return
+			}
 		case pump:
 			options.Pump.Num, err = strconv.Atoi(flag.Value.String())
 			if err != nil {
@@ -439,6 +456,8 @@ func populateOpt(flagSet *pflag.FlagSet) (err error) {
 			options.TiFlash.ConfigPath = flag.Value.String()
 		case ticdcConfig:
 			options.TiCDC.ConfigPath = flag.Value.String()
+		case kvcdcConfig:
+			options.TiKVCDC.ConfigPath = flag.Value.String()
 		case pumpConfig:
 			options.Pump.ConfigPath = flag.Value.String()
 		case drainerConfig:
@@ -454,6 +473,8 @@ func populateOpt(flagSet *pflag.FlagSet) (err error) {
 			options.TiFlash.BinPath = flag.Value.String()
 		case ticdcBinpath:
 			options.TiCDC.BinPath = flag.Value.String()
+		case kvcdcBinpath:
+			options.TiKVCDC.BinPath = flag.Value.String()
 		case pumpBinpath:
 			options.Pump.BinPath = flag.Value.String()
 		case drainerBinpath:
@@ -486,6 +507,9 @@ func populateOpt(flagSet *pflag.FlagSet) (err error) {
 			if err != nil {
 				return
 			}
+
+		case kvcdcVersion:
+			options.TiKVCDC.Version = flag.Value.String()
 		}
 	})
 

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -428,8 +428,8 @@ func (p *Playground) sanitizeComponentConfig(cid string, cfg *instance.Config) e
 }
 
 func (p *Playground) startInstance(ctx context.Context, inst instance.Instance) error {
-	versionOption := p.bindVersion(inst.Component(), p.bootOptions.Version)
-	version, err := environment.GlobalEnv().V1Repository().ResolveComponentVersion(inst.Component(), versionOption)
+	boundVersion := p.bindVersion(inst.Component(), p.bootOptions.Version)
+	version, err := environment.GlobalEnv().V1Repository().ResolveComponentVersion(inst.Component(), boundVersion)
 	if err != nil {
 		return err
 	}
@@ -688,7 +688,7 @@ func (p *Playground) addInstance(componentID string, cfg instance.Config) (ins i
 		ins = inst
 		p.ticdcs = append(p.ticdcs, inst)
 	case spec.ComponentTiKVCDC:
-		inst := instance.NewTiKVCDC(utils.Version(cfg.Version), cfg.BinPath, dir, host, cfg.ConfigPath, id, p.pds)
+		inst := instance.NewTiKVCDC(cfg.BinPath, dir, host, cfg.ConfigPath, id, p.pds)
 		ins = inst
 		p.tikv_cdcs = append(p.tikv_cdcs, inst)
 	case spec.ComponentPump:

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -64,6 +64,7 @@ type Playground struct {
 	tidbs            []*instance.TiDBInstance
 	tiflashs         []*instance.TiFlashInstance
 	ticdcs           []*instance.TiCDC
+	tikv_cdcs        []*instance.TiKVCDC
 	pumps            []*instance.Pump
 	drainers         []*instance.Drainer
 	startedInstances []instance.Instance
@@ -309,6 +310,12 @@ func (p *Playground) handleScaleIn(w io.Writer, pid int) error {
 				p.ticdcs = append(p.ticdcs[:i], p.ticdcs[i+1:]...)
 			}
 		}
+	case spec.ComponentTiKVCDC:
+		for i := 0; i < len(p.tikv_cdcs); i++ {
+			if p.tikv_cdcs[i].Pid() == pid {
+				p.tikv_cdcs = append(p.tikv_cdcs[:i], p.tikv_cdcs[i+1:]...)
+			}
+		}
 	case spec.ComponentTiFlash:
 		for i := 0; i < len(p.tiflashs); i++ {
 			if p.tiflashs[i].Pid() == pid {
@@ -409,6 +416,8 @@ func (p *Playground) sanitizeComponentConfig(cid string, cfg *instance.Config) e
 		return p.sanitizeConfig(p.bootOptions.TiFlash, cfg)
 	case spec.ComponentCDC:
 		return p.sanitizeConfig(p.bootOptions.TiCDC, cfg)
+	case spec.ComponentTiKVCDC:
+		return p.sanitizeConfig(p.bootOptions.TiKVCDC, cfg)
 	case spec.ComponentPump:
 		return p.sanitizeConfig(p.bootOptions.Pump, cfg)
 	case spec.ComponentDrainer:
@@ -419,7 +428,8 @@ func (p *Playground) sanitizeComponentConfig(cid string, cfg *instance.Config) e
 }
 
 func (p *Playground) startInstance(ctx context.Context, inst instance.Instance) error {
-	version, err := environment.GlobalEnv().V1Repository().ResolveComponentVersion(inst.Component(), p.bootOptions.Version)
+	versionOption := p.bindVersion(inst.Component(), p.bootOptions.Version)
+	version, err := environment.GlobalEnv().V1Repository().ResolveComponentVersion(inst.Component(), versionOption)
 	if err != nil {
 		return err
 	}
@@ -593,6 +603,13 @@ func (p *Playground) WalkInstances(fn func(componentID string, ins instance.Inst
 		}
 	}
 
+	for _, ins := range p.tikv_cdcs {
+		err := fn(spec.ComponentTiKVCDC, ins)
+		if err != nil {
+			return err
+		}
+	}
+
 	for _, ins := range p.drainers {
 		err := fn(spec.ComponentDrainer, ins)
 		if err != nil {
@@ -670,6 +687,10 @@ func (p *Playground) addInstance(componentID string, cfg instance.Config) (ins i
 		inst := instance.NewTiCDC(cfg.BinPath, dir, host, cfg.ConfigPath, id, p.pds)
 		ins = inst
 		p.ticdcs = append(p.ticdcs, inst)
+	case spec.ComponentTiKVCDC:
+		inst := instance.NewTiKVCDC(utils.Version(cfg.Version), cfg.BinPath, dir, host, cfg.ConfigPath, id, p.pds)
+		ins = inst
+		p.tikv_cdcs = append(p.tikv_cdcs, inst)
 	case spec.ComponentPump:
 		inst := instance.NewPump(cfg.BinPath, dir, host, cfg.ConfigPath, id, p.pds)
 		ins = inst
@@ -765,6 +786,15 @@ func (p *Playground) waitAllTiFlashUp() {
 	}
 }
 
+func (p *Playground) bindVersion(comp string, version string) (bindVersion string) {
+	switch comp {
+	case spec.ComponentTiKVCDC:
+		return p.bootOptions.TiKVCDC.Version
+	default:
+		return version
+	}
+}
+
 func (p *Playground) bootCluster(ctx context.Context, env *environment.Environment, options *BootOptions) error {
 	for _, cfg := range []*instance.Config{
 		&options.PD,
@@ -773,6 +803,7 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		&options.TiFlash,
 		&options.Pump,
 		&options.Drainer,
+		&options.TiKVCDC,
 	} {
 		path, err := getAbsolutePath(cfg.ConfigPath)
 		if err != nil {
@@ -807,6 +838,7 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		{spec.ComponentPump, options.Pump},
 		{spec.ComponentTiDB, options.TiDB},
 		{spec.ComponentCDC, options.TiCDC},
+		{spec.ComponentTiKVCDC, options.TiKVCDC},
 		{spec.ComponentDrainer, options.Drainer},
 		{spec.ComponentTiFlash, options.TiFlash},
 	}
@@ -997,6 +1029,11 @@ func (p *Playground) terminate(sig syscall.Signal) {
 		}
 	}
 	for _, inst := range p.ticdcs {
+		if inst.Process != nil {
+			kill(inst.Component(), inst.Pid(), inst.Wait)
+		}
+	}
+	for _, inst := range p.tikv_cdcs {
 		if inst.Process != nil {
 			kill(inst.Component(), inst.Pid(), inst.Wait)
 		}

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -44,6 +44,7 @@ const (
 	ComponentDrainer          = "drainer"
 	ComponentPump             = "pump"
 	ComponentCDC              = "cdc"
+	ComponentTiKVCDC          = "tikv-cdc"
 	ComponentTiSpark          = "tispark"
 	ComponentSpark            = "spark"
 	ComponentAlertmanager     = "alertmanager"

--- a/tests/tiup-playground/test_kvcdc.sh
+++ b/tests/tiup-playground/test_kvcdc.sh
@@ -4,7 +4,9 @@ set -eux
 
 TEST_DIR=$(cd "$(dirname "$0")"; pwd)
 TMP_DIR=$TEST_DIR/_tmp
-VERSION="v6.2.0"
+
+TIDB_VERSION="v6.2.0"
+KVCDC_VERSION="v1.0.0-alpha"
 MIRROR="http://staging.tiup-server.pingcap.net" # TODO: move to release mirror after TiKV-CDC is released.
 
 
@@ -60,7 +62,7 @@ function kill_all() {
 outfile=/tmp/tiup-playground-test.out
 tiup mirror set $MIRROR
 # no tiflash to speed up
-tiup-playground $VERSION --db 1 --pd 1 --kv 1 --kvcdc 1 --tiflash 0 > $outfile 2>&1 &
+tiup-playground $TIDB_VERSION --db 1 --pd 1 --kv 1 --tiflash 0 --kvcdc 1 --kvcdc.version $KVCDC_VERSION > $outfile 2>&1 &
 
 # wait $outfile generated
 sleep 3

--- a/tests/tiup-playground/test_kvcdc.sh
+++ b/tests/tiup-playground/test_kvcdc.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -eux
+
+TEST_DIR=$(cd "$(dirname "$0")"; pwd)
+TMP_DIR=$TEST_DIR/_tmp
+VERSION="v6.2.0"
+MIRROR="http://staging.tiup-server.pingcap.net" # TODO: move to release mirror after TiKV-CDC is released.
+
+
+# Profile home directory
+mkdir -p $TMP_DIR/home/bin/
+export TIUP_HOME=$TMP_DIR/home
+curl $MIRROR/root.json -o $TMP_DIR/home/bin/root.json
+
+# Prepare data directory
+rm -rf $TIUP_HOME/data
+mkdir -p $TIUP_HOME/data
+export TIUP_INSTANCE_DATA_DIR=$TIUP_HOME/data/test_play
+mkdir -p $TIUP_INSTANCE_DATA_DIR
+
+mkdir -p $TEST_DIR/cover
+
+function tiup-playground() {
+    # echo "in function"
+    if [ -f "$TEST_DIR/bin/tiup-playground.test" ]; then
+        $TEST_DIR/bin/tiup-playground.test -test.coverprofile=$TEST_DIR/cover/cov.itest-$(date +'%s')-$RANDOM.out __DEVEL--i-heard-you-like-tests "$@"
+    else
+        $TEST_DIR/../../bin/tiup-playground "$@"
+    fi
+}
+
+function tiup() {
+    $TEST_DIR/../../bin/tiup "$@"
+}
+
+# usage: check_tidb_num 1
+# make sure the TiKV-CDC number is 1 or other specified number
+function check_kvcdc_num() {
+    mustbe=$1
+    num=$(tiup-playground display | grep "tikv-cdc" | wc -l | sed 's/ //g')
+    if [ "$num" != "$mustbe" ]; then
+        echo "unexpected tikv-cdc instance number: $num"
+        tiup-playground display
+    fi
+}
+
+function kill_all() {
+    killall -9 tidb-server || true
+    killall -9 tikv-server || true
+    killall -9 pd-server || true
+    killall -9 tiflash || true
+    killall -9 grafana-server || true
+    killall -9 tiup-playground || true
+    killall -9 prometheus || true
+    killall -9 ng-monitoring-server || true
+    cat $outfile
+}
+
+outfile=/tmp/tiup-playground-test.out
+tiup mirror set $MIRROR
+# no tiflash to speed up
+tiup-playground $VERSION --db 1 --pd 1 --kv 1 --kvcdc 1 --tiflash 0 > $outfile 2>&1 &
+
+# wait $outfile generated
+sleep 3
+
+trap "kill_all" EXIT
+
+# wait start cluster successfully
+timeout 300 grep -q "CLUSTER START SUCCESSFULLY" <(tail -f $outfile)
+
+tiup-playground display | grep -qv "exit"
+tiup-playground scale-out --kvcdc 2
+sleep 5
+
+# 1(init) + 2(scale-out)
+check_kvcdc_num 3
+
+# get pid of one tikv-cdc instance and scale-in
+pid=`tiup-playground display | grep "tikv-cdc" | awk 'NR==1 {print $1}'`
+tiup-playground scale-in --pid $pid
+
+sleep 5
+check_kvcdc_num 2
+
+# exit
+killall -2 tiup-playground.test || killall -2 tiup-playground
+sleep 30
+
+echo -e "\033[0;36m<<< Run all test success >>>\033[0m"


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1999: playground: Support component [TiKV-CDC](https://github.com/tikv/migration/tree/main/cdc).

### What is changed and how it works?
Add codes to deal with deploy, scale-in and scale-out of the TiKV-CDC component.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

deploy:
```
❯ bin/tiup-playground v6.2.0 --kvcdc 3 --kvcdc.version=v1.0.0-alpha --db 1 --kv 1 --pd 1 --tiflash 0 --tag clst30 --pd.port 20000
Playground Bootstrapping...
Start pd instance:v6.2.0
Start tikv instance:v6.2.0
Start tidb instance:v6.2.0
Start tikv-cdc instance:v1.0.0-alpha
Start tikv-cdc instance:v1.0.0-alpha
Start tikv-cdc instance:v1.0.0-alpha
Waiting for tidb instances ready
127.0.0.1:38211 ... Done
CLUSTER START SUCCESSFULLY, Enjoy it ^-^
To connect TiDB: mysql --comments --host 127.0.0.1 --port 38211 -u root -p (no password)
To view the dashboard: http://127.0.0.1:20000/dashboard
PD client endpoints: [127.0.0.1:20000]
To view the Prometheus: http://127.0.0.1:34991
To view the Grafana: http://127.0.0.1:39987
❯ 
❯ ^CPlayground receive signal:  interrupt
Wait prometheus(2794768) to quit...
Wait ng-monitoring(2794769) to quit...
Wait grafana(2794849) to quit...
Wait tikv-cdc(2793600) to quit...
Grafana quit
tikv-cdc quit
Wait tikv-cdc(2793601) to quit...
tikv-cdc quit
Wait tikv-cdc(2793611) to quit...
ng-monitoring quit
tikv-cdc quit
Wait tidb(2793599) to quit...
prometheus quit
tidb quit
Wait tikv(2793546) to quit...
tikv quit
Wait pd(2793509) to quit...
pd quit
```

`display`, `scale-in` and `scale-out`:
```
❯ bin/tiup-playground display --tag clst30
Pid      Role      Uptime
---      ----      ------
2670157  pd        29.357248287s
2670173  tikv      29.175895857s
2670180  tidb      29.012693018s
2670233  tikv-cdc  28.543214701s
❯ bin/tiup-playground scale-out --kvcdc 1 --tag clst30
❯ bin/tiup-playground display --tag clst30
Pid      Role      Uptime
---      ----      ------
2670157  pd        59.749018137s
2670173  tikv      59.567665054s
2670180  tidb      59.40447222s
2670233  tikv-cdc  58.934982488s
2672113  tikv-cdc  8.167426031s
❯ bin/tiup-playground scale-in --pid 2670233 --tag clst30
scale in tikv-cdc success
❯ bin/tiup-playground display --tag clst30
Pid      Role      Uptime
---      ----      ------
2670157  pd        1m22.054549013s
2670173  tikv      1m21.873198096s
2670180  tidb      1m21.709997698s
2672113  tikv-cdc  30.472933521s
❯ bin/tiup-playground scale-out --kvcdc 3 --tag clst30
❯ bin/tiup-playground display --tag clst30
Pid      Role      Uptime
---      ----      ------
2670157  pd        1m37.248401925s
2670173  tikv      1m37.067054776s
2670180  tidb      1m36.90385724s
2672113  tikv-cdc  45.666796244s
2672879  tikv-cdc  6.28220083s
2672884  tikv-cdc  6.276836013s
2672889  tikv-cdc  6.271211554s
```

Code changes

 - Has exported variable/fields change

Add `Version` to `instance.Config`, to keep version of TiKV-CDC that can be specified by command line argument.
```
// Config of the instance.
type Config struct {
	ConfigPath string `yaml:"config_path"`
	BinPath    string `yaml:"bin_path"`
	Num        int    `yaml:"num"`
	Host       string `yaml:"host"`
	Port       int    `yaml:"port"`
	UpTimeout  int    `yaml:"up_timeout"`
	Version    string `yaml:"version"`
}
```
 - Has command line arguments added
```
      --kvcdc int                TiKV-CDC instance number
      --kvcdc.binpath string     TiKV-CDC instance binary path
      --kvcdc.config string      TiKV-CDC instance configuration file
      --kvcdc.version string     TiKV-CDC instance version
```


Side effects

 - No.

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Playground supports the TiKV-CDC component.
```
