### PR TITLE
progress: Add option to add error detail

### DIFF
--- a/pkg/tui/progress/display_props.go
+++ b/pkg/tui/progress/display_props.go
@@ -96,6 +96,7 @@ type DisplayProps struct {
 	Prefix string `json:"prefix,omitempty"`
 	Suffix string `json:"suffix,omitempty"` // If `Mode == Done / Error`, Suffix is not printed
 	Mode   Mode   `json:"mode,omitempty"`
+	Detail string `json:"detail,omitempty"`
 }
 
 // String implements string

--- a/pkg/tui/progress/example_single_bar_test.go
+++ b/pkg/tui/progress/example_single_bar_test.go
@@ -1,6 +1,7 @@
 package progress_test
 
 import (
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -42,9 +43,44 @@ func ExampleSingleBar() {
 	b.StopRenderLoop()
 }
 
+func ExampleSingleBar_err() {
+	b := progress.NewSingleBar("Prefix")
+
+	b.UpdateDisplay(&progress.DisplayProps{
+		Prefix: "Prefix",
+		Suffix: "Suffix",
+	})
+
+	n := 3
+
+	go func() {
+		time.Sleep(time.Second)
+		for i := 0; i < n; i++ {
+			b.UpdateDisplay(&progress.DisplayProps{
+				Prefix: "Prefix" + strconv.Itoa(i),
+				Suffix: "Suffix" + strconv.Itoa(i),
+			})
+			time.Sleep(time.Second)
+		}
+	}()
+
+	b.StartRenderLoop()
+
+	time.Sleep(time.Second * time.Duration(n+1))
+
+	b.UpdateDisplay(&progress.DisplayProps{
+		Mode:   progress.ModeError,
+		Prefix: "Prefix",
+		Detail: errors.New("expected failure").Error(),
+	})
+
+	b.StopRenderLoop()
+}
+
 func TestExampleOutput(t *testing.T) {
 	if !testing.Verbose() {
 		return
 	}
 	ExampleSingleBar()
+	ExampleSingleBar_err()
 }

--- a/pkg/tui/progress/single_bar.go
+++ b/pkg/tui/progress/single_bar.go
@@ -31,7 +31,7 @@ type singleBarCore struct {
 
 func (b *singleBarCore) renderDoneOrError(w io.Writer, dp *DisplayProps) {
 	width := int(termSizeWidth.Load())
-	var tail string
+	var tail, detail string
 	var tailColor *color.Color
 	switch dp.Mode {
 	case ModeDone:
@@ -51,7 +51,10 @@ func (b *singleBarCore) renderDoneOrError(w io.Writer, dp *DisplayProps) {
 	} else {
 		displayPrefix = runewidth.Truncate(dp.Prefix, width-prefixWidth, "")
 	}
-	_, _ = fmt.Fprintf(w, "%s ... %s", displayPrefix, tailColor.Sprint(tail))
+	if len(dp.Detail) > 0 {
+		detail = ": " + dp.Detail
+	}
+	_, _ = fmt.Fprintf(w, "%s ... %s%s", displayPrefix, tailColor.Sprint(tail), detail)
 }
 
 func (b *singleBarCore) renderSpinner(w io.Writer, dp *DisplayProps) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
$ go test -v
=== RUN   TestExampleOutput
Prefix ... Done
Prefix ... Error: expected failure
--- PASS: TestExampleOutput (8.00s)
PASS
ok  	github.com/pingcap/tiup/pkg/tui/progress	8.004s
```

This could be helpful to add more detail to Clinic:
![image](https://github.com/pingcap/tiup/assets/1272980/400e57cd-90b9-4d3e-8922-a968f2edc97e)


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
