### PR TITLE
playground: only pull nightly from cluster version

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -889,7 +889,9 @@ func (p *Playground) bindVersion(comp string, version string) (bindVersion strin
 	default:
 	}
 	if bindVersion == "" {
-		bindVersion = version
+		if version == "nightly" {
+			bindVersion = version
+		}
 	}
 	return
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`tiup playground v7.5.0 --tiproxy 1` will fail since `bindVersion = "v7.5.0"`. We should only pull `nightly` instead.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
