### PR TITLE
cluster: fix tiproxy will restart even if version is the same

### DIFF
--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/meta"
 	"github.com/pingcap/tiup/pkg/repository"
-	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/tui"
 	"github.com/pingcap/tiup/pkg/utils"
 	"golang.org/x/mod/semver"
@@ -104,8 +103,6 @@ func (m *Manager) Upgrade(name string, clusterVersion string, componentVersions 
 			}
 		}
 	}
-	nodeFilter := set.NewStringSet(opt.Nodes...)
-
 	monitoredOptions := topo.GetMonitoredOptions()
 	if monitoredOptions != nil {
 		if componentVersions[spec.ComponentBlackboxExporter] != "" {
@@ -137,10 +134,6 @@ This operation will upgrade %s %s cluster %s to %s:%s`,
 	for _, comp := range topo.ComponentsByUpdateOrder(base.Version) {
 		compName := comp.Name()
 		version := comp.CalculateVersion(clusterVersion)
-		instances := operator.FilterInstance(comp.Instances(), nodeFilter)
-		if len(instances) < 1 {
-			continue
-		}
 
 		for _, inst := range comp.Instances() {
 			// Download component from repository

--- a/pkg/cluster/manager/upgrade.go
+++ b/pkg/cluster/manager/upgrade.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/meta"
 	"github.com/pingcap/tiup/pkg/repository"
+	"github.com/pingcap/tiup/pkg/set"
 	"github.com/pingcap/tiup/pkg/tui"
 	"github.com/pingcap/tiup/pkg/utils"
 	"golang.org/x/mod/semver"
@@ -103,6 +104,8 @@ func (m *Manager) Upgrade(name string, clusterVersion string, componentVersions 
 			}
 		}
 	}
+	nodeFilter := set.NewStringSet(opt.Nodes...)
+
 	monitoredOptions := topo.GetMonitoredOptions()
 	if monitoredOptions != nil {
 		if componentVersions[spec.ComponentBlackboxExporter] != "" {
@@ -134,6 +137,10 @@ This operation will upgrade %s %s cluster %s to %s:%s`,
 	for _, comp := range topo.ComponentsByUpdateOrder(base.Version) {
 		compName := comp.Name()
 		version := comp.CalculateVersion(clusterVersion)
+		instances := operator.FilterInstance(comp.Instances(), nodeFilter)
+		if len(instances) < 1 {
+			continue
+		}
 
 		for _, inst := range comp.Instances() {
 			// Download component from repository


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


Restart tiproxy iff version becomes different after `--tiproxyversion` or new cluster version(only `nightly` is possible though).

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
