### PR TITLE
clean: check process name before killing it

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -73,9 +73,21 @@ func cleanData(env *environment.Environment, names []string, all bool) error {
 		}
 
 		if p, err := gops.NewProcess(int32(process.Pid)); err == nil {
-			fmt.Printf("Kill instance of `%s`, pid: %v\n", process.Component, process.Pid)
-			if err := p.Kill(); err != nil {
-				return err
+			pName, err := p.Name()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to get process info for `%s`, pid: %v\n",
+					process.Component, process.Pid)
+			} else {
+				if pName != "tiup-playground" {
+					fmt.Printf("Process name mismatch (`%s` != `tiup-playground`, not killing it.\n",
+						pName)
+				} else {
+					fmt.Printf("Kill instance of `%s`, pid: %v\n",
+						process.Component, process.Pid)
+					if err := p.Kill(); err != nil {
+						return err
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The pid that is read from `tiup_process_meta` can be old and might be recycled due to pid wrap around or after restarts.

This PR checks if the `p.Name()` is `tiup-playground` before killing it.

```
Kill instance of `playground`, pid: 2804212
Clean instance of `playground`, directory: /home/dvaneeden/.tiup/data/crp
Process name mismatch (`/usr/bin/gjs` != `tiup-playground`, not killing it.
Clean instance of `playground`, directory: /home/dvaneeden/.tiup/data/crp
```

For a actual playground the data looks like this:
```
PROC cmdline: /home/dvaneeden/.tiup/components/playground/v1.11.3/tiup-playground -T crp --tiflash 0 --without-monitor v6.6.0
PROC cwd: /home/dvaneeden
PROC exe: /home/dvaneeden/.tiup/components/playground/v1.11.3/tiup-playground
PROC name: tiup-playground
```

For a different process (GNOME Weather) it looks like this:
```
PROC cmdline: /usr/bin/gjs /usr/share/org.gnome.Weather/org.gnome.Weather --gapplication-service
PROC cwd: /home/dvaneeden
PROC exe: /usr/bin/gjs-console
PROC name: /usr/bin/gjs
```

This is what https://godocs.io/github.com/shirou/gopsutil/v3/process shows for `p.Cmdline()`, `p.Cwd()`, `p.Exe()` and `p.Name()`.

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->




### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Copying the `tiup_process_meta` and changing the process.




Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
