### PR TITLE
cluster: fix TLS configs for tiproxy

### DIFF
--- a/pkg/cluster/spec/tiproxy.go
+++ b/pkg/cluster/spec/tiproxy.go
@@ -220,6 +220,7 @@ func (i *TiProxyInstance) checkConfig(
 ) map[string]any {
 	topo := i.topo.(*Specification)
 	spec := i.InstanceSpec.(*TiProxySpec)
+	enableTLS := topo.GlobalOptions.TLSEnabled
 
 	if cfg == nil {
 		cfg = make(map[string]any)
@@ -227,7 +228,7 @@ func (i *TiProxyInstance) checkConfig(
 
 	pds := []string{}
 	for _, pdspec := range topo.PDServers {
-		pds = append(pds, utils.JoinHostPort(pdspec.Host, pdspec.ClientPort))
+		pds = append(pds, pdspec.GetAdvertiseClientURL(enableTLS))
 	}
 	cfg["proxy.pd-addrs"] = strings.Join(pds, ",")
 	cfg["proxy.addr"] = utils.JoinHostPort(i.GetListenHost(), i.GetPort())
@@ -274,7 +275,7 @@ func (i *TiProxyInstance) InitConfig(
 	}
 
 	var err error
-	instanceConfig, err = i.setTLSConfig(ctx, false, instanceConfig, paths)
+	instanceConfig, err = i.setTLSConfig(ctx, topo.GlobalOptions.TLSEnabled, instanceConfig, paths)
 	if err != nil {
 		return err
 	}
@@ -292,12 +293,14 @@ func (i *TiProxyInstance) setTLSConfig(ctx context.Context, enableTLS bool, conf
 		configs["security.cluster-tls.cert"] = fmt.Sprintf("%s/tls/%s.crt", paths.Deploy, i.Role())
 		configs["security.cluster-tls.key"] = fmt.Sprintf("%s/tls/%s.pem", paths.Deploy, i.Role())
 
-		configs["security.server-tls.ca"] = fmt.Sprintf("%s/tls/%s", paths.Deploy, TLSCACert)
-		configs["security.server-tls.cert"] = fmt.Sprintf("%s/tls/%s.crt", paths.Deploy, i.Role())
-		configs["security.server-tls.key"] = fmt.Sprintf("%s/tls/%s.pem", paths.Deploy, i.Role())
-		configs["security.server-tls.skip-ca"] = true
+		configs["security.server-http-tls.ca"] = fmt.Sprintf("%s/tls/%s", paths.Deploy, TLSCACert)
+		configs["security.server-http-tls.cert"] = fmt.Sprintf("%s/tls/%s.crt", paths.Deploy, i.Role())
+		configs["security.server-http-tls.key"] = fmt.Sprintf("%s/tls/%s.pem", paths.Deploy, i.Role())
+		configs["security.server-http-tls.skip-ca"] = true
 
 		configs["security.sql-tls.ca"] = fmt.Sprintf("%s/tls/%s", paths.Deploy, TLSCACert)
+		configs["security.sql-tls.cert"] = fmt.Sprintf("%s/tls/%s.crt", paths.Deploy, i.Role())
+		configs["security.sql-tls.key"] = fmt.Sprintf("%s/tls/%s.pem", paths.Deploy, i.Role())
 	} else {
 		// drainer tls config list
 		tlsConfigs := []string{
@@ -308,7 +311,13 @@ func (i *TiProxyInstance) setTLSConfig(ctx context.Context, enableTLS bool, conf
 			"security.server-tls.cert",
 			"security.server-tls.key",
 			"security.server-tls.skip-ca",
+			"security.server-http-tls.ca",
+			"security.server-http-tls.cert",
+			"security.server-http-tls.key",
+			"security.server-http-tls.skip-ca",
 			"security.sql-tls.ca",
+			"security.sql-tls.cert",
+			"security.sql-tls.key",
 		}
 		// delete TLS configs
 		for _, config := range tlsConfigs {

--- a/pkg/cluster/spec/tiproxy.go
+++ b/pkg/cluster/spec/tiproxy.go
@@ -220,7 +220,6 @@ func (i *TiProxyInstance) checkConfig(
 ) map[string]any {
 	topo := i.topo.(*Specification)
 	spec := i.InstanceSpec.(*TiProxySpec)
-	enableTLS := topo.GlobalOptions.TLSEnabled
 
 	if cfg == nil {
 		cfg = make(map[string]any)
@@ -228,7 +227,7 @@ func (i *TiProxyInstance) checkConfig(
 
 	pds := []string{}
 	for _, pdspec := range topo.PDServers {
-		pds = append(pds, pdspec.GetAdvertiseClientURL(enableTLS))
+		pds = append(pds, utils.JoinHostPort(pdspec.Host, pdspec.ClientPort))
 	}
 	cfg["proxy.pd-addrs"] = strings.Join(pds, ",")
 	cfg["proxy.addr"] = utils.JoinHostPort(i.GetListenHost(), i.GetPort())


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


1. `server-tls` of tidb is manually specified, so does tiproxy's `server-tls`. Instead, for newer tiproxy, `server-http-tls` should be specified.
2. `topo.GlobalOptions.TLSEnabled` is not passed to `setTLSConfig`.
3. remove `schema://` and be consistent with tidb


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
