### PR TITLE
cluster/tiflash: Remove deprecated config items

### DIFF
--- a/pkg/tidbver/tidbver.go
+++ b/pkg/tidbver/tidbver.go
@@ -88,6 +88,11 @@ func TiFlashNotNeedSomeConfig(version string) bool {
 	return semver.Compare(version, "v5.4.0") >= 0 || strings.Contains(version, "nightly")
 }
 
+// TiFlashNotNeedSomeConfig return if given version of TiFlash do not need to start `cluster_manager`
+func TiFlashNotNeedClusterManager(version string) bool {
+	return semver.Compare(version, "v6.0.0") >= 0 || strings.Contains(version, "nightly")
+}
+
 // TiFlashPlaygroundNewStartMode return true if the given version of TiFlash could be started
 // with the new implementation in TiUP playground.
 func TiFlashPlaygroundNewStartMode(version string) bool {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

* `default_profile`/`display_name`/`tmp_path` is no longer need since v5.4.0 (https://github.com/pingcap/tiflash/pull/3414)
* `flash.flash_cluster` is no longer need since v6.0.0 (https://github.com/pingcap/tidb/issues/29924)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
