### PR TITLE
tiup cluster prune need to delete storage.remote.cache.dir

### DIFF
--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -380,7 +380,9 @@ func DestroyComponent(ctx context.Context, instances []spec.Instance, cls spec.T
 		if ins.ComponentName() == spec.ComponentTiFlash {
 			tiflashInstance := ins.(*spec.TiFlashInstance)
 			tiflashSpec := tiflashInstance.InstanceSpec.(*spec.TiFlashSpec)
-			delPaths.Insert(tiflashSpec.Config[spec.TiFlashRemoteCacheDir].(string))
+			if remoteCacheDir, ok := tiflashSpec.Config[spec.TiFlashRemoteCacheDir]; ok {
+				delPaths.Insert(remoteCacheDir.(string))
+			}
 		}
 
 		logDir := ins.LogDir()

--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -376,6 +376,13 @@ func DestroyComponent(ctx context.Context, instances []spec.Instance, cls spec.T
 			}
 		}
 
+		// For TiFlash, we need to delete storage.remote.cache.dir
+		if ins.ComponentName() == spec.ComponentTiFlash {
+			tiflashInstance := ins.(*spec.TiFlashInstance)
+			tiflashSpec := tiflashInstance.InstanceSpec.(*spec.TiFlashSpec)
+			delPaths.Insert(tiflashSpec.Config[spec.TiFlashRemoteCacheDir].(string))
+		}
+
 		logDir := ins.LogDir()
 
 		// In TiDB-Ansible, deploy dir are shared by all components on the same

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -153,6 +153,7 @@ const (
 	TiFlashStorageKeyMainDirs   string = "storage.main.dir"
 	TiFlashStorageKeyLatestDirs string = "storage.latest.dir"
 	TiFlashStorageKeyRaftDirs   string = "storage.raft.dir"
+	TiFlashRemoteCacheDir       string = "storage.remote.cache.dir"
 	TiFlashRequiredCPUFlags     string = "avx2 popcnt movbe"
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
After https://github.com/pingcap/tiflash/pull/6967, TiFlash has added  `storage.remote.cache.dir` config, so tiup cluster prune need to delete storage.remote.cache.dir of TiFlash.

### What is changed and how it works?
tiup cluster prune support to delete storage.remote.cache.dir of TiFlash.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 `./tiup-cluster prune ctl-test-2`
Check if the `storage.remote.cache.dir` has been deleted.
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
