### PR TITLE
playground: init some pd configuration

### DIFF
--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -89,6 +89,15 @@ func (inst *PDInstance) Name() string {
 
 // Start calls set inst.cmd and Start
 func (inst *PDInstance) Start(ctx context.Context, version utils.Version) error {
+	configPath := filepath.Join(inst.Dir, "pd.toml")
+	if err := prepareConfig(
+		configPath,
+		inst.ConfigPath,
+		inst.getConfig(),
+	); err != nil {
+		return err
+	}
+
 	uid := inst.Name()
 	var args []string
 	switch inst.Role {
@@ -98,6 +107,7 @@ func (inst *PDInstance) Start(ctx context.Context, version utils.Version) error 
 		}
 		args = append(args, []string{
 			"--name=" + uid,
+			fmt.Sprintf("--config=%s", configPath),
 			fmt.Sprintf("--data-dir=%s", filepath.Join(inst.Dir, "data")),
 			fmt.Sprintf("--peer-urls=http://%s", utils.JoinHostPort(inst.Host, inst.Port)),
 			fmt.Sprintf("--advertise-peer-urls=http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.Port)),
@@ -105,9 +115,7 @@ func (inst *PDInstance) Start(ctx context.Context, version utils.Version) error 
 			fmt.Sprintf("--advertise-client-urls=http://%s", utils.JoinHostPort(AdvertiseHost(inst.Host), inst.StatusPort)),
 			fmt.Sprintf("--log-file=%s", inst.LogFile()),
 		}...)
-		if inst.ConfigPath != "" {
-			args = append(args, fmt.Sprintf("--config=%s", inst.ConfigPath))
-		}
+
 		switch {
 		case len(inst.initEndpoints) > 0:
 			endpoints := make([]string, 0)

--- a/components/playground/instance/pd_config.go
+++ b/components/playground/instance/pd_config.go
@@ -1,0 +1,20 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+func (inst *PDInstance) getConfig() map[string]any {
+	config := make(map[string]any)
+	config["schedule.patrol-region-interval"] = "100ms"
+	return config
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/tikv/pd/issues/7507

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
#### Before:
![image](https://github.com/pingcap/tiup/assets/6428910/f621e641-0bb4-4dae-843e-cd5cd26cdd25)

#### After:
![image](https://github.com/pingcap/tiup/assets/6428910/97a4a7db-b2da-4249-876b-a4b9ffb1b592)
config:
```
➜  pd-0 cat pd.toml
[schedule]
patrol-region-interval = "100ms"
```


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
