### PR TITLE
ctl: Set ETCDCTL_API=v3 to get the v3 API

### DIFF
--- a/components/ctl/main.go
+++ b/components/ctl/main.go
@@ -101,6 +101,7 @@ func binaryPath(home, cmd string) (string, error) {
 }
 
 func run(name string, args ...string) error {
+	os.Setenv("ETCDCTL_API", "3")
 	// Handle `cdc cli`
 	if strings.Contains(name, " ") {
 		xs := strings.Split(name, " ")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Ensure `tiup ctl etcd` works with TiDB by default.

Closes #2080

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
