### PR TITLE
playground: set tiproxy addr without schema

### DIFF
--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -66,7 +66,7 @@ func (c *TiProxy) MetricAddr() (r MetricAddr) {
 
 // Start implements Instance interface.
 func (c *TiProxy) Start(ctx context.Context, version utils.Version) error {
-	endpoints := pdEndpoints(c.pds, true)
+	endpoints := pdEndpoints(c.pds, false)
 
 	configPath := filepath.Join(c.Dir, "config", "proxy.toml")
 	dir := filepath.Dir(configPath)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


If user sets TLS for PD endpoints, then tiproxy or etcd/client/v3 is not able to use TLS since `http://...` is passed to etcd client. Check https://github.com/etcd-io/etcd/blob/main/client/v3/internal/endpoint/endpoint.go#L90-L118. However, when only `host:port` is passed, the TLS config will be used.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
