### PR TITLE
playground: Only add --comments when needed

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1489,7 +1489,7 @@ func mysqlCommand() (cmd string) {
 	if err != nil {
 		return
 	}
-	vMaj, vMin, _, err := parseMysqlCommand(string(mysqlVerOutput))
+	vMaj, vMin, _, err := parseMysqlVersion(string(mysqlVerOutput))
 	if err == nil {
 		if vMaj == 8 && vMin >= 1 { // 8.1.0 and newer
 			return "mysql"
@@ -1498,12 +1498,12 @@ func mysqlCommand() (cmd string) {
 	return
 }
 
-// parseMysqlCommand parses the output from `mysql --version` that is in `versionOutput`
+// parseMysqlVersion parses the output from `mysql --version` that is in `versionOutput`
 // and returns the major, minor and patch version.
 //
 // New format example: `mysql  Ver 8.2.0 for Linux on x86_64 (MySQL Community Server - GPL)`
 // Old format example: `mysql  Ver 14.14 Distrib 5.7.36, for linux-glibc2.12 (x86_64) using  EditLine wrapper`
-func parseMysqlCommand(versionOutput string) (vMaj int, vMin int, vPatch int, err error) {
+func parseMysqlVersion(versionOutput string) (vMaj int, vMin int, vPatch int, err error) {
 	mysqlVerRegexp := regexp.MustCompile(`(Ver|Distrib) ([0-9]+)\.([0-9]+)\.([0-9]+)`)
 	mysqlVerMatch := mysqlVerRegexp.FindStringSubmatch(versionOutput)
 	if mysqlVerMatch == nil {

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1503,8 +1503,14 @@ func mysqlCommand() (cmd string) {
 //
 // New format example: `mysql  Ver 8.2.0 for Linux on x86_64 (MySQL Community Server - GPL)`
 // Old format example: `mysql  Ver 14.14 Distrib 5.7.36, for linux-glibc2.12 (x86_64) using  EditLine wrapper`
+// MariaDB 11.2 format: `/usr/bin/mysql from 11.2.2-MariaDB, client 15.2 for linux-systemd (x86_64) using readline 5.1`
+//
+// Note that MariaDB has `bin/mysql` (deprecated) and `bin/mariadb`. This is to parse the version from `bin/mysql`.
+// As TiDB is a MySQL compatible database we recommend `bin/mysql` from MySQL.
+// If we ever want to auto-detect other clients like `bin/mariadb`, `bin/mysqlsh`, `bin/mycli`, etc then
+// each of them needs their own version detection and adjust for the right commandline options.
 func parseMysqlVersion(versionOutput string) (vMaj int, vMin int, vPatch int, err error) {
-	mysqlVerRegexp := regexp.MustCompile(`(Ver|Distrib) ([0-9]+)\.([0-9]+)\.([0-9]+)`)
+	mysqlVerRegexp := regexp.MustCompile(`(Ver|Distrib|from) ([0-9]+)\.([0-9]+)\.([0-9]+)`)
 	mysqlVerMatch := mysqlVerRegexp.FindStringSubmatch(versionOutput)
 	if mysqlVerMatch == nil {
 		return 0, 0, 0, errors.New("No match")

--- a/components/playground/playground_test.go
+++ b/components/playground/playground_test.go
@@ -91,6 +91,13 @@ func TestParseMysqlCommand(t *testing.T) {
 			37,
 			false,
 		},
+		{
+			"/bin/mysql from 11.2.2-MariaDB, client 15.2 for linux-systemd (x86_64) using readline 5.1",
+			11,
+			2,
+			2,
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/components/playground/playground_test.go
+++ b/components/playground/playground_test.go
@@ -94,7 +94,7 @@ func TestParseMysqlCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		vMaj, vMin, vPatch, err := parseMysqlCommand(tc.version)
+		vMaj, vMin, vPatch, err := parseMysqlVersion(tc.version)
 		if tc.err {
 			assert.NotNil(t, err)
 		} else {

--- a/components/playground/playground_test.go
+++ b/components/playground/playground_test.go
@@ -40,3 +40,68 @@ func TestPlaygroundAbsDir(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, filepath.Join(u.HomeDir, "c/d/e"), c)
 }
+
+func TestParseMysqlCommand(t *testing.T) {
+	cases := []struct {
+		version string
+		vMaj    int
+		vMin    int
+		vPatch  int
+		err     bool
+	}{
+		{
+			"mysql  Ver 8.2.0 for Linux on x86_64 (MySQL Community Server - GPL)",
+			8,
+			2,
+			0,
+			false,
+		},
+		{
+			"mysql  Ver 8.0.34 for Linux on x86_64 (MySQL Community Server - GPL)",
+			8,
+			0,
+			34,
+			false,
+		},
+		{
+			"mysql  Ver 8.0.34-foobar for Linux on x86_64 (MySQL Community Server - GPL)",
+			8,
+			0,
+			34,
+			false,
+		},
+		{
+			"foobar",
+			0,
+			0,
+			0,
+			true,
+		},
+		{
+			"mysql  Ver 14.14 Distrib 5.7.36, for linux-glibc2.12 (x86_64) using  EditLine wrapper",
+			5,
+			7,
+			36,
+			false,
+		},
+		{
+			"mysql  Ver 15.1 Distrib 10.3.37-MariaDB, for Linux (x86_64) using readline 5.1",
+			10,
+			3,
+			37,
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		vMaj, vMin, vPatch, err := parseMysqlCommand(tc.version)
+		if tc.err {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+		}
+		assert.Equal(t, vMaj, tc.vMaj)
+		assert.Equal(t, vMin, tc.vMin)
+		assert.Equal(t, vPatch, tc.vPatch)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

From https://dev.mysql.com/doc/relnotes/mysql/8.1/en/news-8-1-0.html

> Comments in the mysql client are now enabled by default. To disable them, start mysql with the --skip-comments option.
> 
> Our thanks to Daniël van Eeden for the contribution. (Bug #109972, Bug #35061087, WL #15597)

This means we can shorten the commandline to connect to TiDB if the client is newer than 8.1.0.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Side effects

 - Increased code complexity


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
TiUP Playground now only prints `--comments` for older versions of MySQL Client.
```
