### PR TITLE
playground: Code refine for TiFlash

### DIFF
--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -14,21 +14,12 @@
 package instance
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
-	"github.com/BurntSushi/toml"
-	"github.com/pingcap/errors"
-	"github.com/pingcap/tiup/pkg/cluster/api"
-	"github.com/pingcap/tiup/pkg/cluster/spec"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/tidbver"
 	"github.com/pingcap/tiup/pkg/utils"
@@ -71,22 +62,6 @@ func NewTiFlashInstance(binPath, dir, host, configPath string, id int, pds []*PD
 	}
 }
 
-func getFlashClusterPath(dir string) string {
-	return fmt.Sprintf("%s/flash_cluster_manager", dir)
-}
-
-type scheduleConfig struct {
-	LowSpaceRatio float64 `json:"low-space-ratio"`
-}
-
-type replicateMaxReplicaConfig struct {
-	MaxReplicas int `json:"max-replicas"`
-}
-
-type replicateEnablePlacementRulesConfig struct {
-	EnablePlacementRules string `json:"enable-placement-rules"`
-}
-
 // Addr return the address of tiflash
 func (inst *TiFlashInstance) Addr() string {
 	return utils.JoinHostPort(AdvertiseHost(inst.Host), inst.ServicePort)
@@ -101,13 +76,10 @@ func (inst *TiFlashInstance) StatusAddrs() (addrs []string) {
 
 // Start calls set inst.cmd and Start
 func (inst *TiFlashInstance) Start(ctx context.Context, version utils.Version) error {
-	if tidbver.TiFlashSupportRunWithoutConfig(version.String()) {
-		return inst.startViaArgs(ctx, version)
+	if !tidbver.TiFlashPlaygroundNewStartMode(version.String()) {
+		return inst.startOld(ctx, version)
 	}
-	return inst.startViaConfig(ctx, version)
-}
 
-func (inst *TiFlashInstance) startViaArgs(ctx context.Context, version utils.Version) error {
 	endpoints := pdEndpoints(inst.pds, false)
 
 	args := []string{
@@ -144,74 +116,6 @@ func (inst *TiFlashInstance) startViaArgs(ctx context.Context, version utils.Ver
 	return inst.Process.Start()
 }
 
-func (inst *TiFlashInstance) startViaConfig(ctx context.Context, version utils.Version) error {
-	endpoints := pdEndpoints(inst.pds, false)
-
-	tidbStatusAddrs := make([]string, 0, len(inst.dbs))
-	for _, db := range inst.dbs {
-		tidbStatusAddrs = append(tidbStatusAddrs, utils.JoinHostPort(AdvertiseHost(db.Host), db.StatusPort))
-	}
-	wd, err := filepath.Abs(inst.Dir)
-	if err != nil {
-		return err
-	}
-
-	// Wait for PD
-	pdClient := api.NewPDClient(ctx, endpoints, 10*time.Second, nil)
-	// set low-space-ratio to 1 to avoid low disk space
-	lowSpaceRatio, err := json.Marshal(scheduleConfig{
-		LowSpaceRatio: 0.99,
-	})
-	if err != nil {
-		return err
-	}
-	if err = pdClient.UpdateScheduleConfig(bytes.NewBuffer(lowSpaceRatio)); err != nil {
-		return err
-	}
-	// Update maxReplicas before placement rules so that it would not be overwritten
-	maxReplicas, err := json.Marshal(replicateMaxReplicaConfig{
-		MaxReplicas: 1,
-	})
-	if err != nil {
-		return err
-	}
-	if err = pdClient.UpdateReplicateConfig(bytes.NewBuffer(maxReplicas)); err != nil {
-		return err
-	}
-	// Set enable-placement-rules to allow TiFlash work properly
-	enablePlacementRules, err := json.Marshal(replicateEnablePlacementRulesConfig{
-		EnablePlacementRules: "true",
-	})
-	if err != nil {
-		return err
-	}
-	if err = pdClient.UpdateReplicateConfig(bytes.NewBuffer(enablePlacementRules)); err != nil {
-		return err
-	}
-
-	if inst.BinPath, err = tiupexec.PrepareBinary("tiflash", version, inst.BinPath); err != nil {
-		return err
-	}
-
-	dirPath := filepath.Dir(inst.BinPath)
-	clusterManagerPath := getFlashClusterPath(dirPath)
-	if err = inst.checkConfigForStartViaConfig(wd, clusterManagerPath, version, tidbStatusAddrs, endpoints); err != nil {
-		return err
-	}
-
-	args := []string{
-		"server",
-		fmt.Sprintf("--config-file=%s", inst.ConfigPath),
-	}
-	envs := []string{
-		fmt.Sprintf("LD_LIBRARY_PATH=%s:$LD_LIBRARY_PATH", dirPath),
-	}
-	inst.Process = &process{cmd: PrepareCommand(ctx, inst.BinPath, args, envs, inst.Dir)}
-
-	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
-	return inst.Process.Start()
-}
-
 // Component return the component name.
 func (inst *TiFlashInstance) Component() string {
 	return "tiflash"
@@ -230,90 +134,4 @@ func (inst *TiFlashInstance) Cmd() *exec.Cmd {
 // StoreAddr return the store address of TiFlash
 func (inst *TiFlashInstance) StoreAddr() string {
 	return utils.JoinHostPort(AdvertiseHost(inst.Host), inst.ServicePort)
-}
-
-func (inst *TiFlashInstance) checkConfigForStartViaConfig(deployDir, clusterManagerPath string,
-	version utils.Version, tidbStatusAddrs, endpoints []string) (err error) {
-	if err := utils.MkdirAll(inst.Dir, 0755); err != nil {
-		return errors.Trace(err)
-	}
-
-	var (
-		flashBuf = new(bytes.Buffer)
-		proxyBuf = new(bytes.Buffer)
-
-		flashCfgPath = path.Join(inst.Dir, "tiflash.toml")
-		proxyCfgPath = path.Join(inst.Dir, "tiflash-learner.toml")
-	)
-
-	defer func() {
-		if err != nil {
-			return
-		}
-		if err = utils.WriteFile(flashCfgPath, flashBuf.Bytes(), 0644); err != nil {
-			return
-		}
-
-		if err = utils.WriteFile(proxyCfgPath, proxyBuf.Bytes(), 0644); err != nil {
-			return
-		}
-
-		inst.ConfigPath = flashCfgPath
-	}()
-
-	// Write default config to buffer
-	if err := writeTiFlashConfigForStartViaConfig(flashBuf, version, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
-		inst.Host, deployDir, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {
-		return errors.Trace(err)
-	}
-	if err := writeTiFlashProxyConfigForStartViaConfig(proxyBuf, version, inst.Host, deployDir,
-		inst.ServicePort, inst.ProxyPort, inst.ProxyStatusPort); err != nil {
-		return errors.Trace(err)
-	}
-
-	if inst.ConfigPath == "" {
-		return
-	}
-
-	cfg, err := unmarshalConfig(inst.ConfigPath)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	proxyPath := getTiFlashProxyConfigPath(cfg)
-	if proxyPath != "" {
-		proxyCfg, err := unmarshalConfig(proxyPath)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		err = overwriteBuf(proxyBuf, proxyCfg)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	// Always use the tiflash proxy config file in the instance directory
-	setTiFlashProxyConfigPath(cfg, proxyCfgPath)
-	return errors.Trace(overwriteBuf(flashBuf, cfg))
-}
-
-func unmarshalConfig(path string) (map[string]any, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	c := make(map[string]any)
-	err = toml.Unmarshal(data, &c)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
-}
-
-func overwriteBuf(buf *bytes.Buffer, overwrite map[string]any) (err error) {
-	cfg := make(map[string]any)
-	if err = toml.Unmarshal(buf.Bytes(), &cfg); err != nil {
-		return
-	}
-	buf.Reset()
-	return toml.NewEncoder(buf).Encode(spec.MergeConfig(cfg, overwrite))
 }

--- a/components/playground/instance/tiflash_pre7.go
+++ b/components/playground/instance/tiflash_pre7.go
@@ -1,0 +1,204 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/cluster/api"
+	"github.com/pingcap/tiup/pkg/cluster/spec"
+	tiupexec "github.com/pingcap/tiup/pkg/exec"
+	"github.com/pingcap/tiup/pkg/utils"
+)
+
+func getFlashClusterPath(dir string) string {
+	return fmt.Sprintf("%s/flash_cluster_manager", dir)
+}
+
+type scheduleConfig struct {
+	LowSpaceRatio float64 `json:"low-space-ratio"`
+}
+
+type replicateMaxReplicaConfig struct {
+	MaxReplicas int `json:"max-replicas"`
+}
+
+type replicateEnablePlacementRulesConfig struct {
+	EnablePlacementRules string `json:"enable-placement-rules"`
+}
+
+// startOld is for < 7.1.0. Not maintained any more. Do not introduce new features.
+func (inst *TiFlashInstance) startOld(ctx context.Context, version utils.Version) error {
+	endpoints := pdEndpoints(inst.pds, false)
+
+	tidbStatusAddrs := make([]string, 0, len(inst.dbs))
+	for _, db := range inst.dbs {
+		tidbStatusAddrs = append(tidbStatusAddrs, utils.JoinHostPort(AdvertiseHost(db.Host), db.StatusPort))
+	}
+	wd, err := filepath.Abs(inst.Dir)
+	if err != nil {
+		return err
+	}
+
+	// Wait for PD
+	pdClient := api.NewPDClient(ctx, endpoints, 10*time.Second, nil)
+	// set low-space-ratio to 1 to avoid low disk space
+	lowSpaceRatio, err := json.Marshal(scheduleConfig{
+		LowSpaceRatio: 0.99,
+	})
+	if err != nil {
+		return err
+	}
+	if err = pdClient.UpdateScheduleConfig(bytes.NewBuffer(lowSpaceRatio)); err != nil {
+		return err
+	}
+	// Update maxReplicas before placement rules so that it would not be overwritten
+	maxReplicas, err := json.Marshal(replicateMaxReplicaConfig{
+		MaxReplicas: 1,
+	})
+	if err != nil {
+		return err
+	}
+	if err = pdClient.UpdateReplicateConfig(bytes.NewBuffer(maxReplicas)); err != nil {
+		return err
+	}
+	// Set enable-placement-rules to allow TiFlash work properly
+	enablePlacementRules, err := json.Marshal(replicateEnablePlacementRulesConfig{
+		EnablePlacementRules: "true",
+	})
+	if err != nil {
+		return err
+	}
+	if err = pdClient.UpdateReplicateConfig(bytes.NewBuffer(enablePlacementRules)); err != nil {
+		return err
+	}
+
+	if inst.BinPath, err = tiupexec.PrepareBinary("tiflash", version, inst.BinPath); err != nil {
+		return err
+	}
+
+	dirPath := filepath.Dir(inst.BinPath)
+	clusterManagerPath := getFlashClusterPath(dirPath)
+	if err = inst.checkConfigOld(wd, clusterManagerPath, version, tidbStatusAddrs, endpoints); err != nil {
+		return err
+	}
+
+	args := []string{
+		"server",
+		fmt.Sprintf("--config-file=%s", inst.ConfigPath),
+	}
+	envs := []string{
+		fmt.Sprintf("LD_LIBRARY_PATH=%s:$LD_LIBRARY_PATH", dirPath),
+	}
+	inst.Process = &process{cmd: PrepareCommand(ctx, inst.BinPath, args, envs, inst.Dir)}
+
+	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
+	return inst.Process.Start()
+}
+
+// checkConfigOld is for < 7.1.0. Not maintained any more. Do not introduce new features.
+func (inst *TiFlashInstance) checkConfigOld(deployDir, clusterManagerPath string,
+	version utils.Version, tidbStatusAddrs, endpoints []string) (err error) {
+	if err := utils.MkdirAll(inst.Dir, 0755); err != nil {
+		return errors.Trace(err)
+	}
+
+	var (
+		flashBuf = new(bytes.Buffer)
+		proxyBuf = new(bytes.Buffer)
+
+		flashCfgPath = path.Join(inst.Dir, "tiflash.toml")
+		proxyCfgPath = path.Join(inst.Dir, "tiflash-learner.toml")
+	)
+
+	defer func() {
+		if err != nil {
+			return
+		}
+		if err = utils.WriteFile(flashCfgPath, flashBuf.Bytes(), 0644); err != nil {
+			return
+		}
+
+		if err = utils.WriteFile(proxyCfgPath, proxyBuf.Bytes(), 0644); err != nil {
+			return
+		}
+
+		inst.ConfigPath = flashCfgPath
+	}()
+
+	// Write default config to buffer
+	if err := writeTiFlashConfigOld(flashBuf, version, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
+		inst.Host, deployDir, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {
+		return errors.Trace(err)
+	}
+	if err := writeTiFlashProxyConfigOld(proxyBuf, version, inst.Host, deployDir,
+		inst.ServicePort, inst.ProxyPort, inst.ProxyStatusPort); err != nil {
+		return errors.Trace(err)
+	}
+
+	if inst.ConfigPath == "" {
+		return
+	}
+
+	cfg, err := unmarshalConfig(inst.ConfigPath)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	proxyPath := getTiFlashProxyConfigPathOld(cfg)
+	if proxyPath != "" {
+		proxyCfg, err := unmarshalConfig(proxyPath)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = overwriteBuf(proxyBuf, proxyCfg)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// Always use the tiflash proxy config file in the instance directory
+	setTiFlashProxyConfigPathOld(cfg, proxyCfgPath)
+	return errors.Trace(overwriteBuf(flashBuf, cfg))
+}
+
+func unmarshalConfig(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	c := make(map[string]any)
+	err = toml.Unmarshal(data, &c)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func overwriteBuf(buf *bytes.Buffer, overwrite map[string]any) (err error) {
+	cfg := make(map[string]any)
+	if err = toml.Unmarshal(buf.Bytes(), &cfg); err != nil {
+		return
+	}
+	buf.Reset()
+	return toml.NewEncoder(buf).Encode(spec.MergeConfig(cfg, overwrite))
+}

--- a/components/playground/instance/tiflash_pre7_config.go
+++ b/components/playground/instance/tiflash_pre7_config.go
@@ -22,16 +22,16 @@ import (
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
-const tiflashDaemonConfig = `
+const tiflashDaemonConfigOld = `
 
 [application]
 runAsDaemon = true
 
 `
 
-const tiflashMarkCacheSize = `mark_cache_size = 5368709120`
+const tiflashMarkCacheSizeOld = `mark_cache_size = 5368709120`
 
-const tiflashConfig = `
+const tiflashConfigOld = `
 default_profile = "default"
 display_name = "TiFlash"
 %[2]s
@@ -99,7 +99,8 @@ quota = "default"
 ip = "::/0"
 `
 
-func writeTiFlashConfigForStartViaConfig(w io.Writer, version utils.Version, tcpPort, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
+// writeTiFlashConfigOld is for < 7.1.0. Not maintained any more. Do not introduce new features.
+func writeTiFlashConfigOld(w io.Writer, version utils.Version, tcpPort, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
 	pdAddrs := strings.Join(endpoints, ",")
 	dataDir := fmt.Sprintf("%s/data", deployDir)
 	tmpDir := fmt.Sprintf("%s/tmp", deployDir)
@@ -108,19 +109,19 @@ func writeTiFlashConfigForStartViaConfig(w io.Writer, version utils.Version, tcp
 	var conf string
 
 	if tidbver.TiFlashNotNeedSomeConfig(version.String()) {
-		conf = fmt.Sprintf(tiflashConfig, pdAddrs, "", tcpPort,
+		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, "", tcpPort,
 			deployDir, dataDir, tmpDir, logDir, servicePort, metricsPort,
 			ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath, "", "")
 	} else {
-		conf = fmt.Sprintf(tiflashConfig, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort), tcpPort,
+		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort), tcpPort,
 			deployDir, dataDir, tmpDir, logDir, servicePort, metricsPort,
-			ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath, tiflashDaemonConfig, tiflashMarkCacheSize)
+			ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath, tiflashDaemonConfigOld, tiflashMarkCacheSizeOld)
 	}
 	_, err := w.Write([]byte(conf))
 	return err
 }
 
-func getTiFlashProxyConfigPath(cfg map[string]any) string {
+func getTiFlashProxyConfigPathOld(cfg map[string]any) string {
 	defer func() {
 		if r := recover(); r != nil {
 			return
@@ -129,6 +130,6 @@ func getTiFlashProxyConfigPath(cfg map[string]any) string {
 	return cfg["flash"].(map[string]any)["proxy"].(map[string]any)["config"].(string)
 }
 
-func setTiFlashProxyConfigPath(cfg map[string]any, path string) {
+func setTiFlashProxyConfigPathOld(cfg map[string]any, path string) {
 	cfg["flash"].(map[string]any)["proxy"].(map[string]any)["config"] = path
 }

--- a/components/playground/instance/tiflash_pre7_proxy_config.go
+++ b/components/playground/instance/tiflash_pre7_proxy_config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
-const tiflashProxyConfig = `
+const tiflashProxyConfigOld = `
 log-file = "%[1]s/tiflash_tikv.log"
 
 [rocksdb]
@@ -46,7 +46,8 @@ data-dir = "%[6]s"
 max-open-files = 256
 `
 
-func writeTiFlashProxyConfigForStartViaConfig(w io.Writer, version utils.Version, host, deployDir string, servicePort, proxyPort, proxyStatusPort int) error {
+// writeTiFlashProxyConfigOld is for < 7.1.0. Not maintained any more. Do not introduce new features.
+func writeTiFlashProxyConfigOld(w io.Writer, version utils.Version, host, deployDir string, servicePort, proxyPort, proxyStatusPort int) error {
 	// TODO: support multi-dir
 	dataDir := fmt.Sprintf("%s/flash", deployDir)
 	logDir := fmt.Sprintf("%s/log", deployDir)
@@ -58,7 +59,7 @@ advertise-status-addr = "%[1]s:%[2]d"`, ip, proxyStatusPort)
 	} else {
 		statusAddr = fmt.Sprintf(`status-addr = "%[1]s:%[2]d"`, ip, proxyStatusPort)
 	}
-	conf := fmt.Sprintf(tiflashProxyConfig, logDir, ip, servicePort, proxyPort, statusAddr, dataDir)
+	conf := fmt.Sprintf(tiflashProxyConfigOld, logDir, ip, servicePort, proxyPort, statusAddr, dataDir)
 	_, err := w.Write([]byte(conf))
 	return err
 }

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -72,9 +72,9 @@ func TiFlashNotNeedSomeConfig(version string) bool {
 	return semver.Compare(version, "v5.4.0") >= 0 || strings.Contains(version, "nightly")
 }
 
-// TiFlashSupportRunWithoutConfig return true if the given version of TiFlash could be started without
-// a config file.
-func TiFlashSupportRunWithoutConfig(version string) bool {
+// TiFlashPlaygroundNewStartMode return true if the given version of TiFlash could be started
+// using the new implementation in TiUP playground
+func TiFlashPlaygroundNewStartMode(version string) bool {
 	return semver.Compare(version, "v7.1.0") >= 0 || strings.Contains(version, "nightly")
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

Group and move all legacy TiFlash config and start stuff into `tiflash_pre7_xxx` and name them as `xxx_old`, so that we don't need to care about them any more: we will not introduce any new features to these legacies.

The new start logic of TiFlash is very simple and it takes the place of the default start implementation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
