### PR TITLE
cluster, playground: add config `advertise-addr` to tiproxy

### DIFF
--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -125,6 +125,7 @@ func (c *TiProxy) Start(ctx context.Context, version utils.Version) error {
 	if err := enc.Encode(spec.MergeConfig(userConfig, map[string]any{
 		"proxy.pd-addrs":        strings.Join(endpoints, ","),
 		"proxy.addr":            utils.JoinHostPort(c.Host, c.Port),
+		"proxy.advertise-addr":  AdvertiseHost(c.Host),
 		"api.addr":              utils.JoinHostPort(c.Host, c.StatusPort),
 		"log.log-file.filename": c.LogFile(),
 	})); err != nil {

--- a/pkg/cluster/spec/tiproxy.go
+++ b/pkg/cluster/spec/tiproxy.go
@@ -231,6 +231,7 @@ func (i *TiProxyInstance) checkConfig(
 	}
 	cfg["proxy.pd-addrs"] = strings.Join(pds, ",")
 	cfg["proxy.addr"] = utils.JoinHostPort(i.GetListenHost(), i.GetPort())
+	cfg["proxy.advertise-addr"] = spec.Host
 	cfg["api.addr"] = utils.JoinHostPort(i.GetListenHost(), spec.StatusPort)
 	cfg["log.log-file.filename"] = filepath.Join(paths.Log, "tiproxy.log")
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#2391 
TiProxy reports its IP, instead of its DNS to ETCD.

### What is changed and how it works?
Add config `advertise-addr` to tiproxy spec.
Note that it's compatible with old TiProxy versions because TiProxy won't report errors if there's an unknown config.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

With Playground:

```
MySQL [information_schema]> select * from cluster_config where key like '%advertise%';
+---------+---------------------+------------------------------+---------------------------+
| TYPE    | INSTANCE            | KEY                          | VALUE                     |
+---------+---------------------+------------------------------+---------------------------+
| tidb    | 10.233.90.245:4000  | advertise-address            | 10.233.90.245             |
| pd      | 10.233.90.245:2379  | advertise-client-urls        | http://10.233.90.245:2379/ |
| pd      | 10.233.90.245:2379  | advertise-peer-urls          | http://10.233.90.245:2380/ |
| tikv    | 10.233.90.245:20160 | server.advertise-addr        | 10.233.90.245:20160       |
| tikv    | 10.233.90.245:20160 | server.advertise-status-addr |                           |
| tiproxy | 10.233.90.245:6000  | proxy.advertise-addr         | 10.233.90.245             |
+---------+---------------------+------------------------------+---------------------------+
6 rows in set (0.01 sec)
```

With Cluster:

```
MySQL [information_schema]> select * from cluster_config where key like '%advertise%';
+---------+-------------------+------------------------------+----------------------+
| TYPE    | INSTANCE          | KEY                          | VALUE                |
+---------+-------------------+------------------------------+----------------------+
| tidb    | tidb-peer:4000    | advertise-address            | tidb-peer            |
| pd      | pd-peer:2379      | advertise-client-urls        | https://pd-peer:2379/ |
| pd      | pd-peer:2379      | advertise-peer-urls          | https://pd-peer:2380/ |
| tikv    | tikv-peer:20160   | server.advertise-addr        | tikv-peer:20160      |
| tikv    | tikv-peer:20160   | server.advertise-status-addr | tikv-peer:20180      |
| tiproxy | tiproxy-peer:6000 | proxy.advertise-addr         | tiproxy-peer         |
+---------+-------------------+------------------------------+----------------------+
6 rows in set (0.05 sec)
```

Code changes

None

Side effects

None

Related changes

None


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
