### PR TITLE
playground: fix tiproxy metrics addr

### DIFF
--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -47,7 +47,7 @@ type instance struct {
 	BinPath    string
 }
 
-	// MetricAddr will be used by prometheus scrape_configs.
+// MetricAddr will be used by prometheus scrape_configs.
 type MetricAddr struct {
 	Targets []string          `json:"targets"`
 	Labels  map[string]string `json:"labels"`

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -47,6 +47,11 @@ type instance struct {
 	BinPath    string
 }
 
+type MetricAddr struct {
+	Targets []string          `json:"targets"`
+	Labels  map[string]string `json:"labels"`
+}
+
 // Instance represent running component
 type Instance interface {
 	Pid() int
@@ -59,16 +64,16 @@ type Instance interface {
 	LogFile() string
 	// Uptime show uptime.
 	Uptime() string
-	// StatusAddrs return the address to pull metrics.
-	StatusAddrs() []string
+	// MetricAddr return the address to pull metrics.
+	MetricAddr() MetricAddr
 	// Wait Should only call this if the instance is started successfully.
 	// The implementation should be safe to call Wait multi times.
 	Wait() error
 }
 
-func (inst *instance) StatusAddrs() (addrs []string) {
+func (inst *instance) MetricAddr() (r MetricAddr) {
 	if inst.Host != "" && inst.StatusPort != 0 {
-		addrs = append(addrs, utils.JoinHostPort(inst.Host, inst.StatusPort))
+		r.Targets = append(r.Targets, utils.JoinHostPort(inst.Host, inst.StatusPort))
 	}
 	return
 }

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -47,6 +47,7 @@ type instance struct {
 	BinPath    string
 }
 
+	// MetricAddr will be used by prometheus scrape_configs.
 type MetricAddr struct {
 	Targets []string          `json:"targets"`
 	Labels  map[string]string `json:"labels"`

--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -54,6 +54,7 @@ func NewTiProxy(binPath string, dir, host, configPath string, id int, port int, 
 	return tiproxy
 }
 
+// MetricAddr implements Instance interface.
 func (c *TiProxy) MetricAddr() (r MetricAddr) {
 	r.Targets = append(r.Targets, utils.JoinHostPort(c.Host, c.StatusPort))
 	r.Labels = map[string]string{

--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -54,6 +54,14 @@ func NewTiProxy(binPath string, dir, host, configPath string, id int, port int, 
 	return tiproxy
 }
 
+func (c *TiProxy) MetricAddr() (r MetricAddr) {
+	r.Targets = append(r.Targets, utils.JoinHostPort(c.Host, c.StatusPort))
+	r.Labels = map[string]string{
+		"__metrics_path__": "/api/metrics",
+	}
+	return
+}
+
 // Start implements Instance interface.
 func (c *TiProxy) Start(ctx context.Context, version utils.Version) error {
 	endpoints := pdEndpoints(c.pds, true)

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1289,12 +1289,10 @@ func (p *Playground) renderSDFile() error {
 		return nil
 	}
 
-	cid2targets := make(map[string][]string)
+	cid2targets := make(map[string]instance.MetricAddr)
 
 	_ = p.WalkInstances(func(cid string, inst instance.Instance) error {
-		targets := cid2targets[cid]
-		targets = append(targets, inst.StatusAddrs()...)
-		cid2targets[cid] = targets
+		cid2targets[cid] = inst.MetricAddr()
 		return nil
 	})
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


Playground promtheus pulls wrong metric addresses for tiproxy.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix tiproxy metrics on playground
```
