### PR TITLE
Fix the issue meta backup is failed when symbolic links exist in meta dir.

### DIFF
--- a/pkg/cluster/manager/patch.go
+++ b/pkg/cluster/manager/patch.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -204,7 +205,13 @@ func overwritePatch(specManager *spec.SpecManager, name, comp, packagePath strin
 	if utils.IsSymExist(symlink) {
 		os.Remove(symlink)
 	}
-	return os.Symlink(tg, symlink)
+
+	tgRelPath, err := filepath.Rel(filepath.Dir(symlink), tg)
+	if err != nil {
+		return err
+	}
+
+	return os.Symlink(tgRelPath, symlink)
 }
 
 func instancesToPatch(topo spec.Topology, options operator.Options) ([]spec.Instance, error) {

--- a/pkg/utils/ioutil.go
+++ b/pkg/utils/ioutil.go
@@ -107,10 +107,8 @@ func Tar(writer io.Writer, from string) error {
 			return err
 		}
 
-		fm := info.Mode()
-
 		link := ""
-		if fm&fs.ModeSymlink != 0 {
+		if info.Mode()&fs.ModeSymlink != 0 {
 			link, err = os.Readlink(path)
 			if err != nil {
 				return err

--- a/pkg/utils/ioutil.go
+++ b/pkg/utils/ioutil.go
@@ -101,11 +101,23 @@ func Tar(writer io.Writer, from string) error {
 	tarW := tar.NewWriter(compressW)
 	defer tarW.Close()
 
+	// NOTE: filepath.Walk does not follow the symbolic link.
 	return filepath.Walk(from, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		header, _ := tar.FileInfoHeader(info, "")
+
+		fm := info.Mode()
+
+		link := ""
+		if fm&fs.ModeSymlink != 0 {
+			link, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+
+		header, _ := tar.FileInfoHeader(info, link)
 		header.Name, _ = filepath.Rel(from, path)
 		// skip "."
 		if header.Name == "." {
@@ -116,7 +128,7 @@ func Tar(writer io.Writer, from string) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() {
+		if info.Mode().IsRegular() {
 			fd, err := os.Open(path)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #2241

### What is changed and how it works?
* Use the relative path to create a symbolic link when executing `tiup cluster patch --overwrte`.
* Support packaging symbolic links when executing `tiup cluster meta backup`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

* Patch the pd and check the symbolic link is a relative path.
```
$ ./tiup-cluster patch my-cluster pd-v5.1.0-linux-amd64.tar.gz --overwrite -R pd
...

$ ll /root/.tiup/storage/cluster/clusters/my-cluster/patch/
total 40M
-rw-r--r-- 1 root root 40M Aug 18 06:58 pd-b64365c.tar.gz
lrwxrwxrwx 1 root root  17 Aug 18 06:58 pd.tar.gz -> pd-b64365c.tar.gz
```

* Backup cluster meta.
```
$ /tiup-cluster meta backup my-cluster
successfully backup meta of cluster my-cluster on tiup-cluster_my-cluster_metabackup_2023-08-18T07-00-21Z.tar.gz
```

* Restore to a new cluster and check the symbolic link.
```
$ ./tiup-cluster meta restore my-cluster-restore tiup-cluster_my-cluster_metabackup_2023-08-18T07-00-21Z.tar.gz
meta of cluster my-cluster-restore didn't exist before restore
the given tarball was last modified at 2023-08-18T07:00:32Z
restore meta of cluster my-cluster-restore successfully.

$ ll /root/.tiup/storage/cluster/clusters/my-cluster-restore/patch
total 40M
-rw-r--r-- 1 root root 40M Aug 18 07:01 pd-b64365c.tar.gz
lrwxrwxrwx 1 root root  17 Aug 18 07:01 pd.tar.gz -> pd-b64365c.tar.gz
```

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix the issue meta backup is failed when symbolic links exist in meta dir.
```
