### PR TITLE
cluster: Improve cluster restart messaging

### DIFF
--- a/pkg/cluster/manager/basic.go
+++ b/pkg/cluster/manager/basic.go
@@ -231,13 +231,26 @@ func (m *Manager) RestartCluster(name string, gOpt operator.Options, skipConfirm
 	}
 
 	if !skipConfirm {
-		if err := tui.PromptForConfirmOrAbortError(
-			fmt.Sprintf("Will restart the cluster %s with nodes: %s roles: %s.\nCluster will be unavailable\nDo you want to continue? [y/N]:",
-				color.HiYellowString(name),
-				color.HiYellowString(strings.Join(gOpt.Nodes, ",")),
-				color.HiYellowString(strings.Join(gOpt.Roles, ",")),
-			),
-		); err != nil {
+		var availabilityMessage string
+		var rolesToRestart string
+		var nodesToRestart string
+		if len(gOpt.Nodes) == 0 && len(gOpt.Roles) == 0 {
+			availabilityMessage = "Cluster will be unavailable"
+			rolesToRestart = "all"
+			nodesToRestart = "all"
+		} else {
+			availabilityMessage = fmt.Sprintf("Cluster functionality related to nodes: %s roles: %s will be unavailable", strings.Join(gOpt.Nodes, ","), strings.Join(gOpt.Roles, ","))
+			nodesToRestart = strings.Join(gOpt.Nodes, ",")
+			rolesToRestart = strings.Join(gOpt.Roles, ",")
+		}
+
+		confirmationMessage := fmt.Sprintf("Will restart the cluster %s with nodes: %s roles: %s.\n%s\nDo you want to continue? [y/N]:",
+			color.HiYellowString(name),
+			color.HiYellowString(nodesToRestart),
+			color.HiYellowString(rolesToRestart),
+			availabilityMessage,
+		)
+		if err := tui.PromptForConfirmOrAbortError(confirmationMessage); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION





### What problem does this PR solve? <!--add issue link with summary if exists-->

Cluster restart messaging indicates to user that the:
  - Cluster will be unavailable (https://github.com/pingcap/tiup/blob/654b087a1d293128424c0bd04e1ba216b064ffd1/pkg/cluster/manager/basic.go#L235)

This message is confusing when the command run only requests a single node restart, especially monitoring nodes or ones in an HA deployment.

### What is changed and how it works?

Commit changes the messaging so that users performing full cluster restart retain the same message as before. But users only restarting selected nodes or roles will have that replaced with a more detailed warning message:

`Cluster functionality related to nodes: %s and roles: % will be unavailable`


### Check List <!--REMOVE the items that are not applicable-->

Tests
 - Manual test (add detailed scripts or steps below)
   - I recompiled the code and ran both a full cluster restart request and a single node restart request

Code changes
- N/a

Side effects
- N/a

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
