### PR TITLE
playground: fallback to default version when componen specific version is empty

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -883,12 +883,15 @@ func (p *Playground) waitAllTiFlashUp() {
 func (p *Playground) bindVersion(comp string, version string) (bindVersion string) {
 	switch comp {
 	case spec.ComponentTiKVCDC:
-		return p.bootOptions.TiKVCDC.Version
+		bindVersion = p.bootOptions.TiKVCDC.Version
 	case spec.ComponentTiProxy:
-		return p.bootOptions.TiProxy.Version
+		bindVersion = p.bootOptions.TiProxy.Version
 	default:
-		return version
 	}
+	if bindVersion == "" {
+		bindVersion = version
+	}
+	return
 }
 
 func (p *Playground) bootCluster(ctx context.Context, env *environment.Environment, options *BootOptions) error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close #2343 . Fallback to default version when componen specific version is empty

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
