### PR TITLE
playground: include '--comments' in mysql command line arguments

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -925,7 +925,7 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		for _, dbAddr := range succ {
 			ss := strings.Split(dbAddr, ":")
 			fmt.Printf("Connect TiDB:   ")
-			colorCmd.Printf("mysql --host %s --port %s -u root\n", ss[0], ss[1])
+			colorCmd.Printf("mysql --comments --host %s --port %s -u root\n", ss[0], ss[1])
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #2186

### What is changed and how it works?
It just adds `--comments` to the output to be used for running the mysql command line tool.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
`./bin/tidb-playground` and verify output when cluster is ready.

Code changes
 - output text change only

Side effects

 - none

Related changes

 - none

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
