### PR TITLE
Revert "*: remove tcp_port for tiflash (#2218)"

### DIFF
--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -51,6 +51,7 @@ type TiFlashInstance struct {
 	instance
 	Role            TiFlashRole
 	DisaggOpts      DisaggOptions
+	TCPPort         int
 	ServicePort     int
 	ProxyPort       int
 	ProxyStatusPort int
@@ -81,6 +82,7 @@ func NewTiFlashInstance(role TiFlashRole, disaggOptions DisaggOptions, binPath, 
 		},
 		Role:            role,
 		DisaggOpts:      disaggOptions,
+		TCPPort:         utils.MustGetFreePort(host, 9100), // 9000 for default object store port
 		ServicePort:     utils.MustGetFreePort(host, 3930),
 		ProxyPort:       utils.MustGetFreePort(host, 20170),
 		ProxyStatusPort: utils.MustGetFreePort(host, 20292),
@@ -136,6 +138,7 @@ func (inst *TiFlashInstance) Start(ctx context.Context, version utils.Version) e
 		fmt.Sprintf("--tmp_path=%s", filepath.Join(inst.Dir, "tmp")),
 		fmt.Sprintf("--path=%s", filepath.Join(inst.Dir, "data")),
 		fmt.Sprintf("--listen_host=%s", inst.Host),
+		fmt.Sprintf("--tcp_port=%d", inst.TCPPort),
 		fmt.Sprintf("--logger.log=%s", inst.LogFile()),
 		fmt.Sprintf("--logger.errorlog=%s", filepath.Join(inst.Dir, "tiflash_error.log")),
 		fmt.Sprintf("--status.metrics_port=%d", inst.StatusPort),

--- a/components/playground/instance/tiflash_pre7.go
+++ b/components/playground/instance/tiflash_pre7.go
@@ -146,7 +146,7 @@ func (inst *TiFlashInstance) checkConfigOld(deployDir, clusterManagerPath string
 	}()
 
 	// Write default config to buffer
-	if err := writeTiFlashConfigOld(flashBuf, version, inst.Port, inst.ServicePort, inst.StatusPort,
+	if err := writeTiFlashConfigOld(flashBuf, version, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
 		inst.Host, deployDir, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {
 		return errors.Trace(err)
 	}

--- a/components/playground/instance/tiflash_pre7_config.go
+++ b/components/playground/instance/tiflash_pre7_config.go
@@ -36,27 +36,28 @@ default_profile = "default"
 display_name = "TiFlash"
 %[2]s
 listen_host = "0.0.0.0"
-path = "%[4]s"
-tmp_path = "%[5]s"
+path = "%[5]s"
+tcp_port = %[3]d
+tmp_path = "%[6]s"
+%[14]s
 %[13]s
-%[12]s
 [flash]
-service_addr = "%[9]s:%[7]d"
-tidb_status_addr = "%[10]s"
+service_addr = "%[10]s:%[8]d"
+tidb_status_addr = "%[11]s"
 [flash.flash_cluster]
-cluster_manager_path = "%[11]s"
-log = "%[6]s/tiflash_cluster_manager.log"
+cluster_manager_path = "%[12]s"
+log = "%[7]s/tiflash_cluster_manager.log"
 master_ttl = 60
 refresh_interval = 20
 update_rule_interval = 5
 [flash.proxy]
-config = "%[3]s/tiflash-learner.toml"
+config = "%[4]s/tiflash-learner.toml"
 
 [logger]
 count = 20
-errorlog = "%[6]s/tiflash_error.log"
+errorlog = "%[7]s/tiflash_error.log"
 level = "debug"
-log = "%[6]s/tiflash.log"
+log = "%[7]s/tiflash.log"
 size = "1000M"
 
 [profiles]
@@ -81,7 +82,7 @@ result_rows = 0
 pd_addr = "%[1]s"
 
 [status]
-metrics_port = %[8]d
+metrics_port = %[9]d
 
 [users]
 [users.default]
@@ -99,7 +100,7 @@ ip = "::/0"
 `
 
 // writeTiFlashConfigOld is for < 7.1.0. Not maintained any more. Do not introduce new features.
-func writeTiFlashConfigOld(w io.Writer, version utils.Version, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
+func writeTiFlashConfigOld(w io.Writer, version utils.Version, tcpPort, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
 	pdAddrs := strings.Join(endpoints, ",")
 	dataDir := fmt.Sprintf("%s/data", deployDir)
 	tmpDir := fmt.Sprintf("%s/tmp", deployDir)
@@ -108,11 +109,11 @@ func writeTiFlashConfigOld(w io.Writer, version utils.Version, httpPort, service
 	var conf string
 
 	if tidbver.TiFlashNotNeedSomeConfig(version.String()) {
-		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort),
+		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort), tcpPort,
 			deployDir, dataDir, tmpDir, logDir, servicePort, metricsPort,
 			ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath, "", "")
 	} else {
-		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort),
+		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort), tcpPort,
 			deployDir, dataDir, tmpDir, logDir, servicePort, metricsPort,
 			ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath, tiflashDaemonConfigOld, tiflashMarkCacheSizeOld)
 	}

--- a/embed/examples/cluster/minimal.yaml
+++ b/embed/examples/cluster/minimal.yaml
@@ -181,6 +181,8 @@ tiflash_servers:
   - host: 10.0.1.20
     # # SSH port of the server.
     # ssh_port: 22
+    # # TiFlash TCP Service port.
+    # tcp_port: 9000
     # # TiFlash raft service and coprocessor service listening address.
     # flash_service_port: 3930
     # # TiFlash Proxy service port.
@@ -202,6 +204,7 @@ tiflash_servers:
   # # The ip address of the TiKV Server.
   - host: 10.0.1.21
     # ssh_port: 22
+    # tcp_port: 9000
     # flash_service_port: 3930
     # flash_proxy_port: 20170
     # flash_proxy_status_port: 20292

--- a/embed/examples/cluster/multi-dc.yaml
+++ b/embed/examples/cluster/multi-dc.yaml
@@ -234,6 +234,8 @@ tiflash_servers:
   - host: 10.0.1.24
     # # SSH port of the server.
     # ssh_port: 22
+    # # TiFlash TCP Service port.
+    # tcp_port: 9000
     # # TiFlash raft service and coprocessor service listening address.
     # flash_service_port: 3930
     # # TiFlash Proxy service port.
@@ -254,6 +256,7 @@ tiflash_servers:
     # log_dir: /tidb-deploy/tiflash-9000/log
   - host: 10.0.1.25
     # ssh_port: 22
+    # tcp_port: 9000
     # flash_service_port: 3930
     # flash_proxy_port: 20170
     # flash_proxy_status_port: 20292

--- a/embed/examples/cluster/topology.example.yaml
+++ b/embed/examples/cluster/topology.example.yaml
@@ -223,6 +223,8 @@ tiflash_servers:
   - host: 10.0.1.19
     # # SSH port of the server.
     # ssh_port: 22
+    # # TiFlash TCP Service port.
+    tcp_port: 9000
     # # TiFlash raft service and coprocessor service listening address.
     flash_service_port: 3930
     # # TiFlash Proxy service port.
@@ -243,6 +245,7 @@ tiflash_servers:
     log_dir: /data1/tidb-deploy/tiflash-9000/log
   - host: 10.0.1.19
     # ssh_port: 22
+    tcp_port: 9001
     flash_service_port: 3931
     flash_proxy_port: 20171
     flash_proxy_status_port: 20293
@@ -252,6 +255,7 @@ tiflash_servers:
     log_dir: /data2/tidb-deploy/tiflash-9001/log
   - host: 10.0.1.20
     # ssh_port: 22
+    tcp_port: 9000
     flash_service_port: 3930
     flash_proxy_port: 20170
     flash_proxy_status_port: 20292
@@ -261,6 +265,7 @@ tiflash_servers:
     log_dir: /data1/tidb-deploy/tiflash-9000/log
   - host: 10.0.1.20
     # ssh_port: 22
+    tcp_port: 9001
     flash_service_port: 3931
     flash_proxy_port: 20171
     flash_proxy_status_port: 20293

--- a/pkg/cluster/ansible/inventory.go
+++ b/pkg/cluster/ansible/inventory.go
@@ -325,6 +325,9 @@ func parseGroupVars(ctx context.Context, dir, ansCfgFile string, clsMeta *spec.C
 				OS:       "linux",
 			}
 
+			if tcpPort, ok := grpVars["tcp_port"]; ok {
+				tmpIns.TCPPort, _ = strconv.Atoi(tcpPort)
+			}
 			if !tidbver.TiFlashNotNeedHTTPPortConfig(clsMeta.Version) {
 				if httpPort, ok := grpVars["http_port"]; ok {
 					tmpIns.HTTPPort, _ = strconv.Atoi(httpPort)
@@ -344,6 +347,9 @@ func parseGroupVars(ctx context.Context, dir, ansCfgFile string, clsMeta *spec.C
 			}
 
 			// apply values from the host
+			if tcpPort, ok := srv.Vars["tcp_port"]; ok {
+				tmpIns.TCPPort, _ = strconv.Atoi(tcpPort)
+			}
 			if !tidbver.TiFlashNotNeedHTTPPortConfig(clsMeta.Version) {
 				if httpPort, ok := srv.Vars["http_port"]; ok {
 					tmpIns.HTTPPort, _ = strconv.Atoi(httpPort)

--- a/pkg/cluster/ansible/service_test.go
+++ b/pkg/cluster/ansible/service_test.go
@@ -23,6 +23,7 @@ default_profile = "default"
 display_name = "TiFlash"
 listen_host = "0.0.0.0"
 path = "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db"
+tcp_port = 11315
 tmp_path = "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db/tmp"
 
 [flash]

--- a/pkg/cluster/ansible/test-data/meta.yaml
+++ b/pkg/cluster/ansible/test-data/meta.yaml
@@ -76,6 +76,7 @@ topology:
     - host: 172.16.1.222
       ssh_port: 9999
       imported: true
+      tcp_port: 9000
       flash_service_port: 3930
       flash_proxy_port: 20170
       flash_proxy_status_port: 20292
@@ -87,6 +88,7 @@ topology:
     - host: 172.16.1.223
       ssh_port: 30000
       imported: true
+      tcp_port: 9000
       flash_service_port: 3930
       flash_proxy_port: 20170
       flash_proxy_status_port: 20292

--- a/pkg/cluster/spec/testdata/topology_err.yaml
+++ b/pkg/cluster/spec/testdata/topology_err.yaml
@@ -100,6 +100,7 @@ tikv_servers:
 # tiflash_servers:
 #   - host: 10.0.1.10
 #     ssh_port: 22
+#     tcp_port: 9000
 #     flash_service_port: 3930
 #     flash_proxy_port: 20170
 #     flash_proxy_status_port: 20292

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -46,7 +46,7 @@ type TiFlashSpec struct {
 	Imported             bool                 `yaml:"imported,omitempty"`
 	Patched              bool                 `yaml:"patched,omitempty"`
 	IgnoreExporter       bool                 `yaml:"ignore_exporter,omitempty"`
-	TCPPort              int                  `yaml:"tcp_port" default:"9000"`  // Deprecated since v7.2.0
+	TCPPort              int                  `yaml:"tcp_port" default:"9000"`
 	HTTPPort             int                  `yaml:"http_port" default:"8123"` // Deprecated since v7.1.0
 	FlashServicePort     int                  `yaml:"flash_service_port" default:"3930"`
 	FlashProxyPort       int                  `yaml:"flash_proxy_port" default:"20170"`

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -623,6 +623,7 @@ func (s *Specification) portConflictsDetect() error {
 		"PeerPort",
 		"ClientPort",
 		"WebPort",
+		"TCPPort",
 		"HTTPPort",
 		"FlashServicePort",
 		"FlashProxyPort",

--- a/pkg/telemetry/testdata/single/nilvalue.yaml
+++ b/pkg/telemetry/testdata/single/nilvalue.yaml
@@ -38,6 +38,7 @@ tikv_servers:
 
 tiflash_servers:
   - host: 172.19.0.101
+    tcp_port: 19000
     flash_service_port: 13930
     flash_proxy_port: 10170
     flash_proxy_status_port: 10292


### PR DESCRIPTION
This reverts commit a236734c7cd91fff4912e6d1d064a19c7ac27432.

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
