### PR TITLE
cluster: fix tiproxy config and version

### DIFF
--- a/pkg/cluster/spec/tiproxy.go
+++ b/pkg/cluster/spec/tiproxy.go
@@ -136,10 +136,14 @@ func (c *TiProxyComponent) Source() string {
 
 // CalculateVersion implements the Component interface
 func (c *TiProxyComponent) CalculateVersion(clusterVersion string) string {
-	// always not follow global version, use ""(latest) by default
 	version := c.Topology.ComponentVersions.TiProxy
 	if version == "" {
-		version = "nightly"
+		// always not follow global version
+		// because tiproxy version is different from clusterVersion
+		// but "nightly" is effective
+		if clusterVersion == "nightly" {
+			version = clusterVersion
+		}
 	}
 	return version
 }

--- a/pkg/cluster/spec/tiproxy.go
+++ b/pkg/cluster/spec/tiproxy.go
@@ -138,6 +138,9 @@ func (c *TiProxyComponent) Source() string {
 func (c *TiProxyComponent) CalculateVersion(clusterVersion string) string {
 	// always not follow global version, use ""(latest) by default
 	version := c.Topology.ComponentVersions.TiProxy
+	if version == "" {
+		version = "nightly"
+	}
 	return version
 }
 
@@ -224,7 +227,6 @@ func (i *TiProxyInstance) checkConfig(
 		pds = append(pds, pdspec.GetAdvertiseClientURL(enableTLS))
 	}
 	cfg["proxy.pd-addrs"] = strings.Join(pds, ",")
-	cfg["proxy.require-backend-tls"] = false
 	cfg["proxy.addr"] = utils.JoinHostPort(i.GetListenHost(), i.GetPort())
 	cfg["api.addr"] = utils.JoinHostPort(i.GetListenHost(), spec.StatusPort)
 	cfg["log.log-file.filename"] = filepath.Join(paths.Log, "tiproxy.log")
@@ -311,7 +313,7 @@ func (i *TiProxyInstance) setTLSConfig(ctx context.Context, enableTLS bool, conf
 		}
 	}
 
-	return nil, nil
+	return configs, nil
 }
 
 var _ RollingUpdateInstance = &TiProxyInstance{}

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -938,6 +938,7 @@ func (s *Specification) validateTLSEnabled() error {
 			ComponentTiDB,
 			ComponentTiKV,
 			ComponentTiFlash,
+			ComponentTiProxy,
 			ComponentPump,
 			ComponentDrainer,
 			ComponentCDC,


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1, `require-backend-tls` is useless
2. now we use `nightly` version by default
3. fix a bug where configs are lost


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
