### PR TITLE
cluster: remove duplicated tasks when prune

### DIFF
--- a/pkg/cluster/manager/destroy.go
+++ b/pkg/cluster/manager/destroy.go
@@ -190,6 +190,12 @@ func (m *Manager) DestroyTombstone(
 	}
 	topo = metadata.GetTopology()
 	base = metadata.GetBaseMeta()
+
+	b, err = m.sshTaskBuilder(name, topo, base.User, gOpt)
+	if err != nil {
+		return err
+	}
+
 	regenConfigTasks, _ := buildInitConfigTasks(m, name, topo, base, gOpt, nodes)
 	t = b.
 		ParallelStep("+ Refresh instance configs", gOpt.Force, regenConfigTasks...).


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Bug introduced by #2387. 

The task builder `b` is reused without reseting. Thus `FindTomestoneNodes` will be executed twice, which is not expected.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix duplicated prompt at `tiup-cluster prune`
```
