### PR TITLE
merge tiflash config in tiup playground to reduce handwrite config

### DIFF
--- a/components/playground/command.go
+++ b/components/playground/command.go
@@ -109,7 +109,7 @@ func newScaleOut() *cobra.Command {
 	cmd.Flags().StringVarP(&opt.TiDB.ConfigPath, "db.config", "", opt.TiDB.ConfigPath, "TiDB instance configuration file")
 	cmd.Flags().StringVarP(&opt.TiKV.ConfigPath, "kv.config", "", opt.TiKV.ConfigPath, "TiKV instance configuration file")
 	cmd.Flags().StringVarP(&opt.PD.ConfigPath, "pd.config", "", opt.PD.ConfigPath, "PD instance configuration file")
-	cmd.Flags().StringVarP(&opt.TiDB.ConfigPath, "tiflash.config", "", opt.TiDB.ConfigPath, "TiFlash instance configuration file")
+	cmd.Flags().StringVarP(&opt.TiFlash.ConfigPath, "tiflash.config", "", opt.TiFlash.ConfigPath, "TiFlash instance configuration file")
 	cmd.Flags().StringVarP(&opt.Pump.ConfigPath, "pump.config", "", opt.Pump.ConfigPath, "Pump instance configuration file")
 	cmd.Flags().StringVarP(&opt.Drainer.ConfigPath, "drainer.config", "", opt.Drainer.ConfigPath, "Drainer instance configuration file")
 

--- a/components/playground/instance/tiflash_config.go
+++ b/components/playground/instance/tiflash_config.go
@@ -119,7 +119,9 @@ func writeTiFlashConfig(w io.Writer, version utils.Version, tcpPort, httpPort, s
 
 func getTiFlashProxyConfigPath(cfg map[string]any) string {
 	defer func() {
-		recover()
+		if r := recover(); r != nil {
+			return
+		}
 	}()
 	return cfg["flash"].(map[string]any)["proxy"].(map[string]any)["config"].(string)
 }

--- a/components/playground/instance/tiflash_config.go
+++ b/components/playground/instance/tiflash_config.go
@@ -116,3 +116,14 @@ func writeTiFlashConfig(w io.Writer, version utils.Version, tcpPort, httpPort, s
 	_, err := w.Write([]byte(conf))
 	return err
 }
+
+func getTiFlashProxyConfigPath(cfg map[string]any) string {
+	defer func() {
+		recover()
+	}()
+	return cfg["flash"].(map[string]any)["proxy"].(map[string]any)["config"].(string)
+}
+
+func setTiFlashProxyConfigPath(cfg map[string]any, path string) {
+	cfg["flash"].(map[string]any)["proxy"].(map[string]any)["config"] = path
+}

--- a/pkg/cluster/template/scripts/pd.go
+++ b/pkg/cluster/template/scripts/pd.go
@@ -77,7 +77,7 @@ type PDScaleScript struct {
 
 // NewPDScaleScript return a new PDScaleScript
 func NewPDScaleScript(pdScript *PDScript, join string) *PDScaleScript {
-	return &PDScaleScript{PDScript:*pdScript, Join: join}
+	return &PDScaleScript{PDScript: *pdScript, Join: join}
 }
 
 // ConfigToFile write config content to specific path


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This pull request merges the default TiFlash config with the specified TiFlash config to reduce the handwrite config, which might be annoying while dealing with a few heterogeneous tiflash instances. You guy might ask why not use `tiup cluster` instead. The `tiup cluster` run pretty slow than the playground and makes users frustrated while debugging codes.

### What is changed and how it works?

All generated config will write to the instance directory of the TiFlash instance, and if the config path is set, the config of it will be patched to the default config generated by `tiup playground`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
merge tiflash config in tiup playground to reduce handwrite config
```
