### PR TITLE
Turn off THP added to boot

### DIFF
--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -669,7 +669,13 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder) (s
 			fmt.Sprintf(`if [ -d %[1]s ]; then echo never > %[1]s/enabled; fi`, "/sys/kernel/mm/transparent_hugepage"),
 			"",
 			true)
-		msg = fmt.Sprintf("will try to %s, please check again after reboot", color.HiBlueString("disable THP"))
+		// msg = fmt.Sprintf("will try to %s, please check again after reboot", color.HiBlueString("disable THP"))
+		// Add Disable THP to /etc/rc.local
+		t.Shell(host,
+			fmt.Sprintf(`if ! grep -q 'echo never > %[1]s' /etc/rc.local; then echo 'echo never > %[1]s' | sudo tee -a /etc/rc.local; fi`, "/sys/kernel/mm/transparent_hugepage/enabled"),
+			"",
+			true)
+		msg = fmt.Sprintf("will try to %s, please check again after reboot", color.HiBlueString("disable THP & Add Disable THP to /etc/rc.local"))
 	case operator.CheckNameSwap:
 		// not applying swappiness setting here, it should be fixed
 		// in the sysctl check

--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -666,13 +666,21 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder) (s
 		msg = fmt.Sprintf("will try to %s, reboot might be needed", color.HiBlueString("disable SELinux"))
 	case operator.CheckNameTHP:
 		t.Shell(host,
-			fmt.Sprintf(`if [ -d %[1]s ]; then echo never > %[1]s/enabled; fi`, "/sys/kernel/mm/transparent_hugepage"),
+			fmt.Sprintf(`if [ -d %[1]s ]; then echo never > %[1]s/enabled && echo never > %[1]s/defrag; fi`, "/sys/kernel/mm/transparent_hugepage"),
 			"",
 			true)
 		// msg = fmt.Sprintf("will try to %s, please check again after reboot", color.HiBlueString("disable THP"))
 		// Add Disable THP to /etc/rc.local
 		t.Shell(host,
 			fmt.Sprintf(`if ! grep -q 'echo never > %[1]s' /etc/rc.local; then echo 'echo never > %[1]s' | sudo tee -a /etc/rc.local; fi`, "/sys/kernel/mm/transparent_hugepage/enabled"),
+			"",
+			true)
+		t.Shell(host,
+			fmt.Sprintf(`if ! grep -q 'echo never > %[1]s' /etc/rc.local; then echo 'echo never > %[1]s' | sudo tee -a /etc/rc.local; fi`, "/sys/kernel/mm/transparent_hugepage/defrag"),
+			"",
+			true)
+		t.Shell(host,
+			fmt.Sprintf(`if ! [[ -x "%[1]s" ]]; then sudo chmod +x %[1]s; fi`, "/etc/rc.local"),
 			"",
 			true)
 		msg = fmt.Sprintf("will try to %s, please check again after reboot", color.HiBlueString("disable THP & Add Disable THP to /etc/rc.local"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Troubleshoot the problem that a large page of the server opens after the server restarts

### What is changed and how it works?
Start The large page is opened：
![image](https://github.com/pingcap/tiup/assets/26704896/7cc02e35-b4f8-47a4-bd2c-fe80dcc50389)

tiup check apply：
![image](https://github.com/pingcap/tiup/assets/26704896/92649f88-b918-42e3-ad3b-4acac6b6a7a7)

the config:
![image](https://github.com/pingcap/tiup/assets/26704896/fb3fc579-077d-4406-8164-7c287dab0d9a)

You can see that THP has been turned off, and the shutdown is written into the Open startup item

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
