### PR TITLE
clean: Warn for cleanup failures due to missing datadir

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -67,6 +67,8 @@ func cleanData(env *environment.Environment, names []string, all bool) error {
 			return err
 		}
 		if process == nil {
+			fmt.Fprintf(os.Stderr, "Can't clean directory due to missing meta file: %s\n",
+				filepath.Join(dataDir, dir.Name()))
 			continue
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If the `tiup_process_meta` file is missing in a datadir of a tiup playground then `tiup clean` will silently skipp it.

This changes this to show a message in case this happens.

```
$ tiup clean TS9acXe
Can't clean directory due to missing meta file: /home/dvaneeden/.tiup/data/TS9acXe
$ tiup clean --all
Can't clean directory due to missing meta file: /home/dvaneeden/.tiup/data/TS9acXe
Clean instance of `playground`, directory: /home/dvaneeden/.tiup/data/foo
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
The `tiup clean` command now shows a message if it can't cleanup a directory due to a missing `tiup_process_meta` file.
```
