### PR TITLE
playground: Fix alignment of output

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1166,7 +1166,7 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 
 	if g := p.grafana; g != nil {
 		p.updateMonitorTopology(spec.ComponentGrafana, MonitorInfo{g.host, g.port, g.cmd.Path})
-		fmt.Printf("Grafana:        ")
+		fmt.Printf("Grafana:         ")
 		colorCmd.Printf("http://%s\n", utils.JoinHostPort(g.host, g.port))
 	}
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

`tiup playground --tiproxy 1 v7.1.2`:

Without this PR:

```
Connect TiDB:    mysql --comments --host 127.0.0.1 --port 4000 -u root
Connect TiProxy: mysql --comments --host 127.0.0.1 --port 6000 -u root
TiDB Dashboard:  http://127.0.0.1:2379/dashboard
Grafana:        http://127.0.0.1:3000
```

With this PR:

```
Connect TiDB:    mysql --comments --host 127.0.0.1 --port 4000 -u root
Connect TiProxy: mysql --comments --host 127.0.0.1 --port 36243 -u root
TiDB Dashboard:  http://127.0.0.1:2379/dashboard
Grafana:         http://127.0.0.1:3000
```

The line with `Grafana:` isn't aligned correctly

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
