### PR TITLE
Change revive cognitive-complexity settings

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,22 @@
+name: lint
+
+on:
+  pull_request:
+
+jobs:
+  install:
+    name: Lint
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: go/src/github.com/${{ github.repository }}
+
+      - name: Lint
+        working-directory: ${{ env.working-directory }}
+        run: make lint
+

--- a/components/dm/ansible/import.go
+++ b/components/dm/ansible/import.go
@@ -273,6 +273,8 @@ func instancDeployDir(comp string, port int, hostDir string, globalDir string) s
 }
 
 // ImportFromAnsibleDir generate the metadata from ansible deployed cluster.
+//
+//revive:disable
 func (im *Importer) ImportFromAnsibleDir(ctx context.Context) (clusterName string, meta *spec.Metadata, err error) {
 	dir := im.dir
 	inventoryFileName := im.inventoryFileName

--- a/pkg/cluster/ansible/inventory.go
+++ b/pkg/cluster/ansible/inventory.go
@@ -133,6 +133,7 @@ func ParseAndImportInventory(ctx context.Context, dir, ansCfgFile string, clsMet
 	return defaults.Set(clsMeta)
 }
 
+//revive:disable
 func parseGroupVars(ctx context.Context, dir, ansCfgFile string, clsMeta *spec.ClusterMeta, inv *aini.InventoryData) error {
 	logger := ctx.Value(logprinter.ContextKeyLogger).(*logprinter.Logger)
 

--- a/pkg/cluster/ansible/service.go
+++ b/pkg/cluster/ansible/service.go
@@ -34,6 +34,8 @@ var (
 )
 
 // parseDirs sets values of directories of component
+//
+//revive:disable
 func parseDirs(ctx context.Context, user string, ins spec.InstanceSpec, sshTimeout uint64, sshType executor.SSHType) (spec.InstanceSpec, error) {
 	logger := ctx.Value(logprinter.ContextKeyLogger).(*logprinter.Logger)
 	hostName, sshPort := ins.SSH()

--- a/pkg/cluster/operation/scale_in.go
+++ b/pkg/cluster/operation/scale_in.go
@@ -83,6 +83,8 @@ func ScaleIn(
 }
 
 // ScaleInCluster scales in the cluster
+//
+//revive:disable
 func ScaleInCluster(
 	ctx context.Context,
 	cluster *spec.Specification,

--- a/tools/check/revive.toml
+++ b/tools/check/revive.toml
@@ -45,8 +45,8 @@ warningCode = 0
 [rule.use-any]
 
 [rule.cognitive-complexity]
-  severity = "warning"
-  arguments =[48]
+  severity = "error"
+  arguments =[100]
 #[rule.cyclomatic]
 #  severity = "warning"
 #  arguments = [48]


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The revive check for cognitive complexity was emitting warnings:
```
$ make lint 
linting
  ⚠  https://revive.run/r#cognitive-complexity  function (*Manager).Deploy has cognitive complexity 66 (> max enabled 48)  
  ./pkg/cluster/manager/deploy.go:57:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*Specification).CountDir has cognitive complexity 51 (> max enabled 48)  
  ./pkg/cluster/spec/validate.go:812:1

  ⚠  https://revive.run/r#cognitive-complexity  function newImportCmd has cognitive complexity 51 (> max enabled 48)  
  ./components/cluster/command/import.go:31:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*cleanupFiles).instanceCleanupFiles has cognitive complexity 54 (> max enabled 48)  
  ./pkg/cluster/manager/cleanup.go:186:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*Manager).ScaleOut has cognitive complexity 64 (> max enabled 48)  
  ./pkg/cluster/manager/scale_out.go:40:1

  ⚠  https://revive.run/r#cognitive-complexity  function init has cognitive complexity 56 (> max enabled 48)  
  ./cmd/root.go:56:1

  ⚠  https://revive.run/r#cognitive-complexity  function parseGroupVars has cognitive complexity 245 (> max enabled 48)  
  ./pkg/cluster/ansible/inventory.go:136:1

  ⚠  https://revive.run/r#cognitive-complexity  function parseDirs has cognitive complexity 105 (> max enabled 48)  
  ./pkg/cluster/ansible/service.go:37:1

  ⚠  https://revive.run/r#cognitive-complexity  function cloneComponents has cognitive complexity 71 (> max enabled 48)  
  ./pkg/repository/clone_mirror.go:246:1

  ⚠  https://revive.run/r#cognitive-complexity  function combineVersions has cognitive complexity 79 (> max enabled 48)  
  ./pkg/repository/clone_mirror.go:423:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*Importer).ImportFromAnsibleDir has cognitive complexity 156 (> max enabled 48)  
  ./components/dm/ansible/import.go:276:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*Playground).handleScaleIn has cognitive complexity 74 (> max enabled 48)  
  ./components/playground/playground.go:261:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*Playground).bootCluster has cognitive complexity 99 (> max enabled 48)  
  ./components/playground/playground.go:894:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*Playground).terminate has cognitive complexity 56 (> max enabled 48)  
  ./components/playground/playground.go:1204:1

  ⚠  https://revive.run/r#cognitive-complexity  function Execute has cognitive complexity 57 (> max enabled 48)  
  ./components/cluster/command/root.go:276:1

  ⚠  https://revive.run/r#cognitive-complexity  function ScpDownload has cognitive complexity 65 (> max enabled 48)  
  ./pkg/cluster/executor/scp.go:33:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*Manager).Upgrade has cognitive complexity 90 (> max enabled 48)  
  ./pkg/cluster/manager/upgrade.go:41:1

  ⚠  https://revive.run/r#cognitive-complexity  function Upgrade has cognitive complexity 91 (> max enabled 48)  
  ./pkg/cluster/operation/upgrade.go:43:1

  ⚠  https://revive.run/r#cognitive-complexity  function setCustomDefaults has cognitive complexity 57 (> max enabled 48)  
  ./pkg/cluster/spec/spec.go:608:1

  ⚠  https://revive.run/r#cognitive-complexity  function DestroyComponent has cognitive complexity 59 (> max enabled 48)  
  ./pkg/cluster/operation/destroy.go:339:1

  ⚠  https://revive.run/r#cognitive-complexity  function DestroyClusterTombstone has cognitive complexity 65 (> max enabled 48)  
  ./pkg/cluster/operation/destroy.go:475:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*MonitorInstance).InitConfig has cognitive complexity 80 (> max enabled 48)  
  ./pkg/cluster/spec/monitoring.go:190:1

  ⚠  https://revive.run/r#cognitive-complexity  function ScaleInCluster has cognitive complexity 167 (> max enabled 48)  
  ./pkg/cluster/operation/scale_in.go:86:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*Manager).Display has cognitive complexity 65 (> max enabled 48)  
  ./pkg/cluster/manager/display.go:117:1

  ⚠  https://revive.run/r#cognitive-complexity  function (*Manager).GetClusterTopology has cognitive complexity 56 (> max enabled 48)  
  ./pkg/cluster/manager/display.go:528:1

  ⚠  https://revive.run/r#cognitive-complexity  function ScaleInDMCluster has cognitive complexity 57 (> max enabled 48)  
  ./components/dm/command/scale_in.go:76:1

⚠ 26 problems (0 errors, 26 warnings)

Warnings:
  26  cognitive-complexity  
```

It looks like these warnings were not getting noticed or fixed.

### What is changed and how it works?

This PR:

1.  Changes the complexity limit to 100 and marks existing cases that go over 100 with `//revive:disable`.
2.  Changes the check to error when the limit is exceeded (previously it would just warn)

This makes accidentally exceeding this with new code harder.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
