### PR TITLE
skip destroy monitor when ignore_exporter is true

### DIFF
--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -241,6 +241,9 @@ func DeletePublicKey(ctx context.Context, host string) error {
 
 // DestroyMonitored destroy the monitored service.
 func DestroyMonitored(ctx context.Context, inst spec.Instance, options *spec.MonitoredOptions, timeout uint64) error {
+	if inst.IgnoreMonitorAgent(){
+		return nil
+	}
 	e := ctxt.GetInner(ctx).Get(inst.GetManageHost())
 	logger := ctx.Value(logprinter.ContextKeyLogger).(*logprinter.Logger)
 


### PR DESCRIPTION
当我们设置`ignore_exporter: true'时，tiup不应该破坏节点导出器，因为它从未被部署过。