### PR TITLE
*: remove tcp_port for tiflash >= 7.1.0

### DIFF
--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -51,6 +51,7 @@ type TiFlashInstance struct {
 	instance
 	Role            TiFlashRole
 	DisaggOpts      DisaggOptions
+	TCPPort         int
 	ServicePort     int
 	ProxyPort       int
 	ProxyStatusPort int
@@ -81,6 +82,7 @@ func NewTiFlashInstance(role TiFlashRole, disaggOptions DisaggOptions, binPath, 
 		},
 		Role:            role,
 		DisaggOpts:      disaggOptions,
+		TCPPort:         utils.MustGetFreePort(host, 9100), // 9000 for default object store port
 		ServicePort:     utils.MustGetFreePort(host, 3930),
 		ProxyPort:       utils.MustGetFreePort(host, 20170),
 		ProxyStatusPort: utils.MustGetFreePort(host, 20292),

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -51,7 +51,6 @@ type TiFlashInstance struct {
 	instance
 	Role            TiFlashRole
 	DisaggOpts      DisaggOptions
-	TCPPort         int
 	ServicePort     int
 	ProxyPort       int
 	ProxyStatusPort int
@@ -82,7 +81,6 @@ func NewTiFlashInstance(role TiFlashRole, disaggOptions DisaggOptions, binPath, 
 		},
 		Role:            role,
 		DisaggOpts:      disaggOptions,
-		TCPPort:         utils.MustGetFreePort(host, 9100), // 9000 for default object store port
 		ServicePort:     utils.MustGetFreePort(host, 3930),
 		ProxyPort:       utils.MustGetFreePort(host, 20170),
 		ProxyStatusPort: utils.MustGetFreePort(host, 20292),
@@ -138,7 +136,6 @@ func (inst *TiFlashInstance) Start(ctx context.Context, version utils.Version) e
 		fmt.Sprintf("--tmp_path=%s", filepath.Join(inst.Dir, "tmp")),
 		fmt.Sprintf("--path=%s", filepath.Join(inst.Dir, "data")),
 		fmt.Sprintf("--listen_host=%s", inst.Host),
-		fmt.Sprintf("--tcp_port=%d", inst.TCPPort),
 		fmt.Sprintf("--logger.log=%s", inst.LogFile()),
 		fmt.Sprintf("--logger.errorlog=%s", filepath.Join(inst.Dir, "tiflash_error.log")),
 		fmt.Sprintf("--status.metrics_port=%d", inst.StatusPort),

--- a/components/playground/instance/tiflash_pre7.go
+++ b/components/playground/instance/tiflash_pre7.go
@@ -146,7 +146,7 @@ func (inst *TiFlashInstance) checkConfigOld(deployDir, clusterManagerPath string
 	}()
 
 	// Write default config to buffer
-	if err := writeTiFlashConfigOld(flashBuf, version, inst.Port, inst.ServicePort, inst.StatusPort,
+	if err := writeTiFlashConfigOld(flashBuf, version, inst.Port, inst.TCPPort, inst.ServicePort, inst.StatusPort,
 		inst.Host, deployDir, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {
 		return errors.Trace(err)
 	}

--- a/components/playground/instance/tiflash_pre7.go
+++ b/components/playground/instance/tiflash_pre7.go
@@ -146,7 +146,7 @@ func (inst *TiFlashInstance) checkConfigOld(deployDir, clusterManagerPath string
 	}()
 
 	// Write default config to buffer
-	if err := writeTiFlashConfigOld(flashBuf, version, inst.Port, inst.TCPPort, inst.ServicePort, inst.StatusPort,
+	if err := writeTiFlashConfigOld(flashBuf, version, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
 		inst.Host, deployDir, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {
 		return errors.Trace(err)
 	}

--- a/components/playground/instance/tiflash_pre7.go
+++ b/components/playground/instance/tiflash_pre7.go
@@ -146,7 +146,7 @@ func (inst *TiFlashInstance) checkConfigOld(deployDir, clusterManagerPath string
 	}()
 
 	// Write default config to buffer
-	if err := writeTiFlashConfigOld(flashBuf, version, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
+	if err := writeTiFlashConfigOld(flashBuf, version, inst.Port, inst.ServicePort, inst.StatusPort,
 		inst.Host, deployDir, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {
 		return errors.Trace(err)
 	}

--- a/components/playground/instance/tiflash_pre7_config.go
+++ b/components/playground/instance/tiflash_pre7_config.go
@@ -34,29 +34,30 @@ const tiflashMarkCacheSizeOld = `mark_cache_size = 5368709120`
 const tiflashConfigOld = `
 default_profile = "default"
 display_name = "TiFlash"
-%[2]s
+http_port = %[2]d
+tcp_port = %[3]d
 listen_host = "0.0.0.0"
-path = "%[4]s"
-tmp_path = "%[5]s"
+path = "%[5]s"
+tmp_path = "%[6]s"
+%[14]s
 %[13]s
-%[12]s
 [flash]
-service_addr = "%[9]s:%[7]d"
-tidb_status_addr = "%[10]s"
+service_addr = "%[10]s:%[8]d"
+tidb_status_addr = "%[11]s"
 [flash.flash_cluster]
-cluster_manager_path = "%[11]s"
-log = "%[6]s/tiflash_cluster_manager.log"
+cluster_manager_path = "%[12]s"
+log = "%[7]s/tiflash_cluster_manager.log"
 master_ttl = 60
 refresh_interval = 20
 update_rule_interval = 5
 [flash.proxy]
-config = "%[3]s/tiflash-learner.toml"
+config = "%[4]s/tiflash-learner.toml"
 
 [logger]
 count = 20
-errorlog = "%[6]s/tiflash_error.log"
+errorlog = "%[7]s/tiflash_error.log"
 level = "debug"
-log = "%[6]s/tiflash.log"
+log = "%[7]s/tiflash.log"
 size = "1000M"
 
 [profiles]
@@ -81,7 +82,7 @@ result_rows = 0
 pd_addr = "%[1]s"
 
 [status]
-metrics_port = %[8]d
+metrics_port = %[9]d
 
 [users]
 [users.default]
@@ -99,7 +100,7 @@ ip = "::/0"
 `
 
 // writeTiFlashConfigOld is for < 7.1.0. Not maintained any more. Do not introduce new features.
-func writeTiFlashConfigOld(w io.Writer, version utils.Version, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
+func writeTiFlashConfigOld(w io.Writer, version utils.Version, tcpPort, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
 	pdAddrs := strings.Join(endpoints, ",")
 	dataDir := fmt.Sprintf("%s/data", deployDir)
 	tmpDir := fmt.Sprintf("%s/tmp", deployDir)
@@ -108,11 +109,11 @@ func writeTiFlashConfigOld(w io.Writer, version utils.Version, httpPort, service
 	var conf string
 
 	if tidbver.TiFlashNotNeedSomeConfig(version.String()) {
-		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort),
+		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, httpPort, tcpPort,
 			deployDir, dataDir, tmpDir, logDir, servicePort, metricsPort,
 			ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath, "", "")
 	} else {
-		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort),
+		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, httpPort, tcpPort,
 			deployDir, dataDir, tmpDir, logDir, servicePort, metricsPort,
 			ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath, tiflashDaemonConfigOld, tiflashMarkCacheSizeOld)
 	}

--- a/components/playground/instance/tiflash_pre7_config.go
+++ b/components/playground/instance/tiflash_pre7_config.go
@@ -35,8 +35,8 @@ const tiflashConfigOld = `
 default_profile = "default"
 display_name = "TiFlash"
 http_port = %[2]d
-tcp_port = %[3]d
 listen_host = "0.0.0.0"
+tcp_port = %[3]d
 path = "%[5]s"
 tmp_path = "%[6]s"
 %[14]s

--- a/components/playground/instance/tiflash_pre7_config.go
+++ b/components/playground/instance/tiflash_pre7_config.go
@@ -36,28 +36,27 @@ default_profile = "default"
 display_name = "TiFlash"
 %[2]s
 listen_host = "0.0.0.0"
-path = "%[5]s"
-tcp_port = %[3]d
-tmp_path = "%[6]s"
-%[14]s
+path = "%[4]s"
+tmp_path = "%[5]s"
 %[13]s
+%[12]s
 [flash]
-service_addr = "%[10]s:%[8]d"
-tidb_status_addr = "%[11]s"
+service_addr = "%[9]s:%[7]d"
+tidb_status_addr = "%[10]s"
 [flash.flash_cluster]
-cluster_manager_path = "%[12]s"
-log = "%[7]s/tiflash_cluster_manager.log"
+cluster_manager_path = "%[11]s"
+log = "%[6]s/tiflash_cluster_manager.log"
 master_ttl = 60
 refresh_interval = 20
 update_rule_interval = 5
 [flash.proxy]
-config = "%[4]s/tiflash-learner.toml"
+config = "%[3]s/tiflash-learner.toml"
 
 [logger]
 count = 20
-errorlog = "%[7]s/tiflash_error.log"
+errorlog = "%[6]s/tiflash_error.log"
 level = "debug"
-log = "%[7]s/tiflash.log"
+log = "%[6]s/tiflash.log"
 size = "1000M"
 
 [profiles]
@@ -82,7 +81,7 @@ result_rows = 0
 pd_addr = "%[1]s"
 
 [status]
-metrics_port = %[9]d
+metrics_port = %[8]d
 
 [users]
 [users.default]
@@ -100,7 +99,7 @@ ip = "::/0"
 `
 
 // writeTiFlashConfigOld is for < 7.1.0. Not maintained any more. Do not introduce new features.
-func writeTiFlashConfigOld(w io.Writer, version utils.Version, tcpPort, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
+func writeTiFlashConfigOld(w io.Writer, version utils.Version, httpPort, servicePort, metricsPort int, host, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
 	pdAddrs := strings.Join(endpoints, ",")
 	dataDir := fmt.Sprintf("%s/data", deployDir)
 	tmpDir := fmt.Sprintf("%s/tmp", deployDir)
@@ -109,11 +108,11 @@ func writeTiFlashConfigOld(w io.Writer, version utils.Version, tcpPort, httpPort
 	var conf string
 
 	if tidbver.TiFlashNotNeedSomeConfig(version.String()) {
-		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort), tcpPort,
+		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort),
 			deployDir, dataDir, tmpDir, logDir, servicePort, metricsPort,
 			ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath, "", "")
 	} else {
-		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort), tcpPort,
+		conf = fmt.Sprintf(tiflashConfigOld, pdAddrs, fmt.Sprintf(`http_port = %d`, httpPort),
 			deployDir, dataDir, tmpDir, logDir, servicePort, metricsPort,
 			ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath, tiflashDaemonConfigOld, tiflashMarkCacheSizeOld)
 	}

--- a/embed/examples/cluster/minimal.yaml
+++ b/embed/examples/cluster/minimal.yaml
@@ -182,6 +182,7 @@ tiflash_servers:
     # # SSH port of the server.
     # ssh_port: 22
     # # TiFlash TCP Service port.
+    # # Since 7.1.0, it is not actually listened, and only being used as part of the instance identity.
     # tcp_port: 9000
     # # TiFlash raft service and coprocessor service listening address.
     # flash_service_port: 3930

--- a/embed/examples/cluster/multi-dc.yaml
+++ b/embed/examples/cluster/multi-dc.yaml
@@ -235,6 +235,7 @@ tiflash_servers:
     # # SSH port of the server.
     # ssh_port: 22
     # # TiFlash TCP Service port.
+    # # Since 7.1.0, it is not actually listened, and only being used as part of the instance identity.
     # tcp_port: 9000
     # # TiFlash raft service and coprocessor service listening address.
     # flash_service_port: 3930

--- a/embed/examples/cluster/topology.example.yaml
+++ b/embed/examples/cluster/topology.example.yaml
@@ -224,6 +224,7 @@ tiflash_servers:
     # # SSH port of the server.
     # ssh_port: 22
     # # TiFlash TCP Service port.
+    # # Since 7.1.0, it is not actually listened, and only being used as part of the instance identity.
     tcp_port: 9000
     # # TiFlash raft service and coprocessor service listening address.
     flash_service_port: 3930

--- a/pkg/cluster/ansible/service_test.go
+++ b/pkg/cluster/ansible/service_test.go
@@ -23,7 +23,6 @@ default_profile = "default"
 display_name = "TiFlash"
 listen_host = "0.0.0.0"
 path = "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db"
-tcp_port = 11315
 tmp_path = "/data1/test-cluster/leiysky-ansible-test-deploy/tiflash/data/db/tmp"
 
 [flash]

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -486,6 +486,11 @@ func (i *TiFlashInstance) initTiFlashConfig(ctx context.Context, clusterVersion 
 			httpPort = fmt.Sprintf(`http_port: %d`, spec.HTTPPort)
 		}
 	}
+	tcpPort := "#"
+	// Config tcp_port is only required for TiFlash version < 7.1.0, and is recommended to not specify for TiFlash version >= 7.1.0.
+	if tidbver.TiFlashRequiresTCPPortConfig(clusterVersion) {
+		tcpPort = fmt.Sprintf(`tcp_port: %d`, spec.TCPPort)
+	}
 
 	// set TLS configs
 	spec.Config, err = i.setTLSConfig(ctx, enableTLS, spec.Config, paths)
@@ -511,7 +516,7 @@ server_configs:
     listen_host: "%[7]s"
     tmp_path: "%[11]s"
     %[1]s
-    tcp_port: %[3]d
+    %[3]s
     %[4]s
     flash.tidb_status_addr: "%[5]s"
     flash.service_addr: "%[6]s"
@@ -535,7 +540,7 @@ server_configs:
 `,
 		pathConfig,
 		paths.Log,
-		spec.TCPPort,
+		tcpPort,
 		httpPort,
 		strings.Join(tidbStatusAddrs, ","),
 		utils.JoinHostPort(spec.Host, spec.FlashServicePort),

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -66,6 +66,15 @@ func TiFlashNotNeedHTTPPortConfig(version string) bool {
 	return semver.Compare(version, "v7.1.0") >= 0 || strings.Contains(version, "nightly")
 }
 
+// TiFlashRequiresTCPPortConfig return if given version of TiFlash requires tcp_port config.
+// TiFlash 7.1.0 and later versions won't listen to tpc_port if the config is not given, which is recommended.
+// However this config is required for pre-7.1.0 versions because TiFlash will listen to it anyway,
+// and we must make sure the port is being configured as specified in the topology file,
+// otherwise multiple TiFlash instances will conflict.
+func TiFlashRequiresTCPPortConfig(version string) bool {
+	return semver.Compare(version, "v7.1.0") < 0
+}
+
 // TiFlashNotNeedSomeConfig return if given version of TiFlash do not need some config like runAsDaemon
 func TiFlashNotNeedSomeConfig(version string) bool {
 	// https://github.com/pingcap/tiup/pull/1673


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Remove tiflash tcp_port config for tiflash >= 7.1.0.

### What is changed and how it works?
1. For playground, remove tcp_port for tiflash < 7.1.0, as there are no compatibility and instance identity issues.
2. For ansibile and cluster, not render tcp_port config in tiflash config file for tiflash >= 7.1.0.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

Code changes
 - Has exported function/method change

Side effects
 - None

Related changes
 - None


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
