### PR TITLE
cluster: fix cannot start tiflash above 7.1.0

### DIFF
--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -881,7 +881,7 @@ func (i *TiFlashInstance) PrepareStart(ctx context.Context, tlsCfg *tls.Config) 
 func (i *TiFlashInstance) Ready(ctx context.Context, e ctxt.Executor, timeout uint64, tlsCfg *tls.Config) error {
 	// FIXME: the timeout is applied twice in the whole `Ready()` process, in the worst
 	// case it might wait double time as other components
-	if err := PortStarted(ctx, e, i.Port, timeout); err != nil {
+	if err := PortStarted(ctx, e, i.GetServicePort(), timeout); err != nil {
 		return err
 	}
 

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -72,7 +72,7 @@ func TiFlashNotNeedHTTPPortConfig(version string) bool {
 // and we must make sure the port is being configured as specified in the topology file,
 // otherwise multiple TiFlash instances will conflict.
 func TiFlashRequiresTCPPortConfig(version string) bool {
-	return semver.Compare(version, "v7.1.0") < 0 || strings.Contains(version, "nightly")
+	return semver.Compare(version, "v7.1.0") < 0 && !strings.Contains(version, "nightly")
 }
 
 // TiFlashNotNeedSomeConfig return if given version of TiFlash do not need some config like runAsDaemon

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -72,7 +72,7 @@ func TiFlashNotNeedHTTPPortConfig(version string) bool {
 // and we must make sure the port is being configured as specified in the topology file,
 // otherwise multiple TiFlash instances will conflict.
 func TiFlashRequiresTCPPortConfig(version string) bool {
-	return semver.Compare(version, "v7.1.0") < 0
+	return semver.Compare(version, "v7.1.0") < 0 || strings.Contains(version, "nightly")
 }
 
 // TiFlashNotNeedSomeConfig return if given version of TiFlash do not need some config like runAsDaemon


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close https://github.com/pingcap/tiup/issues/2229

### What is changed and how it works?

1. Include "nightly" in version check for tiflash that doesn't require tcp port.
2. Change ready detection to use service port rather than tcp port.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Deploy v7.1.0/v7.2.0/nightly cluster. Before this patch, starting cluster failed at tiflash component. After this patch, starting cluster succeeded.

Code changes

 - None

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the issue that cluster start failure caused by tiflash checking for tcp port ready.
```
