### PR TITLE
base52: check for invalid chars in Decode()

### DIFF
--- a/pkg/base52/base52.go
+++ b/pkg/base52/base52.go
@@ -45,7 +45,11 @@ func Decode(encoded string) (int64, error) {
 	}
 	var id int64
 	for i := 0; i < len(encoded); i++ {
-		id = id*int64(base) + int64(strings.IndexByte(space, encoded[i]))
+		idx := strings.IndexByte(space, encoded[i])
+		if idx < 0 {
+			return 0, fmt.Errorf("invalid encoded string: '%s' contains invalid character", encoded)
+		}
+		id = id*int64(base) + int64(idx)
 	}
 	return id, nil
 }

--- a/pkg/base52/base52_test.go
+++ b/pkg/base52/base52_test.go
@@ -33,4 +33,8 @@ func (s *base52Suite) TestDecode(c *C) {
 	decoded, err := Decode("2TPzw7")
 	c.Assert(decoded, Equals, int64(1000000000))
 	c.Assert(err, IsNil)
+
+	decoded, err = Decode("../../etc/passwd")
+	c.Assert(decoded, Equals, int64(0))
+	c.Assert(err, NotNil)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The `Decode()` in `base52` does not check for input value for invalid characters, thus may have security risks.

### What is changed and how it works?
Check for invalid characters and return an error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
