### PR TITLE
playground: auto tiproxy sign certs

### DIFF
--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -29,12 +29,13 @@ type TiDBInstance struct {
 	instance
 	pds []*PDInstance
 	Process
-	enableBinlog bool
-	isDisaggMode bool
+	tiproxyCertDir string
+	enableBinlog   bool
+	isDisaggMode   bool
 }
 
 // NewTiDBInstance return a TiDBInstance
-func NewTiDBInstance(binPath string, dir, host, configPath string, id, port int, pds []*PDInstance, enableBinlog bool, isDisaggMode bool) *TiDBInstance {
+func NewTiDBInstance(binPath string, dir, host, configPath string, id, port int, pds []*PDInstance, tiproxyCertDir string, enableBinlog bool, isDisaggMode bool) *TiDBInstance {
 	if port <= 0 {
 		port = 4000
 	}
@@ -48,9 +49,10 @@ func NewTiDBInstance(binPath string, dir, host, configPath string, id, port int,
 			StatusPort: utils.MustGetFreePort("0.0.0.0", 10080),
 			ConfigPath: configPath,
 		},
-		pds:          pds,
-		enableBinlog: enableBinlog,
-		isDisaggMode: isDisaggMode,
+		tiproxyCertDir: tiproxyCertDir,
+		pds:            pds,
+		enableBinlog:   enableBinlog,
+		isDisaggMode:   isDisaggMode,
 	}
 }
 

--- a/components/playground/instance/tidb_config.go
+++ b/components/playground/instance/tidb_config.go
@@ -13,6 +13,11 @@
 
 package instance
 
+import (
+	"os"
+	"path/filepath"
+)
+
 func (inst *TiDBInstance) getConfig() map[string]any {
 	config := make(map[string]any)
 	config["security.auto-tls"] = true
@@ -20,6 +25,15 @@ func (inst *TiDBInstance) getConfig() map[string]any {
 	if inst.isDisaggMode {
 		config["use-autoscaler"] = false
 		config["disaggregated-tiflash"] = true
+	}
+
+	tiproxyCrtPath := filepath.Join(inst.tiproxyCertDir, "tiproxy.crt")
+	tiproxyKeyPath := filepath.Join(inst.tiproxyCertDir, "tiproxy.key")
+	_, err1 := os.Stat(tiproxyCrtPath)
+	_, err2 := os.Stat(tiproxyKeyPath)
+	if err1 == nil && err2 == nil {
+		config["security.session-token-signing-cert"] = tiproxyCrtPath
+		config["security.session-token-signing-key"] = tiproxyKeyPath
 	}
 
 	return config

--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -37,7 +37,7 @@ type TiProxy struct {
 
 var _ Instance = &TiProxy{}
 
-// GenTiproxySessionCerts will create a self-signed certs for TiProxy session migration. NOTE that this cert is directly used by TiDB.
+// GenTiProxySessionCerts will create a self-signed certs for TiProxy session migration. NOTE that this cert is directly used by TiDB.
 func GenTiProxySessionCerts(dir string) error {
 	if _, err := os.Stat(filepath.Join(dir, "tiproxy.crt")); err == nil {
 		return nil

--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -15,6 +15,7 @@ package instance
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
+	"github.com/pingcap/tiup/pkg/crypto"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
 	"github.com/pingcap/tiup/pkg/utils"
 )
@@ -34,6 +36,40 @@ type TiProxy struct {
 }
 
 var _ Instance = &TiProxy{}
+
+func GenTiProxySessionCerts(dir string) error {
+	if _, err := os.Stat(filepath.Join(dir, "tiproxy.crt")); err == nil {
+		return nil
+	}
+
+	ca, err := crypto.NewCA("tiproxy")
+	if err != nil {
+		return err
+	}
+	privKey, err := crypto.NewKeyPair(crypto.KeyTypeRSA, crypto.KeySchemeRSASSAPSSSHA256)
+	if err != nil {
+		return err
+	}
+	csr, err := privKey.CSR("tiproxy", "tiproxy", nil, nil)
+	if err != nil {
+		return err
+	}
+	cert, err := ca.Sign(csr)
+	if err != nil {
+		return err
+	}
+	if err := utils.SaveFileWithBackup(filepath.Join(dir, "tiproxy.key"), privKey.Pem(), ""); err != nil {
+		return err
+	}
+	if err := utils.SaveFileWithBackup(filepath.Join(dir, "tiproxy.crt"), pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	}), ""); err != nil {
+		return err
+	}
+
+	return nil
+}
 
 // NewTiProxy create a TiProxy instance.
 func NewTiProxy(binPath string, dir, host, configPath string, id int, port int, pds []*PDInstance) *TiProxy {

--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -37,6 +37,7 @@ type TiProxy struct {
 
 var _ Instance = &TiProxy{}
 
+// GenTiproxySessionCerts will create a self-signed certs for TiProxy session migration. NOTE that this cert is directly used by TiDB.
 func GenTiProxySessionCerts(dir string) error {
 	if _, err := os.Stat(filepath.Join(dir, "tiproxy.crt")); err == nil {
 		return nil
@@ -61,14 +62,10 @@ func GenTiProxySessionCerts(dir string) error {
 	if err := utils.SaveFileWithBackup(filepath.Join(dir, "tiproxy.key"), privKey.Pem(), ""); err != nil {
 		return err
 	}
-	if err := utils.SaveFileWithBackup(filepath.Join(dir, "tiproxy.crt"), pem.EncodeToMemory(&pem.Block{
+	return utils.SaveFileWithBackup(filepath.Join(dir, "tiproxy.crt"), pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: cert,
-	}), ""); err != nil {
-		return err
-	}
-
-	return nil
+	}), "")
 }
 
 // NewTiProxy create a TiProxy instance.

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -732,7 +732,7 @@ func (p *Playground) addInstance(componentID string, pdRole instance.PDRole, tif
 			p.rms = append(p.rms, inst)
 		}
 	case spec.ComponentTiDB:
-		inst := instance.NewTiDBInstance(cfg.BinPath, dir, host, cfg.ConfigPath, id, cfg.Port, p.pds, p.enableBinlog(), p.bootOptions.Mode == "tidb-disagg")
+		inst := instance.NewTiDBInstance(cfg.BinPath, dir, host, cfg.ConfigPath, id, cfg.Port, p.pds, dataDir, p.enableBinlog(), p.bootOptions.Mode == "tidb-disagg")
 		ins = inst
 		p.tidbs = append(p.tidbs, inst)
 	case spec.ComponentTiKV:
@@ -744,6 +744,9 @@ func (p *Playground) addInstance(componentID string, pdRole instance.PDRole, tif
 		ins = inst
 		p.tiflashs = append(p.tiflashs, inst)
 	case spec.ComponentTiProxy:
+		if err := instance.GenTiProxySessionCerts(dataDir); err != nil {
+			return nil, err
+		}
 		inst := instance.NewTiProxy(cfg.BinPath, dir, host, cfg.ConfigPath, id, cfg.Port, p.pds)
 		ins = inst
 		p.tiproxys = append(p.tiproxys, inst)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

User needs to manually set `session-xxxxx` for tidb, to make tiproxy migration works. However, we could just generate a self-signed cert automatically. There is no security implication: the only requirement for this cert, is that, it should be same on all tidb instances.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 ```
[2024/01/29 15:59:00.527 +08:00] [INFO] [session_token.go:198] ["signing cert is loaded successfully"] ["cert path"=/Users/xhe/.tiup/data/U2jjZcE/tiproxy.crt] ["key path"=/Users/xhe/.tiup/data/U2jjZcE/tiproxy.key]
```
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Enable tiproxy connection migration by default on playground
```
