### PR TITLE
Upgrade TiCDC before TiKV and PD when cluster is equal or greater than v5.1.0

### DIFF
--- a/components/dm/spec/logic.go
+++ b/components/dm/spec/logic.go
@@ -460,7 +460,7 @@ func (topo *Specification) ComponentsByStartOrder() (comps []Component) {
 }
 
 // ComponentsByUpdateOrder return component in the order need to be updated.
-func (topo *Specification) ComponentsByUpdateOrder() (comps []Component) {
+func (topo *Specification) ComponentsByUpdateOrder(curVer string) (comps []Component) {
 	// "dm-master", "dm-worker"
 	comps = append(comps, &DMMasterComponent{topo})
 	comps = append(comps, &DMWorkerComponent{topo})

--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -190,7 +190,7 @@ func checkSystemInfo(
 
 	roleFilter := set.NewStringSet(gOpt.Roles...)
 	nodeFilter := set.NewStringSet(gOpt.Nodes...)
-	components := topo.ComponentsByUpdateOrder()
+	components := topo.ComponentsByStartOrder()
 	components = operator.FilterComponent(components, roleFilter)
 
 	for _, comp := range components {

--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -87,7 +87,7 @@ Do you want to continue? [y/N]:`,
 	}
 
 	hasImported := false
-	for _, comp := range topo.ComponentsByUpdateOrder() {
+	for _, comp := range topo.ComponentsByUpdateOrder(base.Version) {
 		for _, inst := range comp.Instances() {
 			compName := inst.ComponentName()
 

--- a/pkg/cluster/operation/upgrade.go
+++ b/pkg/cluster/operation/upgrade.go
@@ -49,7 +49,7 @@ func Upgrade(
 ) error {
 	roleFilter := set.NewStringSet(options.Roles...)
 	nodeFilter := set.NewStringSet(options.Nodes...)
-	components := topo.ComponentsByUpdateOrder()
+	components := topo.ComponentsByUpdateOrder(currentVersion)
 	components = FilterComponent(components, roleFilter)
 	logger := ctx.Value(logprinter.ContextKeyLogger).(*logprinter.Logger)
 

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -730,11 +730,11 @@ func (s *Specification) ComponentsByStartOrder() (comps []Component) {
 // ComponentsByUpdateOrder return component in the order need to be updated.
 func (s *Specification) ComponentsByUpdateOrder(curVer string) (comps []Component) {
 	// Ref: https://github.com/pingcap/tiup/issues/2166
-	cdcUpgradeBeforePDTiKV := tidbver.TiCDCUpgradeBeforePDTiKV(curVer)
+	cdcUpgradeBeforePDTiKVTiDB := tidbver.TiCDCUpgradeBeforePDTiKVTiDB(curVer)
 
 	// "tiflash", <"cdc">, "pd", "dashboard", "tikv", "pump", "tidb", "drainer", <"cdc>", "prometheus", "grafana", "alertmanager"
 	comps = append(comps, &TiFlashComponent{s})
-	if cdcUpgradeBeforePDTiKV {
+	if cdcUpgradeBeforePDTiKVTiDB {
 		comps = append(comps, &CDCComponent{s})
 	}
 	comps = append(comps, &PDComponent{s})
@@ -743,7 +743,7 @@ func (s *Specification) ComponentsByUpdateOrder(curVer string) (comps []Componen
 	comps = append(comps, &PumpComponent{s})
 	comps = append(comps, &TiDBComponent{s})
 	comps = append(comps, &DrainerComponent{s})
-	if !cdcUpgradeBeforePDTiKV {
+	if !cdcUpgradeBeforePDTiKVTiDB {
 		comps = append(comps, &CDCComponent{s})
 	}
 	comps = append(comps, &MonitorComponent{s})

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -729,15 +729,23 @@ func (s *Specification) ComponentsByStartOrder() (comps []Component) {
 
 // ComponentsByUpdateOrder return component in the order need to be updated.
 func (s *Specification) ComponentsByUpdateOrder(curVer string) (comps []Component) {
-	// "tiflash", "pd", "dashboard", "tikv", "pump", "tidb", "drainer", "cdc", "prometheus", "grafana", "alertmanager"
+	// Ref: https://github.com/pingcap/tiup/issues/2166
+	cdcUpgradeBeforePDTiKV := tidbver.TiCDCUpgradeBeforePDTiKV(curVer)
+
+	// "tiflash", <"cdc">, "pd", "dashboard", "tikv", "pump", "tidb", "drainer", <"cdc>", "prometheus", "grafana", "alertmanager"
 	comps = append(comps, &TiFlashComponent{s})
+	if cdcUpgradeBeforePDTiKV {
+		comps = append(comps, &CDCComponent{s})
+	}
 	comps = append(comps, &PDComponent{s})
 	comps = append(comps, &DashboardComponent{s})
 	comps = append(comps, &TiKVComponent{s})
 	comps = append(comps, &PumpComponent{s})
 	comps = append(comps, &TiDBComponent{s})
 	comps = append(comps, &DrainerComponent{s})
-	comps = append(comps, &CDCComponent{s})
+	if !cdcUpgradeBeforePDTiKV {
+		comps = append(comps, &CDCComponent{s})
+	}
 	comps = append(comps, &MonitorComponent{s})
 	comps = append(comps, &GrafanaComponent{s})
 	comps = append(comps, &AlertManagerComponent{s})

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -161,7 +161,7 @@ type Topology interface {
 	// Instances() []Instance
 	ComponentsByStartOrder() []Component
 	ComponentsByStopOrder() []Component
-	ComponentsByUpdateOrder() []Component
+	ComponentsByUpdateOrder(curVer string) []Component
 	IterInstance(fn func(instance Instance), concurrency ...int)
 	GetMonitoredOptions() *MonitoredOptions
 	// count how many time a path is used by instances in cluster
@@ -728,7 +728,7 @@ func (s *Specification) ComponentsByStartOrder() (comps []Component) {
 }
 
 // ComponentsByUpdateOrder return component in the order need to be updated.
-func (s *Specification) ComponentsByUpdateOrder() (comps []Component) {
+func (s *Specification) ComponentsByUpdateOrder(curVer string) (comps []Component) {
 	// "tiflash", "pd", "dashboard", "tikv", "pump", "tidb", "drainer", "cdc", "prometheus", "grafana", "alertmanager"
 	comps = append(comps, &TiFlashComponent{s})
 	comps = append(comps, &PDComponent{s})

--- a/pkg/cluster/spec/spec_manager_test.go
+++ b/pkg/cluster/spec/spec_manager_test.go
@@ -97,7 +97,7 @@ func (t *TestTopology) ComponentsByStopOrder() []Component {
 	return nil
 }
 
-func (t *TestTopology) ComponentsByUpdateOrder() []Component {
+func (t *TestTopology) ComponentsByUpdateOrder(curVer string) []Component {
 	return nil
 }
 

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -130,6 +130,7 @@ func TiCDCSupportRollingUpgrade(version string) bool {
 	return semver.Compare(version, "v6.3.0") >= 0 || strings.Contains(version, "nightly")
 }
 
+// TiCDCUpgradeBeforePDTiKV return if the given version of TiCDC should upgrade TiCDC before PD and TiKV
 func TiCDCUpgradeBeforePDTiKV(version string) bool {
 	return semver.Compare(version, "v5.1.0") >= 0 || strings.Contains(version, "nightly")
 }

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -130,8 +130,8 @@ func TiCDCSupportRollingUpgrade(version string) bool {
 	return semver.Compare(version, "v6.3.0") >= 0 || strings.Contains(version, "nightly")
 }
 
-// TiCDCUpgradeBeforePDTiKV return if the given version of TiCDC should upgrade TiCDC before PD and TiKV
-func TiCDCUpgradeBeforePDTiKV(version string) bool {
+// TiCDCUpgradeBeforePDTiKVTiDB return if the given version of TiCDC should upgrade TiCDC before PD and TiKV
+func TiCDCUpgradeBeforePDTiKVTiDB(version string) bool {
 	return semver.Compare(version, "v5.1.0") >= 0 || strings.Contains(version, "nightly")
 }
 

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -130,6 +130,10 @@ func TiCDCSupportRollingUpgrade(version string) bool {
 	return semver.Compare(version, "v6.3.0") >= 0 || strings.Contains(version, "nightly")
 }
 
+func TiCDCUpgradeBeforePDTiKV(version string) bool {
+	return semver.Compare(version, "v5.1.0") >= 0 || strings.Contains(version, "nightly")
+}
+
 // NgMonitorDeployByDefault return if given version of TiDB cluster should contain ng-monitoring
 func NgMonitorDeployByDefault(version string) bool {
 	return semver.Compare(version, "v5.4.0") >= 0 || strings.Contains(version, "nightly")


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #2166

### What is changed and how it works?
Upgrade TiCDC before TiKV and PD when cluster is equal or greater than v5.1.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)

1. Upgrade cluster from v5.0.0 to v.5.2.0
```
$ ./tiup-cluster upgrade my-cluster v5.2.0
This operation will upgrade tidb v5.0.0 cluster my-cluster to v5.2.0.
...
Upgrading component pd
        Restarting instance 127.0.0.1:2379
        Restart instance 127.0.0.1:2379 success
Upgrading component tikv
        Restarting instance 127.0.0.1:20160
        Restart instance 127.0.0.1:20160 success
Upgrading component tidb
        Restarting instance 127.0.0.1:4000
        Restart instance 127.0.0.1:4000 success
Upgrading component cdc
        Restarting instance 127.0.0.1:8300
        Restart instance 127.0.0.1:8300 success
...
```

2. Upgrade cluster from v5.1.0 to v5.2.0
```
$ ./tiup-cluster upgrade my-cluster v5.2.0
This operation will upgrade tidb v5.1.0 cluster my-cluster to v5.2.0.
...
Upgrading component cdc
        Restarting instance 127.0.0.1:8300
        Restart instance 127.0.0.1:8300 success
Upgrading component pd
        Restarting instance 127.0.0.1:2379
        Restart instance 127.0.0.1:2379 success
Upgrading component tikv
        Restarting instance 127.0.0.1:20160
        Restart instance 127.0.0.1:20160 success
Upgrading component tidb
        Restarting instance 127.0.0.1:4000
        Restart instance 127.0.0.1:4000 success
...
```

3. Upgrade cluster from v5.2.0 to v5.3.0
```
$  ./tiup-cluster upgrade my-cluster v5.3.0
This operation will upgrade tidb v5.2.0 cluster my-cluster to v5.3.0.
...
Upgrading component cdc
        Restarting instance 127.0.0.1:8300
        Restart instance 127.0.0.1:8300 success
Upgrading component pd
        Restarting instance 127.0.0.1:2379
        Restart instance 127.0.0.1:2379 success
Upgrading component tikv
        Restarting instance 127.0.0.1:20160
        Restart instance 127.0.0.1:20160 success
Upgrading component tidb
        Restarting instance 127.0.0.1:4000
...
```

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Upgrade TiCDC before TiKV and PD when cluster is equal or greater than v5.1.0
```
