### PR TITLE
playground: Run TiFlash via args

### DIFF
--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -29,6 +30,7 @@ import (
 	"github.com/pingcap/tiup/pkg/cluster/api"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
+	"github.com/pingcap/tiup/pkg/tidbver"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -95,6 +97,50 @@ func (inst *TiFlashInstance) StatusAddrs() (addrs []string) {
 
 // Start calls set inst.cmd and Start
 func (inst *TiFlashInstance) Start(ctx context.Context, version utils.Version) error {
+	if tidbver.TiFlashSupportRunWithoutConfig(version.String()) {
+		return inst.startViaArgs(ctx, version)
+	} else {
+		return inst.startViaConfig(ctx, version)
+	}
+}
+
+func (inst *TiFlashInstance) startViaArgs(ctx context.Context, version utils.Version) error {
+	endpoints := pdEndpoints(inst.pds, false)
+
+	args := []string{
+		"server",
+		"--",
+		fmt.Sprintf("--tmp_path=%s", filepath.Join(inst.Dir, "tmp")),
+		fmt.Sprintf("--path=%s", filepath.Join(inst.Dir, "data")),
+		fmt.Sprintf("--http_port=%d", inst.Port),
+		fmt.Sprintf("--listen_host=%s", inst.Host),
+		fmt.Sprintf("--tcp_port=%d", inst.TCPPort),
+		fmt.Sprintf("--logger.log=%s", inst.LogFile()),
+		fmt.Sprintf("--logger.errorlog=%s", filepath.Join(inst.Dir, "tiflash_error.log")),
+		fmt.Sprintf("--status.metrics_port=%d", inst.StatusPort),
+		fmt.Sprintf("--flash.service_addr=%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.ServicePort)),
+		fmt.Sprintf("--raft.pd_addr=%s", strings.Join(endpoints, ",")),
+		fmt.Sprintf("--flash.proxy.addr=%s", utils.JoinHostPort(inst.Host, inst.ProxyPort)),
+		fmt.Sprintf("--flash.proxy.advertise-addr=%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.ProxyPort)),
+		fmt.Sprintf("--flash.proxy.status-addr=%s", utils.JoinHostPort(inst.Host, inst.ProxyStatusPort)),
+		fmt.Sprintf("--flash.proxy.data-dir=%s", filepath.Join(inst.Dir, "proxy-data")),
+		fmt.Sprintf("--flash.proxy.log-file=%s", filepath.Join(inst.Dir, "tiflash_tikv.log")),
+	}
+	if inst.ConfigPath != "" {
+		args = append(args, fmt.Sprintf("--config-file=%s", inst.ConfigPath))
+	}
+
+	var err error
+	if inst.BinPath, err = tiupexec.PrepareBinary("tiflash", version, inst.BinPath); err != nil {
+		return err
+	}
+	inst.Process = &process{cmd: PrepareCommand(ctx, inst.BinPath, args, nil, inst.Dir)}
+
+	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
+	return inst.Process.Start()
+}
+
+func (inst *TiFlashInstance) startViaConfig(ctx context.Context, version utils.Version) error {
 	endpoints := pdEndpoints(inst.pds, false)
 
 	tidbStatusAddrs := make([]string, 0, len(inst.dbs))
@@ -145,7 +191,7 @@ func (inst *TiFlashInstance) Start(ctx context.Context, version utils.Version) e
 
 	dirPath := filepath.Dir(inst.BinPath)
 	clusterManagerPath := getFlashClusterPath(dirPath)
-	if err = inst.checkConfig(wd, clusterManagerPath, version, tidbStatusAddrs, endpoints); err != nil {
+	if err = inst.checkConfigForStartViaConfig(wd, clusterManagerPath, version, tidbStatusAddrs, endpoints); err != nil {
 		return err
 	}
 
@@ -182,7 +228,7 @@ func (inst *TiFlashInstance) StoreAddr() string {
 	return utils.JoinHostPort(AdvertiseHost(inst.Host), inst.ServicePort)
 }
 
-func (inst *TiFlashInstance) checkConfig(deployDir, clusterManagerPath string,
+func (inst *TiFlashInstance) checkConfigForStartViaConfig(deployDir, clusterManagerPath string,
 	version utils.Version, tidbStatusAddrs, endpoints []string) (err error) {
 	if err := utils.MkdirAll(inst.Dir, 0755); err != nil {
 		return errors.Trace(err)
@@ -212,11 +258,11 @@ func (inst *TiFlashInstance) checkConfig(deployDir, clusterManagerPath string,
 	}()
 
 	// Write default config to buffer
-	if err := writeTiFlashConfig(flashBuf, version, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
+	if err := writeTiFlashConfigForStartViaConfig(flashBuf, version, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
 		inst.Host, deployDir, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {
 		return errors.Trace(err)
 	}
-	if err := writeTiFlashProxyConfig(proxyBuf, version, inst.Host, deployDir,
+	if err := writeTiFlashProxyConfigForStartViaConfig(proxyBuf, version, inst.Host, deployDir,
 		inst.ServicePort, inst.ProxyPort, inst.ProxyStatusPort); err != nil {
 		return errors.Trace(err)
 	}

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -99,9 +99,8 @@ func (inst *TiFlashInstance) StatusAddrs() (addrs []string) {
 func (inst *TiFlashInstance) Start(ctx context.Context, version utils.Version) error {
 	if tidbver.TiFlashSupportRunWithoutConfig(version.String()) {
 		return inst.startViaArgs(ctx, version)
-	} else {
-		return inst.startViaConfig(ctx, version)
 	}
+	return inst.startViaConfig(ctx, version)
 }
 
 func (inst *TiFlashInstance) startViaArgs(ctx context.Context, version utils.Version) error {

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -109,6 +109,11 @@ func (inst *TiFlashInstance) startViaArgs(ctx context.Context, version utils.Ver
 
 	args := []string{
 		"server",
+	}
+	if inst.ConfigPath != "" {
+		args = append(args, fmt.Sprintf("--config-file=%s", inst.ConfigPath))
+	}
+	args = append(args,
 		"--",
 		fmt.Sprintf("--tmp_path=%s", filepath.Join(inst.Dir, "tmp")),
 		fmt.Sprintf("--path=%s", filepath.Join(inst.Dir, "data")),
@@ -123,12 +128,9 @@ func (inst *TiFlashInstance) startViaArgs(ctx context.Context, version utils.Ver
 		fmt.Sprintf("--flash.proxy.addr=%s", utils.JoinHostPort(inst.Host, inst.ProxyPort)),
 		fmt.Sprintf("--flash.proxy.advertise-addr=%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.ProxyPort)),
 		fmt.Sprintf("--flash.proxy.status-addr=%s", utils.JoinHostPort(inst.Host, inst.ProxyStatusPort)),
-		fmt.Sprintf("--flash.proxy.data-dir=%s", filepath.Join(inst.Dir, "proxy-data")),
+		fmt.Sprintf("--flash.proxy.data-dir=%s", filepath.Join(inst.Dir, "proxy_data")),
 		fmt.Sprintf("--flash.proxy.log-file=%s", filepath.Join(inst.Dir, "tiflash_tikv.log")),
-	}
-	if inst.ConfigPath != "" {
-		args = append(args, fmt.Sprintf("--config-file=%s", inst.ConfigPath))
-	}
+	)
 
 	var err error
 	if inst.BinPath, err = tiupexec.PrepareBinary("tiflash", version, inst.BinPath); err != nil {

--- a/components/playground/instance/tiflash_config.go
+++ b/components/playground/instance/tiflash_config.go
@@ -99,7 +99,7 @@ quota = "default"
 ip = "::/0"
 `
 
-func writeTiFlashConfig(w io.Writer, version utils.Version, tcpPort, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
+func writeTiFlashConfigForStartViaConfig(w io.Writer, version utils.Version, tcpPort, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
 	pdAddrs := strings.Join(endpoints, ",")
 	dataDir := fmt.Sprintf("%s/data", deployDir)
 	tmpDir := fmt.Sprintf("%s/tmp", deployDir)

--- a/components/playground/instance/tiflash_proxy_config.go
+++ b/components/playground/instance/tiflash_proxy_config.go
@@ -46,7 +46,7 @@ data-dir = "%[6]s"
 max-open-files = 256
 `
 
-func writeTiFlashProxyConfig(w io.Writer, version utils.Version, host, deployDir string, servicePort, proxyPort, proxyStatusPort int) error {
+func writeTiFlashProxyConfigForStartViaConfig(w io.Writer, version utils.Version, host, deployDir string, servicePort, proxyPort, proxyStatusPort int) error {
 	// TODO: support multi-dir
 	dataDir := fmt.Sprintf("%s/flash", deployDir)
 	logDir := fmt.Sprintf("%s/log", deployDir)

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -65,7 +65,7 @@ func (inst *TiKVInstance) Start(ctx context.Context, version utils.Version) erro
 		fmt.Sprintf("--addr=%s", utils.JoinHostPort(inst.Host, inst.Port)),
 		fmt.Sprintf("--advertise-addr=%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.Port)),
 		fmt.Sprintf("--status-addr=%s", utils.JoinHostPort(inst.Host, inst.StatusPort)),
-		fmt.Sprintf("--pd=%s", strings.Join(endpoints, ",")),
+		fmt.Sprintf("--pd-endpoints=%s", strings.Join(endpoints, ",")),
 		fmt.Sprintf("--config=%s", inst.ConfigPath),
 		fmt.Sprintf("--data-dir=%s", filepath.Join(inst.Dir, "data")),
 		fmt.Sprintf("--log-file=%s", inst.LogFile()),

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -67,7 +67,7 @@ func TiFlashNotNeedSomeConfig(version string) bool {
 	return semver.Compare(version, "v5.4.0") >= 0 || strings.Contains(version, "nightly")
 }
 
-// TiFlashSupportRunByArg return true if the given version of TiFlash could be started without
+// TiFlashSupportRunWithoutConfig return true if the given version of TiFlash could be started without
 // a config file.
 func TiFlashSupportRunWithoutConfig(version string) bool {
 	return semver.Compare(version, "v7.1.0") >= 0 || strings.Contains(version, "nightly")

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -67,6 +67,12 @@ func TiFlashNotNeedSomeConfig(version string) bool {
 	return semver.Compare(version, "v5.4.0") >= 0 || strings.Contains(version, "nightly")
 }
 
+// TiFlashSupportRunByArg return true if the given version of TiFlash could be started without
+// a config file.
+func TiFlashSupportRunWithoutConfig(version string) bool {
+	return semver.Compare(version, "v7.1.0") >= 0 || strings.Contains(version, "nightly")
+}
+
 // TiCDCSupportConfigFile return if given version of TiCDC support config file
 func TiCDCSupportConfigFile(version string) bool {
 	// config support since v4.0.13, ignore v5.0.0-rc


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently in playground we run TiFlash via a specified config file, and we put runtime config (like port, data directory) in the config file.

It is hard for us to specify a custom config file, because we must fill these runtime config in the custom config file as well.

### What is changed and how it works?

Move TiFlash runtime config to args, thanks to https://github.com/pingcap/tiflash/pull/7251.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Start one:

```shell
bin/tiup-playground nightly --tiflash.binpath ~/Work/tiflash-workspace2/cmake-build-Debug/dbms/src/Server/tiflash
Using the version nightly for version constraint "nightly".

If you'd like to use a TiDB version other than nightly, cancel and retry with the following arguments:
	Specify version manually:   tiup playground <version>
	Specify version range:      tiup playground ^5
	The nightly version:        tiup playground nightly

Playground Bootstrapping...
Start pd instance:v7.1.0-alpha-nightly-20230408
Start tikv instance:v7.1.0-alpha-nightly-20230408
Start tidb instance:v7.1.0-alpha-nightly-20230408
Waiting for tidb instances ready
127.0.0.1:4000 ... Done
component grafana version v7.1.0-alpha-nightly-20230408 is already installed
Start tiflash instance:v7.1.0-alpha-nightly-20230408
Waiting for tiflash instances ready
127.0.0.1:3930 ... Done
CLUSTER START SUCCESSFULLY, Enjoy it ^-^
To connect TiDB: mysql --comments --host 127.0.0.1 --port 4000 -u root -p (no password)
To view the dashboard: http://127.0.0.1:2379/dashboard
PD client endpoints: [127.0.0.1:2379]
To view the Prometheus: http://127.0.0.1:9090
To view the Grafana: http://127.0.0.1:3000
```

Start another:

```
bin/tiup-playground nightly --tiflash.binpath ~/Work/tiflash-workspace2/cmake-build-Debug/dbms/src/Server/tiflash
Using the version nightly for version constraint "nightly".

If you'd like to use a TiDB version other than nightly, cancel and retry with the following arguments:
	Specify version manually:   tiup playground <version>
	Specify version range:      tiup playground ^5
	The nightly version:        tiup playground nightly

Playground Bootstrapping...
Start pd instance:v7.1.0-alpha-nightly-20230408
Start tikv instance:v7.1.0-alpha-nightly-20230408
Start tidb instance:v7.1.0-alpha-nightly-20230408
Waiting for tidb instances ready
127.0.0.1:49551 ... Done
component grafana version v7.1.0-alpha-nightly-20230408 is already installed
Start tiflash instance:v7.1.0-alpha-nightly-20230408
Waiting for tiflash instances ready
127.0.0.1:49556 ... Done
CLUSTER START SUCCESSFULLY, Enjoy it ^-^
To connect TiDB: mysql --comments --host 127.0.0.1 --port 49551 -u root -p (no password)
To view the dashboard: http://127.0.0.1:49548/dashboard
PD client endpoints: [127.0.0.1:49548]
To view the Prometheus: http://127.0.0.1:49657
To view the Grafana: http://127.0.0.1:49666
```

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
playground: Support custom TiFlash config file
```
