### PR TITLE
playground: Allow setting the TiCDC port

### DIFF
--- a/components/playground/instance/ticdc.go
+++ b/components/playground/instance/ticdc.go
@@ -34,14 +34,17 @@ type TiCDC struct {
 var _ Instance = &TiCDC{}
 
 // NewTiCDC create a TiCDC instance.
-func NewTiCDC(binPath string, dir, host, configPath string, id int, pds []*PDInstance) *TiCDC {
+func NewTiCDC(binPath string, dir, host, configPath string, id int, port int, pds []*PDInstance) *TiCDC {
+	if port <= 0 {
+		port = 8300
+	}
 	ticdc := &TiCDC{
 		instance: instance{
 			BinPath:    binPath,
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, 8300),
+			Port:       utils.MustGetFreePort(host, port),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -104,6 +104,8 @@ const (
 	dbPort      = "db.port"
 	pdHost      = "pd.host"
 	pdPort      = "pd.port"
+	ticdcHost   = "ticdc.host"
+	ticdcPort   = "ticdc.port"
 
 	// config paths
 	dbConfig      = "db.config"
@@ -338,6 +340,8 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 	rootCmd.Flags().Int(dbPort, defaultOptions.TiDB.Port, "Playground TiDB port. If not provided, TiDB will use 4000 as its port")
 	rootCmd.Flags().String(pdHost, defaultOptions.PD.Host, "Playground PD host. If not provided, PD will still use `host` flag as its host")
 	rootCmd.Flags().Int(pdPort, defaultOptions.PD.Port, "Playground PD port. If not provided, PD will use 2379 as its port")
+	rootCmd.Flags().String(ticdcHost, defaultOptions.TiCDC.Host, "Playground TiCDC host. If not provided, TiDB will still use `host` flag as its host")
+	rootCmd.Flags().Int(ticdcPort, defaultOptions.TiCDC.Port, "Playground TiCDC port. If not provided, TiCDC will use 8300 as its port")
 
 	rootCmd.Flags().String(dbConfig, defaultOptions.TiDB.ConfigPath, "TiDB instance configuration file")
 	rootCmd.Flags().String(kvConfig, defaultOptions.TiKV.ConfigPath, "TiKV instance configuration file")
@@ -497,6 +501,13 @@ func populateOpt(flagSet *pflag.FlagSet) (err error) {
 			options.TiDB.Host = flag.Value.String()
 		case dbPort:
 			options.TiDB.Port, err = strconv.Atoi(flag.Value.String())
+			if err != nil {
+				return
+			}
+		case ticdcHost:
+			options.TiCDC.Host = flag.Value.String()
+		case ticdcPort:
+			options.TiCDC.Port, err = strconv.Atoi(flag.Value.String())
 			if err != nil {
 				return
 			}

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -684,7 +684,7 @@ func (p *Playground) addInstance(componentID string, cfg instance.Config) (ins i
 		ins = inst
 		p.tiflashs = append(p.tiflashs, inst)
 	case spec.ComponentCDC:
-		inst := instance.NewTiCDC(cfg.BinPath, dir, host, cfg.ConfigPath, id, p.pds)
+		inst := instance.NewTiCDC(cfg.BinPath, dir, host, cfg.ConfigPath, id, cfg.Port, p.pds)
 		ins = inst
 		p.ticdcs = append(p.ticdcs, inst)
 	case spec.ComponentTiKVCDC:


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Allow setting the TCP port for TiCDC

Example:
```
tiup playground --tiflash 0 --without-monitor --ticdc 1 --ticdc.port 8333 v6.6.0
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Code changes

 - Has exported function/method change


Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Add an option to set a custom TCP port for TiCDC to listen on.
```
