### PR TITLE
Allow specifying Grafana port via command-line arguments

### DIFF
--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -40,10 +40,11 @@ type grafana struct {
 	cmd      *exec.Cmd
 }
 
-func newGrafana(version string, host string) *grafana {
+func newGrafana(version string, host string, port int) *grafana {
 	return &grafana{
 		host:    host,
 		version: version,
+		port:    port,
 	}
 }
 
@@ -151,7 +152,7 @@ var clusterName = "Test-Cluster"
 // dir should contains files untar the grafana.
 // return not error iff the Cmd is started successfully.
 func (g *grafana) start(ctx context.Context, dir string, p8sURL string) (err error) {
-	g.port, err = utils.GetFreePort(g.host, 3000)
+	g.port, err = utils.GetFreePort(g.host, g.port)
 	if err != nil {
 		return err
 	}

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -74,6 +74,7 @@ type BootOptions struct {
 	Host           string              `yaml:"host"`
 	Monitor        bool                `yaml:"monitor"`
 	CSEOpts        instance.CSEOptions `yaml:"cse"` // Only available when mode == tidb-cse
+	GrafanaPort    int                 `yaml:"grafana_port"`
 }
 
 var (
@@ -281,6 +282,7 @@ Note: Version constraint [bold]%s[reset] is resolved to [green][bold]%s[reset]. 
 	rootCmd.Flags().Bool("without-monitor", false, "Don't start prometheus and grafana component")
 	rootCmd.Flags().BoolVar(&options.Monitor, "monitor", true, "Start prometheus and grafana component")
 	_ = rootCmd.Flags().MarkDeprecated("monitor", "Please use --without-monitor to control whether to disable monitor.")
+	rootCmd.Flags().IntVar(&options.GrafanaPort, "grafana.port", 3000, "grafana port. If not provided, grafana will use 3000 as its port.")
 
 	// NOTE: Do not set default values if they may be changed in different modes.
 

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1439,7 +1439,7 @@ func (p *Playground) bootGrafana(ctx context.Context, env *environment.Environme
 		return nil, err
 	}
 
-	grafana := newGrafana(options.Version, options.Host)
+	grafana := newGrafana(options.Version, options.Host, options.GrafanaPort)
 	// fmt.Println("Start Grafana instance...")
 	err = grafana.start(ctx, grafanaDir, "http://"+utils.JoinHostPort(monitorInfo.IP, monitorInfo.Port))
 	if err != nil {

--- a/doc/user/playground.md
+++ b/doc/user/playground.md
@@ -41,6 +41,7 @@ Flags:
       --drainer int              Drainer instance number
       --drainer.binpath string   Drainer instance binary path
       --drainer.config string    Drainer instance configuration file
+      --grafana.port int         grafana port. If not provided, grafana will use 3000 as its port. (default 3000)
   -h, --help                     help for tiup
       --host string              Playground cluster host
       --kv int                   TiKV instance number


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The Grafana port is fixed at 3000 and cannot be changed.

### What is changed and how it works?

I have made it possible to specify the Grafana port via options.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```
$ ./bin/tiup-playground --grafana.port 3333

Note: Version constraint  is resolved to v8.0.0. If you'd like to use other versions:

    Use exact version:      tiup playground v7.1.0
    Use version range:      tiup playground ^5
    Use nightly:            tiup playground nightly

Start pd instance:v8.0.0
Start tikv instance:v8.0.0
Start tidb instance:v8.0.0
Waiting for tidb instances ready
127.0.0.1:4000 ... Done
Start tiflash instance:v8.0.0
Waiting for tiflash instances ready
127.0.0.1:3930 ... Done

🎉 TiDB Playground Cluster is started, enjoy!

Connect TiDB:    mysql --comments --host 127.0.0.1 --port 4000 -u root
TiDB Dashboard:  http://127.0.0.1:2379/dashboard
Grafana:         http://127.0.0.1:3333
```

Code changes


Side effects


Related changes

 - Need to update the documentation

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
