### PR TITLE
playground/log: add mcs name for pd log

### DIFF
--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -37,7 +37,7 @@ const (
 	// PDRoleScheduling is the role of PD scheduling
 	PDRoleScheduling PDRole = "scheduling"
 	// PDRoleResourceManager is the role of PD resource manager
-	PDRoleResourceManager PDRole = "resource manager"
+	PDRoleResourceManager PDRole = "resource_manager"
 )
 
 // PDInstance represent a running pd-server

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -697,6 +697,10 @@ func (p *Playground) addInstance(componentID string, pdRole instance.PDRole, tif
 
 	id := p.allocID(componentID)
 	dir := filepath.Join(dataDir, fmt.Sprintf("%s-%d", componentID, id))
+	if componentID == string(instance.PDRoleNormal) && pdRole != instance.PDRoleNormal {
+		id = p.allocID(fmt.Sprintf("%s-%s", componentID, pdRole))
+		dir = filepath.Join(dataDir, fmt.Sprintf("%s-%s-%d", componentID, pdRole, id))
+	}
 	if err = utils.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

change log name for pd mcs

run `./tiup-playground nightly --pd.mode ms --pd.api 3 --pd.tso 2 --pd.rm 1`
before
![image](https://github.com/pingcap/tiup/assets/53859786/d7b45fa8-d4b0-4dd9-b16e-7e6e1612357f)

after
![image](https://github.com/pingcap/tiup/assets/53859786/0e78d005-fac9-402d-9800-02a3f47b79fd)



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
