### PR TITLE
playground: support microservices mode

### DIFF
--- a/components/playground/command.go
+++ b/components/playground/command.go
@@ -102,7 +102,6 @@ func newScaleOut() *cobra.Command {
 	cmd.Flags().IntVarP(&opt.TiKVCDC.Num, "kvcdc", "", opt.TiKVCDC.Num, "TiKV-CDC instance number")
 	cmd.Flags().IntVarP(&opt.Pump.Num, "pump", "", opt.Pump.Num, "Pump instance number")
 	cmd.Flags().IntVarP(&opt.Drainer.Num, "drainer", "", opt.Pump.Num, "Drainer instance number")
-
 	cmd.Flags().StringVarP(&opt.TiDB.Host, "db.host", "", opt.TiDB.Host, "Playground TiDB host. If not provided, TiDB will still use `host` flag as its host")
 	cmd.Flags().StringVarP(&opt.PD.Host, "pd.host", "", opt.PD.Host, "Playground PD host. If not provided, PD will still use `host` flag as its host")
 

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -109,6 +109,9 @@ func logIfErr(err error) {
 func pdEndpoints(pds []*PDInstance, isHTTP bool) []string {
 	var endpoints []string
 	for _, pd := range pds {
+		if pd.Role == PDRoleTSO {
+			continue
+		}
 		if isHTTP {
 			endpoints = append(endpoints, "http://"+utils.JoinHostPort(AdvertiseHost(pd.Host), pd.StatusPort))
 		} else {

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -109,7 +109,7 @@ func logIfErr(err error) {
 func pdEndpoints(pds []*PDInstance, isHTTP bool) []string {
 	var endpoints []string
 	for _, pd := range pds {
-		if pd.Role == PDRoleTSO {
+		if pd.Role == PDRoleTSO || pd.Role == PDRoleResourceManager {
 			continue
 		}
 		if isHTTP {

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -163,7 +163,10 @@ func (inst *PDInstance) Start(ctx context.Context, version utils.Version) error 
 
 // Component return the component name.
 func (inst *PDInstance) Component() string {
-	return string(inst.Role)
+	if inst.Role == PDRoleNormal {
+		return "pd"
+	}
+	return fmt.Sprintf("pd %s", inst.Role)
 }
 
 // LogFile return the log file.

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -24,16 +24,32 @@ import (
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
+// PDRole is the role of PD.
+type PDRole string
+
+const (
+	// PDRoleNormal is the default role of PD
+	PDRoleNormal PDRole = "pd"
+	// PDRoleAPI is the role of PD API
+	PDRoleAPI PDRole = "api"
+	// PDRoleTSO is the role of PD TSO
+	PDRoleTSO PDRole = "tso"
+	// PDRoleResourceManager is the role of PD resource manager
+	PDRoleResourceManager PDRole = "resource manager"
+)
+
 // PDInstance represent a running pd-server
 type PDInstance struct {
 	instance
+	Role          PDRole
 	initEndpoints []*PDInstance
 	joinEndpoints []*PDInstance
+	pds           []*PDInstance
 	Process
 }
 
 // NewPDInstance return a PDInstance
-func NewPDInstance(binPath, dir, host, configPath string, id, port int) *PDInstance {
+func NewPDInstance(role PDRole, binPath, dir, host, configPath string, id int, pds []*PDInstance, port int) *PDInstance {
 	if port <= 0 {
 		port = 2379
 	}
@@ -47,6 +63,8 @@ func NewPDInstance(binPath, dir, host, configPath string, id, port int) *PDInsta
 			StatusPort: utils.MustGetFreePort(host, port),
 			ConfigPath: configPath,
 		},
+		Role: role,
+		pds:  pds,
 	}
 }
 
@@ -70,35 +88,67 @@ func (inst *PDInstance) Name() string {
 // Start calls set inst.cmd and Start
 func (inst *PDInstance) Start(ctx context.Context, version utils.Version) error {
 	uid := inst.Name()
-	args := []string{
-		"--name=" + uid,
-		fmt.Sprintf("--data-dir=%s", filepath.Join(inst.Dir, "data")),
-		fmt.Sprintf("--peer-urls=http://%s", utils.JoinHostPort(inst.Host, inst.Port)),
-		fmt.Sprintf("--advertise-peer-urls=http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.Port)),
-		fmt.Sprintf("--client-urls=http://%s", utils.JoinHostPort(inst.Host, inst.StatusPort)),
-		fmt.Sprintf("--advertise-client-urls=http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.StatusPort)),
-		fmt.Sprintf("--log-file=%s", inst.LogFile()),
-	}
-	if inst.ConfigPath != "" {
-		args = append(args, fmt.Sprintf("--config=%s", inst.ConfigPath))
-	}
-
-	switch {
-	case len(inst.initEndpoints) > 0:
-		endpoints := make([]string, 0)
-		for _, pd := range inst.initEndpoints {
-			uid := fmt.Sprintf("pd-%d", pd.ID)
-			endpoints = append(endpoints, fmt.Sprintf("%s=http://%s", uid, utils.JoinHostPort(AdvertiseHost(inst.Host), pd.Port)))
+	var args []string
+	switch inst.Role {
+	case PDRoleNormal, PDRoleAPI:
+		if inst.Role == PDRoleAPI {
+			args = []string{"services", "api"}
 		}
-		args = append(args, fmt.Sprintf("--initial-cluster=%s", strings.Join(endpoints, ",")))
-	case len(inst.joinEndpoints) > 0:
-		endpoints := make([]string, 0)
-		for _, pd := range inst.joinEndpoints {
-			endpoints = append(endpoints, fmt.Sprintf("http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), pd.Port)))
+		args = append(args, []string{
+			"--name=" + uid,
+			fmt.Sprintf("--data-dir=%s", filepath.Join(inst.Dir, "data")),
+			fmt.Sprintf("--peer-urls=http://%s", utils.JoinHostPort(inst.Host, inst.Port)),
+			fmt.Sprintf("--advertise-peer-urls=http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.Port)),
+			fmt.Sprintf("--client-urls=http://%s", utils.JoinHostPort(inst.Host, inst.StatusPort)),
+			fmt.Sprintf("--advertise-client-urls=http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.StatusPort)),
+			fmt.Sprintf("--log-file=%s", inst.LogFile()),
+		}...)
+		if inst.ConfigPath != "" {
+			args = append(args, fmt.Sprintf("--config=%s", inst.ConfigPath))
 		}
-		args = append(args, fmt.Sprintf("--join=%s", strings.Join(endpoints, ",")))
-	default:
-		return errors.Errorf("must set the init or join instances")
+		switch {
+		case len(inst.initEndpoints) > 0:
+			endpoints := make([]string, 0)
+			for _, pd := range inst.initEndpoints {
+				uid := fmt.Sprintf("pd-%d", pd.ID)
+				endpoints = append(endpoints, fmt.Sprintf("%s=http://%s", uid, utils.JoinHostPort(AdvertiseHost(inst.Host), pd.Port)))
+			}
+			args = append(args, fmt.Sprintf("--initial-cluster=%s", strings.Join(endpoints, ",")))
+		case len(inst.joinEndpoints) > 0:
+			endpoints := make([]string, 0)
+			for _, pd := range inst.joinEndpoints {
+				endpoints = append(endpoints, fmt.Sprintf("http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), pd.Port)))
+			}
+			args = append(args, fmt.Sprintf("--join=%s", strings.Join(endpoints, ",")))
+		default:
+			return errors.Errorf("must set the init or join instances")
+		}
+	case PDRoleTSO:
+		endpoints := pdEndpoints(inst.pds, true)
+		args = []string{
+			"services",
+			"tso",
+			fmt.Sprintf("--listen-addr=http://%s", utils.JoinHostPort(inst.Host, inst.Port)),
+			fmt.Sprintf("--advertise-listen-addr=http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.Port)),
+			fmt.Sprintf("--backend-endpoints=%s", strings.Join(endpoints, ",")),
+			fmt.Sprintf("--log-file=%s", inst.LogFile()),
+		}
+		if inst.ConfigPath != "" {
+			args = append(args, fmt.Sprintf("--config=%s", inst.ConfigPath))
+		}
+	case PDRoleResourceManager:
+		endpoints := pdEndpoints(inst.pds, true)
+		args = []string{
+			"services",
+			"resource-manager",
+			fmt.Sprintf("--listen-addr=http://%s", utils.JoinHostPort(inst.Host, inst.Port)),
+			fmt.Sprintf("--advertise-listen-addr=http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.Port)),
+			fmt.Sprintf("--backend-endpoints=%s", strings.Join(endpoints, ",")),
+			fmt.Sprintf("--log-file=%s", inst.LogFile()),
+		}
+		if inst.ConfigPath != "" {
+			args = append(args, fmt.Sprintf("--config=%s", inst.ConfigPath))
+		}
 	}
 
 	var err error
@@ -113,12 +163,12 @@ func (inst *PDInstance) Start(ctx context.Context, version utils.Version) error 
 
 // Component return the component name.
 func (inst *PDInstance) Component() string {
-	return "pd"
+	return string(inst.Role)
 }
 
 // LogFile return the log file.
 func (inst *PDInstance) LogFile() string {
-	return filepath.Join(inst.Dir, "pd.log")
+	return filepath.Join(inst.Dir, fmt.Sprintf("%s.log", string(inst.Role)))
 }
 
 // Addr return the listen address of PD

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -56,7 +56,10 @@ import (
 type BootOptions struct {
 	Mode           string                 `yaml:"mode"`
 	Version        string                 `yaml:"version"`
-	PD             instance.Config        `yaml:"pd"`
+	PD             instance.Config        `yaml:"pd"`  // ignored when mode == pd-ms
+	API            instance.Config        `yaml:"api"` // Only available when mode == pd-ms
+	TSO            instance.Config        `yaml:"tso"` // Only available when mode == pd-ms
+	RM             instance.Config        `yaml:"rm"`  // Only available when mode == pd-ms
 	TiDB           instance.Config        `yaml:"tidb"`
 	TiKV           instance.Config        `yaml:"tikv"`
 	TiFlash        instance.Config        `yaml:"tiflash"`         // ignored when mode == tidb-disagg
@@ -266,7 +269,7 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 		},
 	}
 
-	rootCmd.Flags().StringVar(&options.Mode, "mode", "tidb", "TiUP playground mode: 'tidb', 'tidb-disagg', 'tikv-slim'")
+	rootCmd.Flags().StringVar(&options.Mode, "mode", "tidb", "TiUP playground mode: 'tidb', 'tidb-disagg', 'tikv-slim', 'pd-ms'")
 	rootCmd.PersistentFlags().StringVarP(&tag, "tag", "T", "", "Specify a tag for playground") // Use `PersistentFlags()` to make it available to subcommands.
 	rootCmd.Flags().Bool("without-monitor", false, "Don't start prometheus and grafana component")
 	rootCmd.Flags().BoolVar(&options.Monitor, "monitor", true, "Start prometheus and grafana component")
@@ -284,6 +287,10 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 	rootCmd.Flags().IntVar(&options.TiKVCDC.Num, "kvcdc", 0, "TiKV-CDC instance number")
 	rootCmd.Flags().IntVar(&options.Pump.Num, "pump", 0, "Pump instance number")
 	rootCmd.Flags().IntVar(&options.Drainer.Num, "drainer", 0, "Drainer instance number")
+
+	rootCmd.Flags().IntVar(&options.API.Num, "api", 0, "API instance number")
+	rootCmd.Flags().IntVar(&options.TSO.Num, "tso", 0, "TSO instance number")
+	rootCmd.Flags().IntVar(&options.RM.Num, "rm", 0, "Resource manager instance number")
 
 	rootCmd.Flags().IntVar(&options.TiDB.UpTimeout, "db.timeout", 60, "TiDB max wait time in seconds for starting, 0 means no limit")
 	rootCmd.Flags().IntVar(&options.TiFlash.UpTimeout, "tiflash.timeout", 120, "TiFlash max wait time in seconds for starting, 0 means no limit")
@@ -309,6 +316,10 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 	rootCmd.Flags().StringVar(&options.TiCDC.ConfigPath, "ticdc.config", "", "TiCDC instance configuration file")
 	rootCmd.Flags().StringVar(&options.TiKVCDC.ConfigPath, "kvcdc.config", "", "TiKV-CDC instance configuration file")
 
+	rootCmd.Flags().StringVar(&options.API.ConfigPath, "api.config", "", "API instance configuration file")
+	rootCmd.Flags().StringVar(&options.TSO.ConfigPath, "tso.config", "", "TSO instance configuration file")
+	rootCmd.Flags().StringVar(&options.RM.ConfigPath, "rm.config", "", "Resource manager instance configuration file")
+
 	rootCmd.Flags().StringVar(&options.TiDB.BinPath, "db.binpath", "", "TiDB instance binary path")
 	rootCmd.Flags().StringVar(&options.TiKV.BinPath, "kv.binpath", "", "TiKV instance binary path")
 	rootCmd.Flags().StringVar(&options.PD.BinPath, "pd.binpath", "", "PD instance binary path")
@@ -319,6 +330,10 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 	rootCmd.Flags().StringVar(&options.TiKVCDC.BinPath, "kvcdc.binpath", "", "TiKV-CDC instance binary path")
 	rootCmd.Flags().StringVar(&options.Pump.BinPath, "pump.binpath", "", "Pump instance binary path")
 	rootCmd.Flags().StringVar(&options.Drainer.BinPath, "drainer.binpath", "", "Drainer instance binary path")
+
+	rootCmd.Flags().StringVar(&options.API.BinPath, "api.binpath", "", "API instance binary path")
+	rootCmd.Flags().StringVar(&options.TSO.BinPath, "tso.binpath", "", "TSO instance binary path")
+	rootCmd.Flags().StringVar(&options.RM.BinPath, "rm.binpath", "", "Resource manager instance binary path")
 
 	rootCmd.Flags().StringVar(&options.TiKVCDC.Version, "kvcdc.version", "", "TiKV-CDC instance version")
 
@@ -374,6 +389,19 @@ func populateDefaultOpt(flagSet *pflag.FlagSet) error {
 		defaultStr(&options.TiFlashCompute.BinPath, "tiflash.compute.binpath", options.TiFlash.BinPath)
 		defaultStr(&options.TiFlashCompute.ConfigPath, "tiflash.compute.config", options.TiFlash.ConfigPath)
 		options.TiFlashCompute.UpTimeout = options.TiFlash.UpTimeout
+	case "pd-ms":
+		defaultInt(&options.TiDB.Num, "db", 1)
+		defaultInt(&options.TiKV.Num, "kv", 1)
+		defaultInt(&options.API.Num, "api", 1)
+		defaultStr(&options.API.BinPath, "api.binpath", options.API.BinPath)
+		defaultStr(&options.API.ConfigPath, "api.config", options.API.ConfigPath)
+		defaultInt(&options.TSO.Num, "tso", 1)
+		defaultStr(&options.TSO.BinPath, "tso.binpath", options.TSO.BinPath)
+		defaultStr(&options.TSO.ConfigPath, "tso.config", options.TSO.ConfigPath)
+		defaultInt(&options.RM.Num, "rm", 1)
+		defaultStr(&options.RM.BinPath, "rm.binpath", options.RM.BinPath)
+		defaultStr(&options.RM.ConfigPath, "rm.config", options.RM.ConfigPath)
+		defaultInt(&options.TiFlash.Num, "tiflash", 1)
 	default:
 		return errors.Errorf("Unknown --mode %s", options.Mode)
 	}

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -55,11 +55,12 @@ import (
 // BootOptions is the topology and options used to start a playground cluster
 type BootOptions struct {
 	Mode           string                 `yaml:"mode"`
+	PDMode         string                 `yaml:"pd_mode"`
 	Version        string                 `yaml:"version"`
-	PD             instance.Config        `yaml:"pd"`     // ignored when mode == tidb-ms
-	PDAPI          instance.Config        `yaml:"pd_api"` // Only available when mode == tidb-ms
-	PDTSO          instance.Config        `yaml:"pd_tso"` // Only available when mode == tidb-ms
-	PDRM           instance.Config        `yaml:"pd_rm"`  // Only available when mode == tidb-ms
+	PD             instance.Config        `yaml:"pd"`     // ignored when pd_mode == ms
+	PDAPI          instance.Config        `yaml:"pd_api"` // Only available when pd_mode == ms
+	PDTSO          instance.Config        `yaml:"pd_tso"` // Only available when pd_mode == ms
+	PDRM           instance.Config        `yaml:"pd_rm"`  // Only available when pd_mode == ms
 	TiDB           instance.Config        `yaml:"tidb"`
 	TiKV           instance.Config        `yaml:"tikv"`
 	TiFlash        instance.Config        `yaml:"tiflash"`         // ignored when mode == tidb-disagg
@@ -269,7 +270,8 @@ If you'd like to use a TiDB version other than %s, cancel and retry with the fol
 		},
 	}
 
-	rootCmd.Flags().StringVar(&options.Mode, "mode", "tidb", "TiUP playground mode: 'tidb', 'tidb-disagg', 'tikv-slim', 'tidb-ms'")
+	rootCmd.Flags().StringVar(&options.Mode, "mode", "tidb", "TiUP playground mode: 'tidb', 'tidb-disagg', 'tikv-slim'")
+	rootCmd.Flags().StringVar(&options.PDMode, "pd.mode", "pd", "PD mode: 'pd', 'ms'")
 	rootCmd.PersistentFlags().StringVarP(&tag, "tag", "T", "", "Specify a tag for playground") // Use `PersistentFlags()` to make it available to subcommands.
 	rootCmd.Flags().Bool("without-monitor", false, "Don't start prometheus and grafana component")
 	rootCmd.Flags().BoolVar(&options.Monitor, "monitor", true, "Start prometheus and grafana component")
@@ -371,15 +373,12 @@ func populateDefaultOpt(flagSet *pflag.FlagSet) error {
 	case "tidb":
 		defaultInt(&options.TiDB.Num, "db", 1)
 		defaultInt(&options.TiKV.Num, "kv", 1)
-		defaultInt(&options.PD.Num, "pd", 1)
 		defaultInt(&options.TiFlash.Num, "tiflash", 1)
 	case "tikv-slim":
 		defaultInt(&options.TiKV.Num, "kv", 1)
-		defaultInt(&options.PD.Num, "pd", 1)
 	case "tidb-disagg":
 		defaultInt(&options.TiDB.Num, "db", 1)
 		defaultInt(&options.TiKV.Num, "kv", 1)
-		defaultInt(&options.PD.Num, "pd", 1)
 		defaultInt(&options.TiFlash.Num, "tiflash", 1)
 		defaultInt(&options.TiFlashWrite.Num, "tiflash.write", options.TiFlash.Num)
 		defaultStr(&options.TiFlashWrite.BinPath, "tiflash.write.binpath", options.TiFlash.BinPath)
@@ -389,9 +388,14 @@ func populateDefaultOpt(flagSet *pflag.FlagSet) error {
 		defaultStr(&options.TiFlashCompute.BinPath, "tiflash.compute.binpath", options.TiFlash.BinPath)
 		defaultStr(&options.TiFlashCompute.ConfigPath, "tiflash.compute.config", options.TiFlash.ConfigPath)
 		options.TiFlashCompute.UpTimeout = options.TiFlash.UpTimeout
-	case "tidb-ms":
-		defaultInt(&options.TiDB.Num, "db", 1)
-		defaultInt(&options.TiKV.Num, "kv", 1)
+	default:
+		return errors.Errorf("Unknown --mode %s", options.Mode)
+	}
+
+	switch options.PDMode {
+	case "pd":
+		defaultInt(&options.PD.Num, "pd", 1)
+	case "ms":
 		defaultInt(&options.PDAPI.Num, "pd.api", 1)
 		defaultStr(&options.PDAPI.BinPath, "pd.api.binpath", options.PDAPI.BinPath)
 		defaultStr(&options.PDAPI.ConfigPath, "pd.api.config", options.PDAPI.ConfigPath)
@@ -401,9 +405,8 @@ func populateDefaultOpt(flagSet *pflag.FlagSet) error {
 		defaultInt(&options.PDRM.Num, "pd.rm", 1)
 		defaultStr(&options.PDRM.BinPath, "pd.rm.binpath", options.PDRM.BinPath)
 		defaultStr(&options.PDRM.ConfigPath, "pd.rm.config", options.PDRM.ConfigPath)
-		defaultInt(&options.TiFlash.Num, "tiflash", 1)
 	default:
-		return errors.Errorf("Unknown --mode %s", options.Mode)
+		return errors.Errorf("Unknown --pd.mode %s", options.PDMode)
 	}
 
 	return nil

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -430,7 +430,11 @@ func (p *Playground) sanitizeComponentConfig(cid string, cfg *instance.Config) e
 
 func (p *Playground) startInstance(ctx context.Context, inst instance.Instance) error {
 	boundVersion := p.bindVersion(inst.Component(), p.bootOptions.Version)
-	version, err := environment.GlobalEnv().V1Repository().ResolveComponentVersion(inst.Component(), boundVersion)
+	component := inst.Component()
+	if component == string(instance.PDRoleAPI) || component == string(instance.PDRoleTSO) || component == string(instance.PDRoleResourceManager) {
+		component = string(instance.PDRoleNormal)
+	}
+	version, err := environment.GlobalEnv().V1Repository().ResolveComponentVersion(component, boundVersion)
 	if err != nil {
 		return err
 	}
@@ -469,7 +473,7 @@ func (p *Playground) handleScaleOut(w io.Writer, cmd *Command) error {
 		return err
 	}
 	// TODO: Support scale-out in disaggregated mode
-	inst, err := p.addInstance(cmd.ComponentID, instance.TiFlashRoleNormal, cmd.Config)
+	inst, err := p.addInstance(cmd.ComponentID, instance.PDRoleNormal, instance.TiFlashRoleNormal, cmd.Config)
 	if err != nil {
 		return err
 	}
@@ -633,7 +637,7 @@ func (p *Playground) enableBinlog() bool {
 	return p.bootOptions.Pump.Num > 0
 }
 
-func (p *Playground) addInstance(componentID string, tiflashRole instance.TiFlashRole, cfg instance.Config) (ins instance.Instance, err error) {
+func (p *Playground) addInstance(componentID string, pdRole instance.PDRole, tiflashRole instance.TiFlashRole, cfg instance.Config) (ins instance.Instance, err error) {
 	if cfg.BinPath != "" {
 		cfg.BinPath, err = getAbsolutePath(cfg.BinPath)
 		if err != nil {
@@ -651,7 +655,7 @@ func (p *Playground) addInstance(componentID string, tiflashRole instance.TiFlas
 	dataDir := p.dataDir
 
 	id := p.allocID(componentID)
-	dir := filepath.Join(dataDir, fmt.Sprintf("%s-%d", componentID, id))
+	dir := filepath.Join(dataDir, fmt.Sprintf("%s-%d", pdRole, id))
 	if err = utils.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}
@@ -663,16 +667,20 @@ func (p *Playground) addInstance(componentID string, tiflashRole instance.TiFlas
 
 	switch componentID {
 	case spec.ComponentPD:
-		inst := instance.NewPDInstance(cfg.BinPath, dir, host, cfg.ConfigPath, id, cfg.Port)
+		inst := instance.NewPDInstance(pdRole, cfg.BinPath, dir, host, cfg.ConfigPath, id, p.pds, cfg.Port)
 		ins = inst
-		if p.booted {
-			inst.Join(p.pds)
-			p.pds = append(p.pds, inst)
+		if pdRole == instance.PDRoleNormal || pdRole == instance.PDRoleAPI {
+			if p.booted {
+				inst.Join(p.pds)
+				p.pds = append(p.pds, inst)
+			} else {
+				p.pds = append(p.pds, inst)
+				for _, pd := range p.pds {
+					pd.InitCluster(p.pds)
+				}
+			}
 		} else {
 			p.pds = append(p.pds, inst)
-			for _, pd := range p.pds {
-				pd.InitCluster(p.pds)
-			}
 		}
 	case spec.ComponentTiDB:
 		inst := instance.NewTiDBInstance(cfg.BinPath, dir, host, cfg.ConfigPath, id, cfg.Port, p.pds, p.enableBinlog(), p.bootOptions.Mode == "tidb-disagg")
@@ -801,6 +809,9 @@ func (p *Playground) bindVersion(comp string, version string) (bindVersion strin
 func (p *Playground) bootCluster(ctx context.Context, env *environment.Environment, options *BootOptions) error {
 	for _, cfg := range []*instance.Config{
 		&options.PD,
+		&options.API,
+		&options.TSO,
+		&options.RM,
 		&options.TiDB,
 		&options.TiKV,
 		&options.TiFlash,
@@ -820,7 +831,7 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 	p.bootOptions = options
 
 	// All others components depend on the pd, we just ensure the pd count must be great than 0
-	if options.PD.Num < 1 {
+	if options.Mode != "pd-ms" && options.PD.Num < 1 {
 		return fmt.Errorf("all components count must be great than 0 (pd=%v)", options.PD.Num)
 	}
 
@@ -837,24 +848,26 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 
 	type InstancePair struct {
 		comp        string
+		pdRole      instance.PDRole
 		tiflashRole instance.TiFlashRole
 		instance.Config
 	}
 
 	instances := []InstancePair{
-		{spec.ComponentPD, "", options.PD},
-		{spec.ComponentTiKV, "", options.TiKV},
-		{spec.ComponentPump, "", options.Pump},
-		{spec.ComponentTiDB, "", options.TiDB},
-		{spec.ComponentCDC, "", options.TiCDC},
-		{spec.ComponentTiKVCDC, "", options.TiKVCDC},
-		{spec.ComponentDrainer, "", options.Drainer},
+		{spec.ComponentTiKV, "", "", options.TiKV},
+		{spec.ComponentPump, "", "", options.Pump},
+		{spec.ComponentTiDB, "", "", options.TiDB},
+		{spec.ComponentCDC, "", "", options.TiCDC},
+		{spec.ComponentTiKVCDC, "", "", options.TiKVCDC},
+		{spec.ComponentDrainer, "", "", options.Drainer},
 	}
 
 	if options.Mode == "tidb" {
-		instances = append(
-			instances,
-			InstancePair{spec.ComponentTiFlash, instance.TiFlashRoleNormal, options.TiFlash},
+		instances = append([]InstancePair{{spec.ComponentPD, instance.PDRoleNormal, instance.TiFlashRoleNormal, options.PD}},
+			instances...,
+		)
+		instances = append(instances,
+			InstancePair{spec.ComponentTiFlash, instance.PDRoleNormal, instance.TiFlashRoleNormal, options.TiFlash},
 		)
 	} else if options.Mode == "tidb-disagg" {
 		if !tidbver.TiDBSupportDisagg(options.Version) {
@@ -889,17 +902,36 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 				return fmt.Errorf("Disaggregate mode preflight check failed: Bucket %s doesn't exist", options.DisaggOpts.Bucket)
 			}
 		}
-
+		instances = append([]InstancePair{{spec.ComponentPD, instance.PDRoleNormal, instance.TiFlashRoleNormal, options.PD}},
+			instances...,
+		)
 		instances = append(
 			instances,
-			InstancePair{spec.ComponentTiFlash, instance.TiFlashRoleDisaggWrite, options.TiFlashWrite},
-			InstancePair{spec.ComponentTiFlash, instance.TiFlashRoleDisaggCompute, options.TiFlashCompute},
+			InstancePair{spec.ComponentTiFlash, instance.PDRoleNormal, instance.TiFlashRoleDisaggWrite, options.TiFlashWrite},
+			InstancePair{spec.ComponentTiFlash, instance.PDRoleNormal, instance.TiFlashRoleDisaggCompute, options.TiFlashCompute},
+		)
+	} else if options.Mode == "pd-ms" {
+		if !tidbver.PDSupportMicroServices(options.Version) {
+			return fmt.Errorf("PD cluster doesn't support microservices mode in version %s", options.Version)
+		}
+		instances = append([]InstancePair{
+			{spec.ComponentPD, instance.PDRoleAPI, instance.TiFlashRoleNormal, options.API},
+			{spec.ComponentPD, instance.PDRoleTSO, instance.TiFlashRoleNormal, options.TSO},
+			{spec.ComponentPD, instance.PDRoleResourceManager, instance.TiFlashRoleNormal, options.RM}},
+			instances...,
+		)
+		instances = append(instances,
+			InstancePair{spec.ComponentTiFlash, instance.PDRoleNormal, instance.TiFlashRoleNormal, options.TiFlash},
+		)
+	} else {
+		instances = append([]InstancePair{{spec.ComponentPD, instance.PDRoleNormal, instance.TiFlashRoleNormal, options.PD}},
+			instances...,
 		)
 	}
 
 	for _, inst := range instances {
 		for i := 0; i < inst.Num; i++ {
-			_, err := p.addInstance(inst.comp, inst.tiflashRole, inst.Config)
+			_, err := p.addInstance(inst.comp, inst.pdRole, inst.tiflashRole, inst.Config)
 			if err != nil {
 				return err
 			}

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -93,6 +93,11 @@ func TiDBSupportDisagg(version string) bool {
 	return semver.Compare(version, "v7.0.0") >= 0 || strings.Contains(version, "nightly")
 }
 
+// PDSupportMicroServices returns true if the given version of PD supports micro services.
+func PDSupportMicroServices(version string) bool {
+	return semver.Compare(version, "v7.3.0") >= 0 || strings.Contains(version, "nightly")
+}
+
 // TiCDCSupportConfigFile return if given version of TiCDC support config file
 func TiCDCSupportConfigFile(version string) bool {
 	// config support since v4.0.13, ignore v5.0.0-rc


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Introduce the pd-ms mode for better testing of the PD microservices mode.

### What is changed and how it works?
Usage:
```
tiup-playground nightly --pd.mode ms
```
It will start 1 API, 1 TSO, 1 resource manager server by default. If we want to start more, just use the following cmd like other mode:
```
tiup-playground nightly --pd.mode ms --pd.api 3 --pd.tso 2 --pd.rm 1
```
Output:
```
🎉 TiDB Playground Cluster is started, enjoy!

Connect TiDB:   mysql --comments --host 127.0.0.1 --port 4000 -u root
TiDB Dashboard: http://127.0.0.1:2379/dashboard
Grafana:        http://127.0.0.1:3000
```

For `tikv-slim`:
```
tiup-playground nightly --mode tikv-slim --pd.mode ms --pd.api 3 --pd.tso 2 --pd.rm 1
```
Output:
```
PD TSO Endpoints:   127.0.0.1:2386,127.0.0.1:2388
PD API Endpoints:   127.0.0.1:2379,127.0.0.1:2382,127.0.0.1:2384
PD Resource Ranager Endpoints:   127.0.0.1:2390
Grafana:        http://127.0.0.1:3000
```



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
