### PR TITLE
playground: Enable AutoTLS by default

### DIFF
--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -16,6 +16,7 @@ package instance
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -30,12 +31,24 @@ type TiDBInstance struct {
 	pds []*PDInstance
 	Process
 	enableBinlog bool
+	TempConfig   string
 }
 
 // NewTiDBInstance return a TiDBInstance
 func NewTiDBInstance(binPath string, dir, host, configPath string, id, port int, pds []*PDInstance, enableBinlog bool) *TiDBInstance {
+	var tempName string
 	if port <= 0 {
 		port = 4000
+	}
+	if configPath == "" {
+		tempFile, err := os.CreateTemp("", "tidb-playground-config")
+		if err == nil {
+			_, err2 := tempFile.WriteString("[security]\nauto-tls=true\n")
+			if err2 == nil {
+				configPath = tempFile.Name()
+				tempName = configPath
+			}
+		}
 	}
 	return &TiDBInstance{
 		instance: instance{
@@ -49,6 +62,7 @@ func NewTiDBInstance(binPath string, dir, host, configPath string, id, port int,
 		},
 		pds:          pds,
 		enableBinlog: enableBinlog,
+		TempConfig:   tempName,
 	}
 }
 

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1045,6 +1045,9 @@ func (p *Playground) terminate(sig syscall.Signal) {
 	}
 	// tidb must exit earlier then pd
 	for _, inst := range p.tidbs {
+		if inst.TempConfig != "" {
+			os.Remove(inst.TempConfig)
+		}
 		if inst.Process != nil {
 			kill(inst.Component(), inst.Pid(), inst.Wait)
 		}


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

TiDB Playground doesn't enable TLS by default. While TLS isn't needed in most cases to make the playground secure, it can help to detect issues with client code early on that could cause problems later when deployed on TiDB Cloud Serverless (which requires TLS).

### What is changed and how it works?

if there is no config specified, create a temporary config that enables
AutoTLS.

https://docs.pingcap.com/tidb/stable/tidb-configuration-file#auto-tls


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported variable/fields change

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
TiUP Playground enables AutoTLS by default
```
