### PR TITLE
Optimized the active judgment command

### DIFF
--- a/pkg/cluster/module/systemd.go
+++ b/pkg/cluster/module/systemd.go
@@ -77,7 +77,7 @@ func NewSystemdModule(config SystemdModuleConfig) *SystemdModule {
 		systemctl, strings.ToLower(config.Action), config.Unit)
 
 	if config.CheckActive {
-		cmd = fmt.Sprintf("if [[ $(%s is-active %s) == \"active\" ]]; then %s; fi",
+		cmd = fmt.Sprintf("if %s is-active %s &>/dev/null; then %s; fi",
 			systemctl, config.Unit, cmd)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when use GNU bash, version 5.2.21(1)-release (x86_64-redhat-linux-gnu) scale-out will be failed
```
[tidb@d86d4890486f ~]$ sudo -H bash -c "systemctl daemon-reload && if [[ $(systemctl is-active prometheus-9090.service) == "active" ]]; then systemctl reload prometheus-9090.service; fi"
Failed to connect to bus: No such file or directory
bash: -c: line 1: conditional binary operator expected
bash: -c: line 1: syntax error near `active'
bash: -c: line 1: `systemctl daemon-reload && if [[  == active ]]; then systemctl reload prometheus-9090.service; fi'
```


### What is changed and how it works?
Optimized shell statement

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
