### PR TITLE
Improve handling of mirror renw

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -364,7 +364,11 @@ func newMirrorRenewCmd() *cobra.Command {
 				if !v1manifest.IsExpirationError(perrs.Cause(err)) {
 					return err
 				}
-				fmt.Println(err)
+				fmt.Printf("Ignoring expiration error: %s", err)
+			}
+
+			if m == nil {
+				return errors.New("got nil manifest")
 			}
 
 			if days > 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`GetComponentManifest()` can return a nil manifest if it returns an error. `newMirrorRenewCmd()` ignores expiration errors when calling `GetComponentManifest()`. It should make sure that the manifest is not nil when calling `RenewManifest()`.

ref #2398

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)



Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Bugfix: The `tiup mirror renew` command could segfault on expired manifests.
```
