### PR TITLE
delete `logger.level` and `profiles.default.max_memory_usage` in tiflash default configs

### DIFF
--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -538,10 +538,6 @@ func (i *TiFlashInstance) initTiFlashConfig(ctx context.Context, version string,
 		markCacheSize = `mark_cache_size: 5368709120`
 	}
 
-	logLevel := "debug"
-	if tidbver.TiFlashUseInfoLogAsDefault(version) {
-		logLevel = "info"
-	}
 	err = yaml.Unmarshal([]byte(fmt.Sprintf(`
 server_configs:
   tiflash:
@@ -564,7 +560,6 @@ server_configs:
     logger.errorlog: "%[2]s/tiflash_error.log"
     logger.log: "%[2]s/tiflash.log"
     logger.count: 20
-    logger.level: "%[15]s"
     logger.size: "1000M"
     %[13]s
     raft.pd_addr: "%[9]s"
@@ -586,7 +581,6 @@ server_configs:
 		deprecatedUsersConfig,
 		daemonConfig,
 		markCacheSize,
-		logLevel,
 	)), &topo)
 
 	if err != nil {

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -563,7 +563,6 @@ server_configs:
     logger.size: "1000M"
     %[13]s
     raft.pd_addr: "%[9]s"
-    profiles.default.max_memory_usage: 0
     %[12]s
     %[14]s
 `,

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -537,6 +537,11 @@ func (i *TiFlashInstance) initTiFlashConfig(ctx context.Context, version string,
 		daemonConfig = `application.runAsDaemon: true`
 		markCacheSize = `mark_cache_size: 5368709120`
 	}
+
+	logLevel := "debug"
+	if tidbver.TiFlashUseInfoLogAsDefault(version) {
+		logLevel = "info"
+	}
 	err = yaml.Unmarshal([]byte(fmt.Sprintf(`
 server_configs:
   tiflash:
@@ -559,7 +564,7 @@ server_configs:
     logger.errorlog: "%[2]s/tiflash_error.log"
     logger.log: "%[2]s/tiflash.log"
     logger.count: 20
-    logger.level: "debug"
+    logger.level: "%[15]s"
     logger.size: "1000M"
     %[13]s
     raft.pd_addr: "%[9]s"
@@ -581,6 +586,7 @@ server_configs:
 		deprecatedUsersConfig,
 		daemonConfig,
 		markCacheSize,
+		logLevel,
 	)), &topo)
 
 	if err != nil {

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -56,11 +56,6 @@ func TiFlashSupportMultiDisksDeployment(version string) bool {
 	return semver.Compare(version, "v4.0.9") >= 0 || strings.Contains(version, "nightly")
 }
 
-// TiFlashUseInfoLogAsDefault return true if given version of TiFlash need use info log as the default log level
-func TiFlashUseInfoLogAsDefault(version string) bool {
-	return (semver.Compare(version, "v6.5.7") >= 0 && semver.Compare(version, "v6.6.0") < 0) || semver.Compare(version, "v7.1.0") >= 0 || strings.Contains(version, "nightly")
-}
-
 // TiFlashRequireCPUFlagAVX2 return if given version of TiFlash requires AVX2 CPU flags
 func TiFlashRequireCPUFlagAVX2(version string) bool {
 	// https://github.com/pingcap/tiup/pull/2054

--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -56,6 +56,11 @@ func TiFlashSupportMultiDisksDeployment(version string) bool {
 	return semver.Compare(version, "v4.0.9") >= 0 || strings.Contains(version, "nightly")
 }
 
+// TiFlashUseInfoLogAsDefault return true if given version of TiFlash need use info log as the default log level
+func TiFlashUseInfoLogAsDefault(version string) bool {
+	return (semver.Compare(version, "v6.5.7") >= 0 && semver.Compare(version, "v6.6.0") < 0) || semver.Compare(version, "v7.1.0") >= 0 || strings.Contains(version, "nightly")
+}
+
 // TiFlashRequireCPUFlagAVX2 return if given version of TiFlash requires AVX2 CPU flags
 func TiFlashRequireCPUFlagAVX2(version string) bool {
 	// https://github.com/pingcap/tiup/pull/2054


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
delete logger.level and profiles.default.max_memory_usage in tiflash default configs since there is no need to set them explicitly in the config file.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
