### PR TITLE
fix the start script for alertmanager when enabling numa

### DIFF
--- a/embed/templates/scripts/run_alertmanager.sh.tpl
+++ b/embed/templates/scripts/run_alertmanager.sh.tpl
@@ -11,7 +11,7 @@ exec > >(tee -i -a "{{.LogDir}}/alertmanager.log")
 exec 2>&1
 
 {{- if .NumaNode}}
-exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/alertmanager \
+exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/alertmanager/alertmanager \
 {{- else}}
 exec bin/alertmanager/alertmanager \
 {{- end}}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close #2329

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Deploy a cluster with a alertmanager.

```yaml
alertmanager_servers:
  - host: 127.0.0.1
    numa_node: "0"
```

Check the start script of this alertmanager.

```bash
#!/bin/bash
set -e

DEPLOY_DIR=/tidb-deploy/alertmanager-9093
cd "${DEPLOY_DIR}" || exit 1

# WARNING: This file was auto-generated. Do not edit!
#          All your edit might be overwritten!

exec > >(tee -i -a "/tidb-deploy/alertmanager-9093/log/alertmanager.log")
exec 2>&1
exec numactl --cpunodebind=0 --membind=0 bin/alertmanager/alertmanager \
    --config.file="conf/alertmanager.yml" \
    --storage.path="/tidb-data/alertmanager-9093" \
    --data.retention=120h \
    --log.level="info" \
    --web.listen-address="0.0.0.0:9093" \
    --web.external-url="http://127.0.0.1:9093" \
    --cluster.peer="127.0.0.1:9094" \
    --cluster.listen-address="127.0.0.1:9094"
```

 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
