### PR TITLE
not cache the output of  `ss -tln` command when checking wether components are started/stopped

### DIFF
--- a/pkg/cluster/api/tidbapi.go
+++ b/pkg/cluster/api/tidbapi.go
@@ -75,4 +75,3 @@ func (c *TiDBClient) FinishUpgrade() error {
 
 	return err
 }
-

--- a/pkg/cluster/executor/executor.go
+++ b/pkg/cluster/executor/executor.go
@@ -118,6 +118,19 @@ func New(etype SSHType, sudo bool, c SSHConfig) (ctxt.Executor, error) {
 	return &CheckPointExecutor{executor, &c}, nil
 }
 
+// UnwarpCheckPointExecutor unwarp the CheckPointExecutor and return the real executor
+//
+// Sometimes we just want to get the output of a command, and the CheckPointExecutor will
+// always cache the output, it will be a problem when we want to get the real output.
+func UnwarpCheckPointExecutor(e ctxt.Executor) ctxt.Executor {
+	switch e := e.(type) {
+	case *CheckPointExecutor:
+		return e.Executor
+	default:
+		return e
+	}
+}
+
 func checkLocalIP(ip string) error {
 	ifaces, err := net.Interfaces()
 	if err != nil {

--- a/pkg/cluster/module/wait_for.go
+++ b/pkg/cluster/module/wait_for.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
+	"github.com/pingcap/tiup/pkg/cluster/executor"
 	"github.com/pingcap/tiup/pkg/utils"
 	"go.uber.org/zap"
 )
@@ -71,7 +72,7 @@ func (w *WaitFor) Execute(ctx context.Context, e ctxt.Executor) (err error) {
 	}
 	if err := utils.Retry(func() error {
 		// only listing TCP ports
-		stdout, _, err := e.Execute(ctx, "ss -ltn", false)
+		stdout, _, err := executor.UnwarpCheckPointExecutor(e).Execute(ctx, "ss -ltn", false)
 		if err == nil {
 			switch w.c.State {
 			case "started":


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #2267

### What is changed and how it works?
Add a function `UnwarpCheckPointExecutor` to get a real executor without checkpoints.

Use `UnwarpCheckPointExecutor` to executor `ss -tln` when checking wether components are started/stopped.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

1. Deploy a new cluster and check audit logs.
    
    The `ss -tln` command isn't cached when starting components.
```
// ...
2023-11-01T02:34:40.179Z        INFO    Starting component blackbox_exporter
2023-11-01T02:34:40.179Z        INFO            Starting instance 127.0.0.1
2023-11-01T02:34:41.152Z        INFO    LocalCommand    {"cmd": "export LANG=C; PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin /usr/bin/sudo -H -u root bash -c \"cd; systemctl daemon-reload && systemctl start blackbox_exporter-9115.service\"", "stdout": "", "stderr": ""}
2023-11-01T02:34:41.153Z        INFO    CheckPoint      {"host": "127.0.0.1", "port": 22, "user": "tidb", "sudo": true, "cmd": "systemctl daemon-reload && systemctl start blackbox_exporter-9115.service", "stdout": "", "stderr": "", "__hash__": "7634a3f7", "__func__": "github.com/pingcap/tiup/pkg/cluster/executor.(*CheckPointExecutor).Execute", "hit": false}
2023-11-01T02:34:41.189Z        INFO    LocalCommand    {"cmd": "export LANG=C; PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin /usr/bin/sudo -H -u tidb bash -c \"cd; ss -ltn\"", "stdout": "State  Recv-Q Send-Q      Local Address:Port  Peer Address:PortProcess\nLISTEN 0      70              127.0.0.1:33060      0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:45347      0.0.0.0:*          \nLISTEN 0      200             127.0.0.1:8234       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:9090       0.0.0.0:*          \nLISTEN 0      511             127.0.0.1:42251      0.0.0.0:*          \nLISTEN 0      4096           127.0.0.54:53         0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:2380       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:2379       0.0.0.0:*          \nLISTEN 0      4096        127.0.0.53%lo:53         0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:3000       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:44301      0.0.0.0:*          \nLISTEN 0      151             127.0.0.1:3306       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:44037      0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:4000       0.0.0.0:*          \nLISTEN 0      128             127.0.0.1:20292      0.0.0.0:*          \nLISTEN 0      128             127.0.0.1:20180      0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:12020      0.0.0.0:*          \nLISTEN 0      4096                    *:9100             *:*          \nLISTEN 0      4096                    *:22               *:*          \nLISTEN 0      4096                    *:8300             *:*          \nLISTEN 0      4096                    *:10080            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:3930             *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:3930             *:*          \nLISTEN 0      4096                    *:9527             *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160
*:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \n", "stderr": ""}
2023-11-01T02:34:42.229Z        INFO    LocalCommand    {"cmd": "export LANG=C; PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin /usr/bin/sudo -H -u tidb bash -c \"cd; ss -ltn\"", "stdout": "State  Recv-Q Send-Q      Local Address:Port  Peer Address:PortProcess\nLISTEN 0      70              127.0.0.1:33060      0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:45347      0.0.0.0:*          \nLISTEN 0      200             127.0.0.1:8234       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:9090       0.0.0.0:*          \nLISTEN 0      511             127.0.0.1:42251      0.0.0.0:*          \nLISTEN 0      4096           127.0.0.54:53         0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:2380       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:2379       0.0.0.0:*          \nLISTEN 0      4096        127.0.0.53%lo:53         0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:3000       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:44301      0.0.0.0:*          \nLISTEN 0      151             127.0.0.1:3306       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:44037      0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:4000       0.0.0.0:*          \nLISTEN 0      128             127.0.0.1:20292      0.0.0.0:*          \nLISTEN 0      128             127.0.0.1:20180      0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:12020      0.0.0.0:*          \nLISTEN 0      4096                    *:9100             *:*          \nLISTEN 0      4096                    *:9115             *:*          \nLISTEN 0      4096                    *:22               *:*          \nLISTEN 0      4096                    *:8300             *:*          \nLISTEN 0      4096                    *:10080            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:3930             *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:3930             *:*          \nLISTEN 0      4096                    *:9527
*:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \n", "stderr": ""}
2023-11-01T02:34:42.229Z        INFO            Start 127.0.0.1 success
// ...
````
 
2. Upgrade the cluster and check audit logs.

   The `ss -tln` command isn't cached when stopping components.
```
2023-11-01T02:36:29.240Z        INFO    Stopping component node_exporter
2023-11-01T02:36:29.246Z        INFO            Stopping instance 127.0.0.1
2023-11-01T02:36:30.044Z        INFO    LocalCommand    {"cmd": "export LANG=C; PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin /usr/bin/sudo -H -u root bash -c \"cd; systemctl daemon-reload && systemctl stop node_exporter-9100.service\"", "stdout": "", "stderr": ""}
2023-11-01T02:36:30.044Z        INFO    CheckPoint      {"host": "127.0.0.1", "port": 22, "user": "tidb", "sudo": true, "cmd": "systemctl daemon-reload && systemctl stop node_exporter-9100.service", "stdout": "", "stderr": "", "__hash__": "7634a3f7", "__func__": "github.com/pingcap/tiup/pkg/cluster/executor.(*CheckPointExecutor).Execute", "hit": false}
2023-11-01T02:36:30.072Z        INFO    LocalCommand    {"cmd": "export LANG=C; PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin /usr/bin/sudo -H -u tidb bash -c \"cd; ss -ltn\"", "stdout": "State  Recv-Q Send-Q      Local Address:Port  Peer Address:PortProcess\nLISTEN 0      70              127.0.0.1:33060      0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:45347      0.0.0.0:*          \nLISTEN 0      200             127.0.0.1:8234       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:9090       0.0.0.0:*          \nLISTEN 0      511             127.0.0.1:42251      0.0.0.0:*          \nLISTEN 0      4096           127.0.0.54:53         0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:2380       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:2379       0.0.0.0:*          \nLISTEN 0      4096        127.0.0.53%lo:53         0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:3000       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:44301      0.0.0.0:*          \nLISTEN 0      151             127.0.0.1:3306       0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:44037      0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:4000       0.0.0.0:*          \nLISTEN 0      128             127.0.0.1:20292      0.0.0.0:*          \nLISTEN 0      128             127.0.0.1:20180      0.0.0.0:*          \nLISTEN 0      4096            127.0.0.1:12020      0.0.0.0:*          \nLISTEN 0      4096                    *:9115             *:*          \nLISTEN 0      4096                    *:22               *:*          \nLISTEN 0      4096                    *:8300             *:*          \nLISTEN 0      4096                    *:10080            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:3930             *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:3930             *:*          \nLISTEN 0      4096                    *:9527             *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160
*:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20160            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \nLISTEN 0      4096   [::ffff:127.0.0.1]:20170            *:*          \n", "stderr": ""}
2023-11-01T02:36:30.072Z        INFO            Stop 127.0.0.1 success
```

 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
