### PR TITLE
playground: tiproxy needs to override usercfg

### DIFF
--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -90,11 +90,10 @@ func (c *TiProxy) Start(ctx context.Context, version utils.Version) error {
 	enc := toml.NewEncoder(cf)
 	enc.Indent = ""
 	if err := enc.Encode(spec.MergeConfig(userConfig, map[string]any{
-		"proxy.pd-addrs":            strings.Join(endpoints, ","),
-		"proxy.addr":                utils.JoinHostPort(c.Host, c.Port),
-		"proxy.require-backend-tls": false,
-		"api.addr":                  utils.JoinHostPort(c.Host, c.StatusPort),
-		"log.log-file.filename":     c.LogFile(),
+		"proxy.pd-addrs":        strings.Join(endpoints, ","),
+		"proxy.addr":            utils.JoinHostPort(c.Host, c.Port),
+		"api.addr":              utils.JoinHostPort(c.Host, c.StatusPort),
+		"log.log-file.filename": c.LogFile(),
 	})); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/minio/minio-go/v7 v7.0.52
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/otiai10/copy v1.9.0
-	github.com/pelletier/go-toml v1.9.5
 	github.com/pingcap/check v0.0.0-20211026125417-57bd13f7b5f0
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,6 @@ github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.4.0 h1:umwcf7gbpEwf7WFzqmWwSv0CzbeMsae2u9ZvpP8j2q4=
 github.com/otiai10/mint v1.4.0/go.mod h1:gifjb2MYOoULtKLqUAEILUG/9KONW6f7YsJ6vQLTlFI=
-github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
-github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/check v0.0.0-20211026125417-57bd13f7b5f0 h1:HVl5539r48eA+uDuX/ziBmQCxzT1pGrzWbKuXT46Bq0=
 github.com/pingcap/check v0.0.0-20211026125417-57bd13f7b5f0/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close #2339 

previously, it doesnt override user config correctly leading to port conflicts when using custom configs for multiple tiproxy instances. TiDB pass ports by cli flags so then are fine.

Also, log-file is not passed

### What is changed and how it works?

1. use different logic than TiDB to generate configs.
2. pass log-file


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
