### PR TITLE
Add --cluster.advertise-address to  embed/templates/scripts/run_alertmanager.sh.tpl

### DIFF
--- a/embed/templates/scripts/run_alertmanager.sh.tpl
+++ b/embed/templates/scripts/run_alertmanager.sh.tpl
@@ -27,4 +27,4 @@ exec bin/alertmanager/alertmanager \
 {{- end}}
 {{- end}}
     --cluster.listen-address="{{.ClusterListenAddr}}" \
-    --cluster.advertise-address=="{{.ClusterAdvertiseAddr}}"
+    --cluster.advertise-address="{{.ClusterAdvertiseAddr}}"

--- a/embed/templates/scripts/run_alertmanager.sh.tpl
+++ b/embed/templates/scripts/run_alertmanager.sh.tpl
@@ -26,4 +26,5 @@ exec bin/alertmanager/alertmanager \
     --cluster.peer="{{$am}}" \
 {{- end}}
 {{- end}}
-    --cluster.listen-address="{{.ClusterListenAddr}}"
+    --cluster.listen-address="{{.ClusterListenAddr}}" \
+    --cluster.advertise-address=="{{.ClusterAdvertiseAddr}}"

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -37,6 +37,7 @@ type AlertmanagerSpec struct {
 	IgnoreExporter  bool                 `yaml:"ignore_exporter,omitempty"`
 	WebPort         int                  `yaml:"web_port" default:"9093"`
 	ClusterPort     int                  `yaml:"cluster_port" default:"9094"`
+	AdvertisePort   int                  `yaml:"advertise_port" default:"9093"`
 	ListenHost      string               `yaml:"listen_host,omitempty" validate:"listen_host:editable"`
 	DeployDir       string               `yaml:"deploy_dir,omitempty"`
 	DataDir         string               `yaml:"data_dir,omitempty"`
@@ -157,10 +158,11 @@ func (i *AlertManagerInstance) InitConfig(
 		peers = append(peers, utils.JoinHostPort(amspec.Host, amspec.ClusterPort))
 	}
 	cfg := &scripts.AlertManagerScript{
-		WebListenAddr:     utils.JoinHostPort(i.GetListenHost(), spec.WebPort),
-		WebExternalURL:    fmt.Sprintf("http://%s", utils.JoinHostPort(spec.Host, spec.WebPort)),
-		ClusterPeers:      peers,
-		ClusterListenAddr: utils.JoinHostPort(i.GetListenHost(), spec.ClusterPort),
+		WebListenAddr:        utils.JoinHostPort(i.GetListenHost(), spec.WebPort),
+		WebExternalURL:       fmt.Sprintf("http://%s", utils.JoinHostPort(spec.Host, spec.WebPort)),
+		ClusterPeers:         peers,
+		ClusterListenAddr:    utils.JoinHostPort(i.GetListenHost(), spec.ClusterPort),
+		ClusterAdvertiseAddr: utils.JoinHostPort(i.GetListenHost(), spec.AdvertisePort),
 
 		DeployDir: paths.Deploy,
 		LogDir:    paths.Log,

--- a/pkg/cluster/template/scripts/alertmanager.go
+++ b/pkg/cluster/template/scripts/alertmanager.go
@@ -24,10 +24,11 @@ import (
 
 // AlertManagerScript represent the data to generate AlertManager start script
 type AlertManagerScript struct {
-	WebListenAddr     string
-	WebExternalURL    string
-	ClusterPeers      []string
-	ClusterListenAddr string
+	WebListenAddr        string
+	WebExternalURL       string
+	ClusterPeers         []string
+	ClusterListenAddr    string
+	ClusterAdvertiseAddr string
 
 	DeployDir string
 	LogDir    string


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tiup/issues/2155


### What is changed and how it works?
Add --cluster.advertise-address to alertmanger startup script. 
https://serverfault.com/questions/1024890/prometheus-alert-manager-error-component-cluster-err-couldnt-deduce-an-advert


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
