### PR TITLE
display disaggregated mode

### DIFF
--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -601,6 +601,12 @@ func (m *Manager) GetClusterTopology(dopt DisplayOption, opt operator.Options) (
 
 		// check if the role is patched
 		roleName := ins.Role()
+		// get extended name for TiFlash to distinguish disaggregated mode.
+		if ins.ComponentName() == spec.ComponentTiFlash {
+			tiflashInstance := ins.(*spec.TiFlashInstance)
+			tiflashSpec := tiflashInstance.InstanceSpec.(*spec.TiFlashSpec)
+			roleName = tiflashSpec.GetExtendedRole(ctx, tlsCfg, masterActive...)
+		}
 		if ins.IsPatched() {
 			roleName += " (patched)"
 		}

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -605,7 +605,7 @@ func (m *Manager) GetClusterTopology(dopt DisplayOption, opt operator.Options) (
 		if ins.ComponentName() == spec.ComponentTiFlash {
 			tiflashInstance := ins.(*spec.TiFlashInstance)
 			tiflashSpec := tiflashInstance.InstanceSpec.(*spec.TiFlashSpec)
-			roleName = tiflashSpec.GetExtendedRole(ctx, tlsCfg, masterActive...)
+			roleName += tiflashSpec.GetExtendedRole(ctx, tlsCfg, masterActive...)
 		}
 		if ins.IsPatched() {
 			roleName += " (patched)"

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -41,6 +41,8 @@ const (
 	ComponentTiKV             = "tikv"
 	ComponentPD               = "pd"
 	ComponentTiFlash          = "tiflash"
+	ComponentTiFlashCompute   = "tiflash_compute"
+	ComponentTiFlashWrite     = "tiflash_write"
 	ComponentGrafana          = "grafana"
 	ComponentDrainer          = "drainer"
 	ComponentDashboard        = "tidb-dashboard"

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -41,8 +41,6 @@ const (
 	ComponentTiKV             = "tikv"
 	ComponentPD               = "pd"
 	ComponentTiFlash          = "tiflash"
-	ComponentTiFlashCompute   = "tiflash_compute"
-	ComponentTiFlashWrite     = "tiflash_write"
 	ComponentGrafana          = "grafana"
 	ComponentDrainer          = "drainer"
 	ComponentDashboard        = "tidb-dashboard"

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -94,20 +94,20 @@ const (
 // GetExtendedRole get extended name for TiFlash to distinguish disaggregated mode.
 func (s *TiFlashSpec) GetExtendedRole(ctx context.Context, tlsCfg *tls.Config, pdList ...string) string {
 	if len(pdList) < 1 {
-		return ComponentTiFlash
+		return ""
 	}
 	storeAddr := utils.JoinHostPort(s.Host, s.FlashServicePort)
 	pdapi := api.NewPDClient(ctx, pdList, statusQueryTimeout, tlsCfg)
 	store, err := pdapi.GetCurrentStore(storeAddr)
 	if err != nil {
-		return ComponentTiFlash
+		return ""
 	}
 	isWriteNode := false
 	isTiFlash := false
 	for _, label := range store.Store.Labels {
 		if label.Key == EngineLabelKey {
 			if label.Value == EngineLabelTiFlashCompute {
-				return ComponentTiFlashCompute
+				return " (compute)"
 			}
 			if label.Value == EngineLabelTiFlash {
 				isTiFlash = true
@@ -117,10 +117,10 @@ func (s *TiFlashSpec) GetExtendedRole(ctx context.Context, tlsCfg *tls.Config, p
 			isWriteNode = true
 		}
 		if isTiFlash && isWriteNode {
-			return ComponentTiFlashWrite
+			return " (write)"
 		}
 	}
-	return ComponentTiFlash
+	return ""
 }
 
 // Role returns the component role of the instance

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -86,7 +86,7 @@ const (
 	// it's the lable of tiflash_compute nodes.
 	EngineLabelTiFlashCompute = "tiflash_compute"
 	// EngineRoleLabelKey is the label that indicates if the TiFlash instance is a write node.
-	EngineRoleLabelKey = "engine-role"
+	EngineRoleLabelKey = "engine_role"
 	// EngineRoleLabelWrite is for disaggregated tiflash write node.
 	EngineRoleLabelWrite = "write"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?
https://github.com/pingcap/tiup/issues/2135
When the label of TiFlash contains engine-role:write, it means that This TiFlash is a tiflash_write node. So tiflash_write should be displayed in tiup cluster display. But we don't support -R `tiflash_write` or `tiflash_compute` now, so just display `tiflash (write)` or `tiflash (compute)`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
![image](https://user-images.githubusercontent.com/14118780/225190715-de881aa8-e280-4102-894e-cfb9137d186d.png)

 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
