### PR TITLE
add a new flag '--numa' to show numa in display command

### DIFF
--- a/components/cluster/command/display.go
+++ b/components/cluster/command/display.go
@@ -97,6 +97,7 @@ func newDisplayCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&showTiKVLabels, "labels", false, "Only display labels of specified TiKV role or nodes")
 	cmd.Flags().BoolVar(&dopt.ShowProcess, "process", false, "display cpu and memory usage of nodes")
 	cmd.Flags().BoolVar(&dopt.ShowManageHost, "manage-host", false, "display manage host of nodes")
+	cmd.Flags().BoolVar(&dopt.ShowNuma, "numa", false, "display numa information of nodes")
 	cmd.Flags().Uint64Var(&statusTimeout, "status-timeout", 10, "Timeout in seconds when getting node status")
 
 	return cmd

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -50,6 +50,7 @@ type DisplayOption struct {
 	ShowUptime     bool
 	ShowProcess    bool
 	ShowManageHost bool
+	ShowNuma       bool
 }
 
 // InstInfo represents an instance info
@@ -67,6 +68,8 @@ type InstInfo struct {
 	Since       string `json:"since"`
 	DataDir     string `json:"data_dir"`
 	DeployDir   string `json:"deploy_dir"`
+	NumaNode    string `json:"numa_node"`
+	NumaCores   string `json:"numa_cores"`
 
 	ComponentName string
 	Port          int
@@ -199,6 +202,10 @@ func (m *Manager) Display(dopt DisplayOption, opt operator.Options) error {
 	if dopt.ShowUptime {
 		rowHead = append(rowHead, "Since")
 	}
+	if dopt.ShowNuma {
+		rowHead = append(rowHead, "Numa Node", "Numd Cores")
+	}
+
 	rowHead = append(rowHead, "Data Dir", "Deploy Dir")
 	clusterTable = append(clusterTable, rowHead)
 
@@ -225,6 +232,10 @@ func (m *Manager) Display(dopt DisplayOption, opt operator.Options) error {
 		if dopt.ShowUptime {
 			row = append(row, v.Since)
 		}
+		if dopt.ShowNuma {
+			row = append(row, v.NumaNode, v.NumaCores)
+		}
+
 		row = append(row, v.DataDir, v.DeployDir)
 		clusterTable = append(clusterTable, row)
 
@@ -654,6 +665,8 @@ func (m *Manager) GetClusterTopology(dopt DisplayOption, opt operator.Options) (
 			ComponentName: ins.ComponentName(),
 			Port:          ins.GetPort(),
 			Since:         since,
+			NumaNode:      ins.GetNumaNode(),
+			NumaCores:     ins.GetNumaCores(),
 		})
 		mu.Unlock()
 	}, opt.Concurrency)

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -665,8 +665,8 @@ func (m *Manager) GetClusterTopology(dopt DisplayOption, opt operator.Options) (
 			ComponentName: ins.ComponentName(),
 			Port:          ins.GetPort(),
 			Since:         since,
-			NumaNode:      ins.GetNumaNode(),
-			NumaCores:     ins.GetNumaCores(),
+			NumaNode:      utils.Ternary(ins.GetNumaNode() == "", "-", ins.GetNumaNode()).(string),
+			NumaCores:     utils.Ternary(ins.GetNumaCores() == "", "-", ins.GetNumaCores()).(string),
 		})
 		mu.Unlock()
 	}, opt.Concurrency)

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -115,6 +115,8 @@ func (c *AlertManagerComponent) Instances() []Instance {
 				ListenHost:   s.ListenHost,
 				Port:         s.WebPort,
 				SSHP:         s.SSHPort,
+				NumaNode:     s.NumaNode,
+				NumaCores:    "",
 
 				Ports: []int{
 					s.WebPort,

--- a/pkg/cluster/spec/cdc.go
+++ b/pkg/cluster/spec/cdc.go
@@ -126,6 +126,8 @@ func (c *CDCComponent) Instances() []Instance {
 			Port:         s.Port,
 			SSHP:         s.SSHPort,
 			Source:       s.GetSource(),
+			NumaNode:     s.NumaNode,
+			NumaCores:    "",
 
 			Ports: []int{
 				s.Port,

--- a/pkg/cluster/spec/dashboard.go
+++ b/pkg/cluster/spec/dashboard.go
@@ -129,6 +129,8 @@ func (c *DashboardComponent) Instances() []Instance {
 			Port:         s.Port,
 			SSHP:         s.SSHPort,
 			Source:       s.Source,
+			NumaNode:     s.NumaNode,
+			NumaCores:    "",
 
 			Ports: []int{
 				s.Port,

--- a/pkg/cluster/spec/drainer.go
+++ b/pkg/cluster/spec/drainer.go
@@ -147,6 +147,8 @@ func (c *DrainerComponent) Instances() []Instance {
 			Port:         s.Port,
 			SSHP:         s.SSHPort,
 			Source:       s.GetSource(),
+			NumaNode:     s.NumaNode,
+			NumaCores:    "",
 
 			Ports: []int{
 				s.Port,

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -122,6 +122,8 @@ func (c *GrafanaComponent) Instances() []Instance {
 				ManageHost:   s.ManageHost,
 				Port:         s.Port,
 				SSHP:         s.SSHPort,
+				NumaNode:     "",
+				NumaCores:    "",
 
 				Ports: []int{
 					s.Port,

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -370,10 +370,12 @@ func (i *BaseInstance) GetSSHPort() int {
 	return i.SSHP
 }
 
+// GetNumaNode implements Instance interface
 func (i *BaseInstance) GetNumaNode() string {
 	return i.NumaNode
 }
 
+// GetNumaCores implements Instance interface
 func (i *BaseInstance) GetNumaCores() string {
 	return i.NumaCores
 }

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -98,6 +98,8 @@ type Instance interface {
 	GetManageHost() string
 	GetPort() int
 	GetSSHPort() int
+	GetNumaNode() string
+	GetNumaCores() string
 	DeployDir() string
 	UsedPorts() []int
 	UsedDirs() []string
@@ -145,6 +147,8 @@ type BaseInstance struct {
 	Port       int
 	SSHP       int
 	Source     string
+	NumaNode   string
+	NumaCores  string
 
 	Ports    []int
 	Dirs     []string
@@ -364,6 +368,14 @@ func (i *BaseInstance) GetListenHost() string {
 // GetSSHPort implements Instance interface
 func (i *BaseInstance) GetSSHPort() int {
 	return i.SSHP
+}
+
+func (i *BaseInstance) GetNumaNode() string {
+	return i.NumaNode
+}
+
+func (i *BaseInstance) GetNumaCores() string {
+	return i.NumaCores
 }
 
 // DeployDir implements Instance interface

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -138,6 +138,8 @@ func (c *MonitorComponent) Instances() []Instance {
 			ManageHost:   s.ManageHost,
 			Port:         s.Port,
 			SSHP:         s.SSHPort,
+			NumaNode:     s.NumaNode,
+			NumaCores:    "",
 
 			Ports: []int{
 				s.Port,

--- a/pkg/cluster/spec/pd.go
+++ b/pkg/cluster/spec/pd.go
@@ -175,6 +175,8 @@ func (c *PDComponent) Instances() []Instance {
 				Port:         s.ClientPort,
 				SSHP:         s.SSHPort,
 				Source:       s.GetSource(),
+				NumaNode:     s.NumaNode,
+				NumaCores:    "",
 
 				Ports: []int{
 					s.ClientPort,

--- a/pkg/cluster/spec/pump.go
+++ b/pkg/cluster/spec/pump.go
@@ -146,6 +146,8 @@ func (c *PumpComponent) Instances() []Instance {
 			Port:         s.Port,
 			SSHP:         s.SSHPort,
 			Source:       s.GetSource(),
+			NumaNode:     s.NumaNode,
+			NumaCores:    "",
 
 			Ports: []int{
 				s.Port,

--- a/pkg/cluster/spec/tidb.go
+++ b/pkg/cluster/spec/tidb.go
@@ -124,6 +124,8 @@ func (c *TiDBComponent) Instances() []Instance {
 			Port:         s.Port,
 			SSHP:         s.SSHPort,
 			Source:       s.Source,
+			NumaNode:     s.NumaNode,
+			NumaCores:    s.NumaCores,
 
 			Ports: []int{
 				s.Port,

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -294,6 +294,8 @@ func (c *TiFlashComponent) Instances() []Instance {
 			Port:         s.GetMainPort(),
 			SSHP:         s.SSHPort,
 			Source:       s.GetSource(),
+			NumaNode:     s.NumaNode,
+			NumaCores:    s.NumaCores,
 
 			Ports: []int{
 				s.TCPPort,

--- a/pkg/cluster/spec/tikv.go
+++ b/pkg/cluster/spec/tikv.go
@@ -199,6 +199,8 @@ func (c *TiKVComponent) Instances() []Instance {
 			Port:         s.Port,
 			SSHP:         s.SSHPort,
 			Source:       s.Source,
+			NumaNode:     s.NumaNode,
+			NumaCores:    s.NumaCores,
 
 			Ports: []int{
 				s.Port,

--- a/pkg/cluster/spec/tikv_cdc.go
+++ b/pkg/cluster/spec/tikv_cdc.go
@@ -126,6 +126,8 @@ func (c *TiKVCDCComponent) Instances() []Instance {
 			Port:         s.Port,
 			SSHP:         s.SSHPort,
 			Source:       s.GetSource(),
+			NumaNode:     s.NumaNode,
+			NumaCores:    "",
 
 			Ports: []int{
 				s.Port,

--- a/pkg/cluster/spec/tiproxy.go
+++ b/pkg/cluster/spec/tiproxy.go
@@ -142,6 +142,8 @@ func (c *TiProxyComponent) Instances() []Instance {
 			Port:         s.Port,
 			SSHP:         s.SSHPort,
 			Source:       ComponentTiProxy,
+			NumaNode:     s.NumaNode,
+			NumaCores:    "",
 			Ports: []int{
 				s.Port,
 				s.StatusPort,

--- a/pkg/cluster/spec/tispark.go
+++ b/pkg/cluster/spec/tispark.go
@@ -154,6 +154,8 @@ func (c *TiSparkMasterComponent) Instances() []Instance {
 				Host:         s.Host,
 				Port:         s.Port,
 				SSHP:         s.SSHPort,
+				NumaNode:     "",
+				NumaCores:    "",
 
 				Ports: []int{
 					s.Port,
@@ -333,6 +335,8 @@ func (c *TiSparkWorkerComponent) Instances() []Instance {
 				Host:         s.Host,
 				Port:         s.Port,
 				SSHP:         s.SSHPort,
+				NumaNode:     "",
+				NumaCores:    "",
 
 				Ports: []int{
 					s.Port,


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #2294

### What is changed and how it works?
add a new flag '--numa' to show numa in display command.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

1. Deploy a new cluster.
2. Display with '--numa' flag.
![image](https://github.com/pingcap/tiup/assets/26425336/5b9f0db2-7611-4f2b-9d4c-6187ce84f9fb)
 

 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
add a new flag '--numa' to show numa in display command
```
