### PR TITLE
cluster/api: sync pdapi & typeutil with pd 6.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c
 	github.com/pingcap/fn v1.0.0
-	github.com/pingcap/kvproto v0.0.0-20220525022339-6aaebf466305
+	github.com/pingcap/kvproto v0.0.0-20220913050750-f6d05706948a
 	github.com/pingcap/tidb-insight/collector v0.0.0-20220902034607-fb5ae0ddc8c1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -394,8 +394,8 @@ github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c h1:CgbKAHto5CQgW
 github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
 github.com/pingcap/fn v1.0.0 h1:CyA6AxcOZkQh52wIqYlAmaVmF6EvrcqFywP463pjA8g=
 github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z24=
-github.com/pingcap/kvproto v0.0.0-20220525022339-6aaebf466305 h1:TZ0teMZoKHnZDlJxNkWrp5Sgv3w+ruNbrqtBYKsfaNw=
-github.com/pingcap/kvproto v0.0.0-20220525022339-6aaebf466305/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
+github.com/pingcap/kvproto v0.0.0-20220913050750-f6d05706948a h1:LCtkOPEzjWk86NclzxdZ42nNtbhuIN1p6cpd/FYUqkU=
+github.com/pingcap/kvproto v0.0.0-20220913050750-f6d05706948a/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v1.1.0 h1:ELiPxACz7vdo1qAvvaWJg1NrYFoY6gqAh/+Uo6aXdD8=

--- a/pkg/cluster/api/typeutil/size.go
+++ b/pkg/cluster/api/typeutil/size.go
@@ -24,6 +24,16 @@ import (
 // ByteSize is a retype uint64 for TOML and JSON.
 type ByteSize uint64
 
+// ParseMBFromText parses MB from text.
+func ParseMBFromText(text string, value uint64) uint64 {
+	b := ByteSize(0)
+	err := b.UnmarshalText([]byte(text))
+	if err != nil {
+		return value
+	}
+	return uint64(b / units.MiB)
+}
+
 // MarshalJSON returns the size as a JSON string.
 func (b ByteSize) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + units.BytesSize(float64(b)) + `"`), nil

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -242,7 +242,7 @@ func (m *Manager) Display(dopt DisplayOption, opt operator.Options) error {
 	if m.logger.GetDisplayMode() == logprinter.DisplayModeJSON {
 		grafanaURLs := getGrafanaURL(clusterInstInfos)
 		if len(grafanaURLs) != 0 {
-			j.ClusterMetaInfo.GrafanaURLS = grafanaURLs		
+			j.ClusterMetaInfo.GrafanaURLS = grafanaURLs
 		}
 	} else {
 		urls, exist := getGrafanaURLStr(clusterInstInfos)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Sync latest version of PD types and `typeutil` from `tikv/pd`.

The code we use in `pkg/cluster/api` is ported from PD (to avoid direct dependency) and is a little bit outdated. 

I've kept the upstream-removed `ApplyingSnapCount` field in our port and added an `omitempty` to the newly added field `SlowScore` in `StoreStatus` so there should be no compatibility issue with legacy PD releases.

This change should have no effect to end user.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
