### PR TITLE
playground: Fix --tiflash 0 not working

### DIFF
--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -318,27 +318,27 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 	return rootCmd.Execute()
 }
 
-func setIfZeroInt(variable *int, defaultValue int) {
-	if *variable == 0 {
-		*variable = defaultValue
-	}
-}
-
 func populateDefaultOpt(flagSet *pflag.FlagSet) error {
 	if flagSet.Lookup("without-monitor").Changed {
 		v, _ := flagSet.GetBool("without-monitor")
 		options.Monitor = !v
 	}
 
+	defaultInt := func(variable *int, flagName string, defaultValue int) {
+		if !flagSet.Lookup(flagName).Changed {
+			*variable = defaultValue
+		}
+	}
+
 	switch options.Mode {
 	case "tidb":
-		setIfZeroInt(&options.TiDB.Num, 1)
-		setIfZeroInt(&options.TiKV.Num, 1)
-		setIfZeroInt(&options.PD.Num, 1)
-		setIfZeroInt(&options.TiFlash.Num, 1)
+		defaultInt(&options.TiDB.Num, "db", 1)
+		defaultInt(&options.TiKV.Num, "kv", 1)
+		defaultInt(&options.PD.Num, "pd", 1)
+		defaultInt(&options.TiFlash.Num, "tiflash", 1)
 	case "tikv-slim":
-		setIfZeroInt(&options.TiKV.Num, 1)
-		setIfZeroInt(&options.PD.Num, 1)
+		defaultInt(&options.TiKV.Num, "kv", 1)
+		defaultInt(&options.PD.Num, "pd", 1)
 	default:
 		return errors.Errorf("Unknown --mode %s", options.Mode)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently `--tiflash 0` is not working because we treat 0 as default value and 0 is discarded.

### What is changed and how it works?

We use `.Changed` to check whether an option is set.

(Or may be some better way is to use `*int` instead? I'm not sure).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
