### PR TITLE
playground: Allow specifying port offset

### DIFF
--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -151,12 +151,8 @@ var clusterName = "Test-Cluster"
 
 // dir should contains files untar the grafana.
 // return not error iff the Cmd is started successfully.
-func (g *grafana) start(ctx context.Context, dir string, p8sURL string) (err error) {
-	g.port, err = utils.GetFreePort(g.host, g.port)
-	if err != nil {
-		return err
-	}
-
+func (g *grafana) start(ctx context.Context, dir string, portOffset int, p8sURL string) (err error) {
+	g.port = utils.MustGetFreePort(g.host, g.port, portOffset)
 	fname := filepath.Join(dir, "conf", "provisioning", "dashboards", "dashboard.yml")
 	err = writeDashboardConfig(fname, clusterName, filepath.Join(dir, "dashboards"))
 	if err != nil {

--- a/components/playground/instance/drainer.go
+++ b/components/playground/instance/drainer.go
@@ -32,14 +32,14 @@ type Drainer struct {
 var _ Instance = &Drainer{}
 
 // NewDrainer create a Drainer instance.
-func NewDrainer(binPath string, dir, host, configPath string, id int, pds []*PDInstance) *Drainer {
+func NewDrainer(binPath string, dir, host, configPath string, portOffset int, id int, pds []*PDInstance) *Drainer {
 	d := &Drainer{
 		instance: instance{
 			BinPath:    binPath,
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, 8250),
+			Port:       utils.MustGetFreePort(host, 8250, portOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	tiupexec "github.com/pingcap/tiup/pkg/exec"
+	"github.com/pingcap/tiup/pkg/tui/colorstr"
 	"github.com/pingcap/tiup/pkg/utils"
 )
 
@@ -98,9 +99,9 @@ func (inst *instance) PrepareBinary(componentName string, version utils.Version)
 	}
 	// distinguish whether the instance is started by specific binary path.
 	if inst.BinPath == "" {
-		fmt.Printf("Start %s instance:%s\n", componentName, version)
+		colorstr.Printf("[dark_gray]Start %s instance: %s[reset]\n", componentName, version)
 	} else {
-		fmt.Printf("Start %s instance:%s\n", componentName, instanceBinPath)
+		colorstr.Printf("[dark_gray]Start %s instance: %s[reset]\n", componentName, instanceBinPath)
 	}
 	inst.Version = version
 	inst.BinPath = instanceBinPath

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -50,7 +50,7 @@ type PDInstance struct {
 }
 
 // NewPDInstance return a PDInstance
-func NewPDInstance(role PDRole, binPath, dir, host, configPath string, id int, pds []*PDInstance, port int, isCSEMode bool) *PDInstance {
+func NewPDInstance(role PDRole, binPath, dir, host, configPath string, portOffset int, id int, pds []*PDInstance, port int, isCSEMode bool) *PDInstance {
 	if port <= 0 {
 		port = 2379
 	}
@@ -60,8 +60,8 @@ func NewPDInstance(role PDRole, binPath, dir, host, configPath string, id int, p
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, 2380),
-			StatusPort: utils.MustGetFreePort(host, port),
+			Port:       utils.MustGetFreePort(host, 2380, portOffset),
+			StatusPort: utils.MustGetFreePort(host, port, portOffset),
 			ConfigPath: configPath,
 		},
 		Role:      role,

--- a/components/playground/instance/pump.go
+++ b/components/playground/instance/pump.go
@@ -34,14 +34,14 @@ type Pump struct {
 var _ Instance = &Pump{}
 
 // NewPump create a Pump instance.
-func NewPump(binPath string, dir, host, configPath string, id int, pds []*PDInstance) *Pump {
+func NewPump(binPath string, dir, host, configPath string, portOffset int, id int, pds []*PDInstance) *Pump {
 	pump := &Pump{
 		instance: instance{
 			BinPath:    binPath,
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, 8249),
+			Port:       utils.MustGetFreePort(host, 8249, portOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/instance/ticdc.go
+++ b/components/playground/instance/ticdc.go
@@ -33,7 +33,7 @@ type TiCDC struct {
 var _ Instance = &TiCDC{}
 
 // NewTiCDC create a TiCDC instance.
-func NewTiCDC(binPath string, dir, host, configPath string, id int, port int, pds []*PDInstance) *TiCDC {
+func NewTiCDC(binPath string, dir, host, configPath string, portOffset int, id int, port int, pds []*PDInstance) *TiCDC {
 	if port <= 0 {
 		port = 8300
 	}
@@ -43,7 +43,7 @@ func NewTiCDC(binPath string, dir, host, configPath string, id int, port int, pd
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, port),
+			Port:       utils.MustGetFreePort(host, port, portOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -34,7 +34,7 @@ type TiDBInstance struct {
 }
 
 // NewTiDBInstance return a TiDBInstance
-func NewTiDBInstance(binPath string, dir, host, configPath string, id, port int, pds []*PDInstance, tiproxyCertDir string, enableBinlog bool, isCSEMode bool) *TiDBInstance {
+func NewTiDBInstance(binPath string, dir, host, configPath string, portOffset int, id, port int, pds []*PDInstance, tiproxyCertDir string, enableBinlog bool, isCSEMode bool) *TiDBInstance {
 	if port <= 0 {
 		port = 4000
 	}
@@ -44,8 +44,8 @@ func NewTiDBInstance(binPath string, dir, host, configPath string, id, port int,
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, port),
-			StatusPort: utils.MustGetFreePort("0.0.0.0", 10080),
+			Port:       utils.MustGetFreePort(host, port, portOffset),
+			StatusPort: utils.MustGetFreePort("0.0.0.0", 10080, portOffset),
 			ConfigPath: configPath,
 		},
 		tiproxyCertDir: tiproxyCertDir,

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -53,14 +53,14 @@ type TiFlashInstance struct {
 }
 
 // NewTiFlashInstance return a TiFlashInstance
-func NewTiFlashInstance(role TiFlashRole, cseOptions CSEOptions, binPath, dir, host, configPath string, id int, pds []*PDInstance, dbs []*TiDBInstance, version string) *TiFlashInstance {
+func NewTiFlashInstance(role TiFlashRole, cseOptions CSEOptions, binPath, dir, host, configPath string, portOffset int, id int, pds []*PDInstance, dbs []*TiDBInstance, version string) *TiFlashInstance {
 	if role != TiFlashRoleNormal && role != TiFlashRoleDisaggWrite && role != TiFlashRoleDisaggCompute {
 		panic(fmt.Sprintf("Unknown TiFlash role %s", role))
 	}
 
 	httpPort := 8123
 	if !tidbver.TiFlashNotNeedHTTPPortConfig(version) {
-		httpPort = utils.MustGetFreePort(host, httpPort)
+		httpPort = utils.MustGetFreePort(host, httpPort, portOffset)
 	}
 	return &TiFlashInstance{
 		instance: instance{
@@ -69,15 +69,15 @@ func NewTiFlashInstance(role TiFlashRole, cseOptions CSEOptions, binPath, dir, h
 			Dir:        dir,
 			Host:       host,
 			Port:       httpPort,
-			StatusPort: utils.MustGetFreePort(host, 8234),
+			StatusPort: utils.MustGetFreePort(host, 8234, portOffset),
 			ConfigPath: configPath,
 		},
 		Role:            role,
 		cseOpts:         cseOptions,
-		TCPPort:         utils.MustGetFreePort(host, 9100), // 9000 for default object store port
-		ServicePort:     utils.MustGetFreePort(host, 3930),
-		ProxyPort:       utils.MustGetFreePort(host, 20170),
-		ProxyStatusPort: utils.MustGetFreePort(host, 20292),
+		TCPPort:         utils.MustGetFreePort(host, 9100, portOffset), // 9000 for default object store port
+		ServicePort:     utils.MustGetFreePort(host, 3930, portOffset),
+		ProxyPort:       utils.MustGetFreePort(host, 20170, portOffset),
+		ProxyStatusPort: utils.MustGetFreePort(host, 20292, portOffset),
 		pds:             pds,
 		dbs:             dbs,
 	}

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -36,7 +36,7 @@ type TiKVInstance struct {
 }
 
 // NewTiKVInstance return a TiKVInstance
-func NewTiKVInstance(binPath string, dir, host, configPath string, id int, port int, pds []*PDInstance, tsos []*PDInstance, isCSEMode bool, cseOptions CSEOptions, isPDMSMode bool) *TiKVInstance {
+func NewTiKVInstance(binPath string, dir, host, configPath string, portOffset int, id int, port int, pds []*PDInstance, tsos []*PDInstance, isCSEMode bool, cseOptions CSEOptions, isPDMSMode bool) *TiKVInstance {
 	if port <= 0 {
 		port = 20160
 	}
@@ -46,8 +46,8 @@ func NewTiKVInstance(binPath string, dir, host, configPath string, id int, port 
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, port),
-			StatusPort: utils.MustGetFreePort(host, 20180),
+			Port:       utils.MustGetFreePort(host, port, portOffset),
+			StatusPort: utils.MustGetFreePort(host, 20180, portOffset),
 			ConfigPath: configPath,
 		},
 		pds:        pds,

--- a/components/playground/instance/tikv_cdc.go
+++ b/components/playground/instance/tikv_cdc.go
@@ -32,14 +32,14 @@ type TiKVCDC struct {
 var _ Instance = &TiKVCDC{}
 
 // NewTiKVCDC create a TiKVCDC instance.
-func NewTiKVCDC(binPath string, dir, host, configPath string, id int, pds []*PDInstance) *TiKVCDC {
+func NewTiKVCDC(binPath string, dir, host, configPath string, portOffset int, id int, pds []*PDInstance) *TiKVCDC {
 	tikvCdc := &TiKVCDC{
 		instance: instance{
 			BinPath:    binPath,
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, 8600),
+			Port:       utils.MustGetFreePort(host, 8600, portOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -68,7 +68,7 @@ func GenTiProxySessionCerts(dir string) error {
 }
 
 // NewTiProxy create a TiProxy instance.
-func NewTiProxy(binPath string, dir, host, configPath string, id int, port int, pds []*PDInstance) *TiProxy {
+func NewTiProxy(binPath string, dir, host, configPath string, portOffset int, id int, port int, pds []*PDInstance) *TiProxy {
 	if port <= 0 {
 		port = 6000
 	}
@@ -78,8 +78,8 @@ func NewTiProxy(binPath string, dir, host, configPath string, id int, port int, 
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, port),
-			StatusPort: utils.MustGetFreePort(host, 3080),
+			Port:       utils.MustGetFreePort(host, port, portOffset),
+			StatusPort: utils.MustGetFreePort(host, 3080, portOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -78,15 +78,12 @@ func (m *monitor) wait() error {
 }
 
 // the cmd is not started after return
-func newMonitor(ctx context.Context, version string, host, dir string) (*monitor, error) {
+func newMonitor(ctx context.Context, version string, host, dir string, portOffset int) (*monitor, error) {
 	if err := utils.MkdirAll(dir, 0755); err != nil {
 		return nil, errors.AddStack(err)
 	}
 
-	port, err := utils.GetFreePort(host, 9090)
-	if err != nil {
-		return nil, err
-	}
+	port := utils.MustGetFreePort(host, 9090, portOffset)
 	addr := utils.JoinHostPort(host, port)
 
 	tmpl := `
@@ -132,6 +129,7 @@ scrape_configs:
 	}
 
 	var binPath string
+	var err error
 	if binPath, err = tiupexec.PrepareBinary("prometheus", utils.Version(version), binPath); err != nil {
 		return nil, err
 	}

--- a/components/playground/ngmonitoring.go
+++ b/components/playground/ngmonitoring.go
@@ -45,16 +45,12 @@ func (m *ngMonitoring) wait() error {
 }
 
 // the cmd is not started after return
-func newNGMonitoring(ctx context.Context, version string, host, dir string, pds []*instance.PDInstance) (*ngMonitoring, error) {
+func newNGMonitoring(ctx context.Context, version string, host, dir string, portOffset int, pds []*instance.PDInstance) (*ngMonitoring, error) {
 	if err := utils.MkdirAll(dir, 0755); err != nil {
 		return nil, errors.AddStack(err)
 	}
 
-	port, err := utils.GetFreePort(host, 12020)
-	if err != nil {
-		return nil, err
-	}
-
+	port := utils.MustGetFreePort(host, 12020, portOffset)
 	m := new(ngMonitoring)
 	var endpoints []string
 	for _, pd := range pds {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -49,11 +49,7 @@ func MaybeStartProxy(
 		return err
 	}
 
-	httpPort, err := utils.GetFreePort("127.0.0.1", 12345)
-	if err != nil {
-		return err
-	}
-
+	httpPort := utils.MustGetFreePort("127.0.0.1", 12345, 0)
 	addr := fmt.Sprintf("127.0.0.1:%d", httpPort)
 
 	// TODO: Using environment variables to share data may not be a good idea

--- a/pkg/proxy/tcp_proxy.go
+++ b/pkg/proxy/tcp_proxy.go
@@ -66,11 +66,7 @@ func NewTCPProxy(
 		p.config.Password = password
 	}
 
-	port, err := utils.GetFreePort("127.0.0.1", 22345)
-	if err != nil {
-		logger.Errorf("get free port error: %v", err)
-		return nil
-	}
+	port = utils.MustGetFreePort("127.0.0.1", 22345, 0)
 	p.endpoint = fmt.Sprintf("127.0.0.1:%d", port)
 
 	listener, err := net.Listen("tcp", p.endpoint)

--- a/pkg/utils/freeport.go
+++ b/pkg/utils/freeport.go
@@ -22,9 +22,8 @@ import (
 // To avoid the same port be generated twice in a short time
 var portCache sync.Map
 
-// GetFreePort asks the kernel for a free open port that is ready to use.
-func GetFreePort(host string, priority int) (int, error) {
-	if port, err := getPort(host, priority); err == nil {
+func getFreePort(host string, defaultPort int) (int, error) {
+	if port, err := getPort(host, defaultPort); err == nil {
 		return port, nil
 	} else if port, err := getPort(host, 0); err == nil {
 		return port, nil
@@ -34,8 +33,9 @@ func GetFreePort(host string, priority int) (int, error) {
 }
 
 // MustGetFreePort asks the kernel for a free open port that is ready to use, if fail, panic
-func MustGetFreePort(host string, priority int) int {
-	if port, err := GetFreePort(host, priority); err == nil {
+func MustGetFreePort(host string, defaultPort int, portOffset int) int {
+	bestPort := defaultPort + portOffset
+	if port, err := getFreePort(host, bestPort); err == nil {
 		return port
 	}
 	panic("can't get a free port")

--- a/pkg/utils/freeport_test.go
+++ b/pkg/utils/freeport_test.go
@@ -10,11 +10,11 @@ type TestFreePortSuite struct{}
 
 func (s *TestFreePortSuite) TestGetFreePort(c *C) {
 	expected := 22334
-	port, err := GetFreePort("127.0.0.1", expected)
+	port, err := getFreePort("127.0.0.1", expected)
 	c.Assert(err, IsNil)
 	c.Assert(port, Equals, expected, Commentf("expect port %s", expected))
 
-	port, err = GetFreePort("127.0.0.1", expected)
+	port, err = getFreePort("127.0.0.1", expected)
 	c.Assert(err, IsNil)
 	c.Assert(port == expected, IsFalse, Commentf("should not return same port twice"))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

### What is changed and how it works?

Sometimes we want to start multiple clusters concurrently (and also preserve them).

Preserving data is possible by specifying --tag.

But multiple co-exist clusters will meet issues after restart because dynamic port may be changed and stores are regarded as new stores.

This PR adds `--port-offset` so that this could work nicely, e.g:
- Cluster1: `--tag=cluster1 --port-offset=10000`
- Cluster2: `--tag=cluster2 --port-offset=20000`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
