### PR TITLE
tiflash: check instance cpu flags when deploy | scale-out | upgrade

### DIFF
--- a/components/dm/command/upgrade.go
+++ b/components/dm/command/upgrade.go
@@ -14,12 +14,18 @@
 package command
 
 import (
+	"path/filepath"
+
+	"github.com/pingcap/tiup/pkg/cluster/manager"
+	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
 func newUpgradeCmd() *cobra.Command {
 	offlineMode := false
-
+	opt := manager.DeployOptions{
+		IdentityFile: filepath.Join(utils.UserHome(), ".ssh", "id_rsa"),
+	}
 	cmd := &cobra.Command{
 		Use:   "upgrade <cluster-name> <version>",
 		Short: "Upgrade a specified DM cluster",
@@ -28,7 +34,7 @@ func newUpgradeCmd() *cobra.Command {
 				return cmd.Help()
 			}
 
-			return cm.Upgrade(args[0], args[1], gOpt, skipConfirm, offlineMode)
+			return cm.Upgrade(args[0], args[1], gOpt, skipConfirm, offlineMode, opt)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			switch len(args) {
@@ -40,6 +46,9 @@ func newUpgradeCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVarP(&opt.User, "user", "u", utils.CurrentUser(), "The user name to login via SSH. The user must has root (or sudo) privilege.")
+	cmd.Flags().StringVarP(&opt.IdentityFile, "identity_file", "i", opt.IdentityFile, "The path of the SSH identity file. If specified, public key authentication will be used.")
+	cmd.Flags().BoolVarP(&opt.UsePassword, "password", "p", false, "Use password of target hosts. If specified, password authentication will be used.")
 	cmd.Flags().BoolVarP(&offlineMode, "offline", "", false, "Upgrade a stopped cluster")
 
 	return cmd

--- a/components/dm/spec/topology_dm.go
+++ b/components/dm/spec/topology_dm.go
@@ -817,7 +817,7 @@ func setDMCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) erro
 			if field.Field(j).String() != "" {
 				field.Field(j).Set(reflect.ValueOf(strings.ToLower(field.Field(j).String())))
 			}
-		case "OS":
+		case "OS", "CPUFlags":
 			// convert to lower case
 			if field.Field(j).String() != "" {
 				field.Field(j).Set(reflect.ValueOf(strings.ToLower(field.Field(j).String())))

--- a/embed/templates/scripts/run_tiflash.sh.tpl
+++ b/embed/templates/scripts/run_tiflash.sh.tpl
@@ -10,25 +10,6 @@ export RUST_BACKTRACE=1
 export TZ=${TZ:-/etc/localtime}
 export LD_LIBRARY_PATH={{.DeployDir}}/bin/tiflash:$LD_LIBRARY_PATH
 
-{{- if .RequiredCPUFlags }}
-if [ -f "/proc/cpuinfo" ]; then
-    IFS_OLD=$IFS
-    IFS=' '
-    required_cpu_flags="{{.RequiredCPUFlags}}"
-    for flag in $(echo $required_cpu_flags); do
-        if grep -q ${flag} /proc/cpuinfo; then
-            true
-        else
-            err_msg="Fail to check CPU flags: \`${flag}\` not supported. Require \`${required_cpu_flags}\`."
-            echo ${err_msg}
-            echo ${err_msg} >>"{{.LogDir}}/tiflash_stderr.log"
-            exit -1
-        fi
-    done
-    IFS=$IFS_OLD
-fi
-{{- end}}
-
 echo -n 'sync ... '
 stat=$(time sync)
 echo ok

--- a/pkg/cluster/manager/basic.go
+++ b/pkg/cluster/manager/basic.go
@@ -308,7 +308,7 @@ func checkTiFlashWithTLS(topo spec.Topology, version string) error {
 
 // checkTiFlashCPUFlags check tiflash required CPU flags
 func checkTiFlashCPUFlags(topo spec.Topology, version string) error {
-	var err error = nil
+	var err error
 	if tidbver.TiFlashRequireCPUFlagAVX2(version) {
 		topo.IterInstance(func(inst spec.Instance) {
 			if spec.ComponentTiFlash == inst.ComponentName() && inst.Arch() == "amd64" && inst.OS() == "linux" {

--- a/pkg/cluster/manager/basic.go
+++ b/pkg/cluster/manager/basic.go
@@ -313,7 +313,7 @@ func checkTiFlashCPUFlags(topo spec.Topology, version string) error {
 		topo.IterInstance(func(inst spec.Instance) {
 			if spec.ComponentTiFlash == inst.ComponentName() && inst.Arch() == "amd64" && inst.OS() == "linux" {
 				if strings.Index(inst.CPUFlags(), "avx2") == -1 {
-					err = fmt.Errorf("Fail to check CPU flags in host `%s`. TiFlash requires `avx2` under `x86-64` platform since `v6.3.0`.", inst.GetHost())
+					err = fmt.Errorf("Fail to check CPU flags in host `%s`. TiFlash requires `avx2` under `x86-64` platform since `v6.3.0`. ", inst.GetHost())
 				}
 			}
 		})

--- a/pkg/cluster/manager/basic.go
+++ b/pkg/cluster/manager/basic.go
@@ -313,7 +313,7 @@ func checkTiFlashCPUFlags(topo spec.Topology, version string) error {
 		topo.IterInstance(func(inst spec.Instance) {
 			if spec.ComponentTiFlash == inst.ComponentName() && inst.Arch() == "amd64" && inst.OS() == "linux" {
 				if strings.Index(inst.CPUFlags(), "avx2") == -1 {
-					err = fmt.Errorf("Fail to check CPU flags in host `%s`. TiFlash requires `avx2` since `v6.3.0`.", inst.GetHost())
+					err = fmt.Errorf("Fail to check CPU flags in host `%s`. TiFlash requires `avx2` under `x86-64` platform since `v6.3.0`.", inst.GetHost())
 				}
 			}
 		})

--- a/pkg/cluster/manager/basic.go
+++ b/pkg/cluster/manager/basic.go
@@ -306,6 +306,21 @@ func checkTiFlashWithTLS(topo spec.Topology, version string) error {
 	return nil
 }
 
+// checkTiFlashCPUFlags check tiflash required CPU flags
+func checkTiFlashCPUFlags(topo spec.Topology, version string) error {
+	var err error = nil
+	if tidbver.TiFlashRequireCPUFlagAVX2(version) {
+		topo.IterInstance(func(inst spec.Instance) {
+			if spec.ComponentTiFlash == inst.ComponentName() && inst.Arch() == "amd64" && inst.OS() == "linux" {
+				if strings.Index(inst.CPUFlags(), "avx2") == -1 {
+					err = fmt.Errorf("Fail to check CPU flags in host `%s`. TiFlash requires `avx2` since `v6.3.0`.", inst.GetHost())
+				}
+			}
+		})
+	}
+	return err
+}
+
 // BackupClusterMeta backup cluster meta to given filepath
 func (m *Manager) BackupClusterMeta(clusterName, filePath string) error {
 	exist, err := m.specManager.Exist(clusterName)

--- a/pkg/cluster/manager/basic.go
+++ b/pkg/cluster/manager/basic.go
@@ -312,7 +312,7 @@ func checkTiFlashCPUFlags(topo spec.Topology, version string) error {
 	if tidbver.TiFlashRequireCPUFlagAVX2(version) {
 		topo.IterInstance(func(inst spec.Instance) {
 			if spec.ComponentTiFlash == inst.ComponentName() && inst.Arch() == "amd64" && inst.OS() == "linux" {
-				if strings.Index(inst.CPUFlags(), "avx2") == -1 {
+				if !strings.Contains(inst.CPUFlags(), "avx2") {
 					err = fmt.Errorf("Fail to check CPU flags in host `%s`. TiFlash requires `avx2` under `x86-64` platform since `v6.3.0`. ", inst.GetHost())
 				}
 			}

--- a/pkg/cluster/manager/deploy.go
+++ b/pkg/cluster/manager/deploy.go
@@ -153,6 +153,10 @@ func (m *Manager) Deploy(
 		return err
 	}
 
+	if err := checkTiFlashCPUFlags(topo, clusterVersion); err != nil {
+		return err
+	}
+
 	if !skipConfirm && strings.ToLower(gOpt.DisplayMode) != "json" {
 		if err := m.confirmTopology(name, clusterVersion, topo, set.NewStringSet()); err != nil {
 			return err

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -231,7 +231,7 @@ func (m *Manager) fillHostArchOrOS(s, p *tui.SSHConnectionProps, topo spec.Topol
 		case spec.FullOSType:
 			tf = tf.Shell(inst.GetHost(), "uname -s", "", false)
 		case spec.FullCPUFlagsType:
-			tf = tf.Shell(inst.GetHost(), "cat /proc/cpuinfo 2>&1 | grep flags | head -n 1 || echo", "", false)
+			tf = tf.Shell(inst.GetHost(), "command -v lscpu >/dev/null 2>&1 && lscpu || true", "", false)
 		default:
 			tf = tf.Shell(inst.GetHost(), "uname -m", "", false)
 		}
@@ -261,7 +261,7 @@ func (m *Manager) fillHostArchOrOS(s, p *tui.SSHConnectionProps, topo spec.Topol
 		}
 		if fullType == spec.FullCPUFlagsType {
 			cpuFlags := strings.Trim(string(stdout), "\n")
-			flags := strings.Split(cpuFlags, ":")
+			flags := strings.Split(cpuFlags, "Flags:")
 			if len(flags) != 2 {
 				cpuFlags = ""
 			} else {

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -186,16 +186,19 @@ func (m *Manager) fillHostArchOrOS(s, p *tui.SSHConnectionProps, topo spec.Topol
 	var detectTasks []*task.StepDisplay
 
 	topo.IterInstance(func(inst spec.Instance) {
-		if fullType == spec.FullOSType {
+		switch fullType {
+		case spec.FullOSType:
 			if inst.OS() != "" {
 				return
 			}
-		} else if fullType == spec.FullCPUFlagsType {
+		case spec.FullCPUFlagsType:
 			if inst.CPUFlags() != "" {
 				return
 			}
-		} else if inst.Arch() != "" {
-			return
+		default:
+			if inst.Arch() != "" {
+				return
+			}
 		}
 
 		if _, ok := hostArchOrOS[inst.GetHost()]; ok {

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -257,14 +257,14 @@ func (m *Manager) fillHostArchOrOS(s, p *tui.SSHConnectionProps, topo spec.Topol
 			return fmt.Errorf("no check results found for %s", host)
 		}
 		if fullType == spec.FullCPUFlagsType {
-			cpu_flags := strings.Trim(string(stdout), "\n")
-			flags := strings.Split(cpu_flags, ":")
+			cpuFlags := strings.Trim(string(stdout), "\n")
+			flags := strings.Split(cpuFlags, ":")
 			if len(flags) != 2 {
-				cpu_flags = "unknown"
+				cpuFlags = "unknown"
 			} else {
-				cpu_flags = strings.Trim(flags[1], " ")
+				cpuFlags = strings.Trim(flags[1], " ")
 			}
-			hostArchOrOS[host] = cpu_flags
+			hostArchOrOS[host] = cpuFlags
 		} else {
 			hostArchOrOS[host] = strings.Trim(string(stdout), "\n")
 		}

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -263,7 +263,7 @@ func (m *Manager) fillHostArchOrOS(s, p *tui.SSHConnectionProps, topo spec.Topol
 			cpuFlags := strings.Trim(string(stdout), "\n")
 			flags := strings.Split(cpuFlags, ":")
 			if len(flags) != 2 {
-				cpuFlags = "unknown"
+				cpuFlags = ""
 			} else {
 				cpuFlags = strings.Trim(flags[1], " ")
 			}

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -124,6 +124,9 @@ func (m *Manager) ScaleOut(
 	if err := m.fillHost(sshConnProps, sshProxyProps, newPart, &gOpt, opt.User); err != nil {
 		return err
 	}
+	if err := checkTiFlashCPUFlags(newPart, base.Version); err != nil {
+		return err
+	}
 
 	var mergedTopo spec.Topology
 	// in satge2, not need mergedTopo

--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -69,6 +69,10 @@ func (m *Manager) Upgrade(name string, clusterVersion string, opt operator.Optio
 		return err
 	}
 
+	if err := checkTiFlashCPUFlags(topo, clusterVersion); err != nil {
+		return err
+	}
+
 	if !skipConfirm {
 		if err := tui.PromptForConfirmOrAbortError(
 			"This operation will upgrade %s %s cluster %s to %s.\nDo you want to continue? [y/N]:",

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -103,6 +103,7 @@ type Instance interface {
 	LogDir() string
 	OS() string // only linux supported now
 	Arch() string
+	CPUFlags() string // only linux supported now
 	IsPatched() bool
 	SetPatched(bool)
 	setTLSConfig(ctx context.Context, enableTLS bool, configs map[string]any, paths meta.DirPaths) (map[string]any, error)
@@ -395,6 +396,15 @@ func (i *BaseInstance) OS() string {
 // Arch implements Instance interface
 func (i *BaseInstance) Arch() string {
 	v := reflect.Indirect(reflect.ValueOf(i.InstanceSpec)).FieldByName("Arch")
+	if !v.IsValid() {
+		return ""
+	}
+	return v.Interface().(string)
+}
+
+// CPUFlags implements Instance interface
+func (i *BaseInstance) CPUFlags() string {
+	v := reflect.Indirect(reflect.ValueOf(i.InstanceSpec)).FieldByName("CPUFlags")
 	if !v.IsValid() {
 		return ""
 	}

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -911,15 +911,16 @@ func setHostArchOrOS(field reflect.Value, hostArchOrOS map[string]string, fullTy
 	cpuFlags := field.FieldByName("CPUFlags")
 
 	// set arch only if not set before
-	if fullType == FullOSType {
+	switch fullType {
+	case FullOSType:
 		if !host.IsZero() && os.CanSet() && len(os.String()) == 0 {
 			os.Set(reflect.ValueOf(hostArchOrOS[host.String()]))
 		}
-	} else if fullType == FullCPUFlagsType {
+	case FullCPUFlagsType:
 		if !host.IsZero() && cpuFlags.CanSet() && len(cpuFlags.String()) == 0 {
 			cpuFlags.Set(reflect.ValueOf(hostArchOrOS[host.String()]))
 		}
-	} else {
+	default:
 		if !host.IsZero() && arch.CanSet() && len(arch.String()) == 0 {
 			arch.Set(reflect.ValueOf(hostArchOrOS[host.String()]))
 		}

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -908,7 +908,7 @@ func setHostArchOrOS(field reflect.Value, hostArchOrOS map[string]string, fullTy
 	host := field.FieldByName("Host")
 	arch := field.FieldByName("Arch")
 	os := field.FieldByName("OS")
-	cpu_flags := field.FieldByName("CPUFlags")
+	cpuFlags := field.FieldByName("CPUFlags")
 
 	// set arch only if not set before
 	if fullType == FullOSType {
@@ -916,8 +916,8 @@ func setHostArchOrOS(field reflect.Value, hostArchOrOS map[string]string, fullTy
 			os.Set(reflect.ValueOf(hostArchOrOS[host.String()]))
 		}
 	} else if fullType == FullCPUFlagsType {
-		if !host.IsZero() && cpu_flags.CanSet() && len(cpu_flags.String()) == 0 {
-			cpu_flags.Set(reflect.ValueOf(hostArchOrOS[host.String()]))
+		if !host.IsZero() && cpuFlags.CanSet() && len(cpuFlags.String()) == 0 {
+			cpuFlags.Set(reflect.ValueOf(hostArchOrOS[host.String()]))
 		}
 	} else {
 		if !host.IsZero() && arch.CanSet() && len(arch.String()) == 0 {

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -53,6 +53,8 @@ const (
 	FullArchType FullHostType = "Arch"
 	// FullOSType kernel-name
 	FullOSType FullHostType = "OS"
+	// FullCPUFlagsType cpu-flags
+	FullCPUFlagsType FullHostType = "CPUFlags"
 )
 
 // general role names
@@ -657,7 +659,7 @@ func setCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) error 
 			if field.Field(j).String() != "" {
 				field.Field(j).Set(reflect.ValueOf(strings.ToLower(field.Field(j).String())))
 			}
-		case "OS":
+		case "OS", "CPUFlags":
 			// convert to lower case
 			if field.Field(j).String() != "" {
 				field.Field(j).Set(reflect.ValueOf(strings.ToLower(field.Field(j).String())))
@@ -906,11 +908,16 @@ func setHostArchOrOS(field reflect.Value, hostArchOrOS map[string]string, fullTy
 	host := field.FieldByName("Host")
 	arch := field.FieldByName("Arch")
 	os := field.FieldByName("OS")
+	cpu_flags := field.FieldByName("CPUFlags")
 
 	// set arch only if not set before
 	if fullType == FullOSType {
 		if !host.IsZero() && os.CanSet() && len(os.String()) == 0 {
 			os.Set(reflect.ValueOf(hostArchOrOS[host.String()]))
+		}
+	} else if fullType == FullCPUFlagsType {
+		if !host.IsZero() && cpu_flags.CanSet() && len(cpu_flags.String()) == 0 {
+			cpu_flags.Set(reflect.ValueOf(hostArchOrOS[host.String()]))
 		}
 	} else {
 		if !host.IsZero() && arch.CanSet() && len(arch.String()) == 0 {

--- a/pkg/cluster/spec/spec_test.go
+++ b/pkg/cluster/spec/spec_test.go
@@ -656,20 +656,6 @@ pd_servers:
 	c.Assert(err, NotNil)
 }
 
-func (s *metaSuiteTopo) TestTiFlashRequiredCPUFlags(c *C) {
-	cfg := scripts.NewTiFlashScript("", "", "", "", "", "")
-	cfg.WithRequiredCPUFlags(getTiFlashRequiredCPUFlagsWithVersion("v6.3.0", "AMD64"))
-	c.Assert(cfg.RequiredCPUFlags, Equals, TiFlashRequiredCPUFlags)
-	cfg.WithRequiredCPUFlags(getTiFlashRequiredCPUFlagsWithVersion("v6.3.0", "X86_64"))
-	c.Assert(cfg.RequiredCPUFlags, Equals, TiFlashRequiredCPUFlags)
-	cfg.WithRequiredCPUFlags(getTiFlashRequiredCPUFlagsWithVersion("nightly", "amd64"))
-	c.Assert(cfg.RequiredCPUFlags, Equals, TiFlashRequiredCPUFlags)
-	cfg.WithRequiredCPUFlags(getTiFlashRequiredCPUFlagsWithVersion("v6.3.0", "aarch64"))
-	c.Assert(cfg.RequiredCPUFlags, Equals, "")
-	cfg.WithRequiredCPUFlags(getTiFlashRequiredCPUFlagsWithVersion("v6.2.0", "amd64"))
-	c.Assert(cfg.RequiredCPUFlags, Equals, "")
-}
-
 func (s *metaSuiteTopo) TestTiFlashStorageSection(c *C) {
 	ctx := context.Background()
 	spec := &Specification{}

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -63,6 +63,7 @@ type TiFlashSpec struct {
 	ResourceControl      meta.ResourceControl `yaml:"resource_control,omitempty" validate:"resource_control:editable"`
 	Arch                 string               `yaml:"arch,omitempty"`
 	OS                   string               `yaml:"os,omitempty"`
+	CPUFlags             string               `yaml:"cpu_flags,omitempty"`
 }
 
 // Status queries current status of the instance
@@ -105,7 +106,6 @@ const (
 	TiFlashStorageKeyMainDirs   string = "storage.main.dir"
 	TiFlashStorageKeyLatestDirs string = "storage.latest.dir"
 	TiFlashStorageKeyRaftDirs   string = "storage.raft.dir"
-	TiFlashRequiredCPUFlags     string = "avx2 popcnt movbe"
 )
 
 // GetOverrideDataDir returns the data dir.
@@ -614,17 +614,6 @@ func (i *TiFlashInstance) setTLSConfig(ctx context.Context, enableTLS bool, conf
 	return configs, nil
 }
 
-// getTiFlashRequiredCPUFlagsWithVersion return required CPU flags for TiFlash by given version
-func getTiFlashRequiredCPUFlagsWithVersion(clusterVersion string, arch string) string {
-	arch = strings.ToLower(arch)
-	if arch == "x86_64" || arch == "amd64" {
-		if tidbver.TiFlashRequireCPUFlagAVX2(clusterVersion) {
-			return TiFlashRequiredCPUFlags
-		}
-	}
-	return ""
-}
-
 // InitConfig implement Instance interface
 func (i *TiFlashInstance) InitConfig(
 	ctx context.Context,
@@ -665,7 +654,6 @@ func (i *TiFlashInstance) InitConfig(
 		WithTmpDir(spec.TmpDir).
 		WithNumaNode(spec.NumaNode).
 		WithNumaCores(spec.NumaCores).
-		WithRequiredCPUFlags(getTiFlashRequiredCPUFlagsWithVersion(clusterVersion, spec.Arch)).
 		AppendEndpoints(topo.Endpoints(deployUser)...)
 
 	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_tiflash_%s_%d.sh", i.GetHost(), i.GetPort()))

--- a/pkg/cluster/template/scripts/tiflash.go
+++ b/pkg/cluster/template/scripts/tiflash.go
@@ -42,7 +42,6 @@ type TiFlashScript struct {
 	Endpoints            []*PDScript
 	TiDBStatusAddrs      string
 	PDAddrs              string
-	RequiredCPUFlags     string
 }
 
 // NewTiFlashScript returns a TiFlashScript with given arguments
@@ -117,12 +116,6 @@ func (c *TiFlashScript) WithNumaNode(numa string) *TiFlashScript {
 // WithNumaCores set NumaCores field of TiFlashScript
 func (c *TiFlashScript) WithNumaCores(numaCores string) *TiFlashScript {
 	c.NumaCores = numaCores
-	return c
-}
-
-// WithRequiredCPUFlags set required CPU flags for TiFlashScript
-func (c *TiFlashScript) WithRequiredCPUFlags(requiredCPUFlags string) *TiFlashScript {
-	c.RequiredCPUFlags = requiredCPUFlags
 	return c
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close https://github.com/pingcap/tiflash/issues/6075
rollback #2054

### What is changed and how it works?

- use shell cmd `command -v lscpu >/dev/null 2>&1 && lscpu || true` to get cpu flags
- check cpu flags for tiflash instance when deploy | scale-out | upgrade

```
+ Detect CPU Arch Name
  - Detecting node 172.16.4.42 Arch info ... Done

+ Detect CPU OS Name
  - Detecting node 172.16.4.42 OS info ... Done

+ Detect CPU CPUFlags Name
  - Detecting node 172.16.4.42 CPUFlags info ... Done

Error: Fail to check CPU flags in host `172.16.4.42`. TiFlash requires `avx2` under `x86-64` platform since `v6.3.0`.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - [x] Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
