### PR TITLE
playground: add panic guard to prevent some corner cases

### DIFF
--- a/components/playground/instance/process.go
+++ b/components/playground/instance/process.go
@@ -11,6 +11,10 @@ import (
 	"github.com/pingcap/errors"
 )
 
+var (
+	errNotUp = errors.New("not up")
+)
+
 // Process represent process to be run by playground
 type Process interface {
 	Start() error
@@ -32,6 +36,10 @@ type process struct {
 
 // Start the process
 func (p *process) Start() error {
+	if p == nil {
+		return errNotUp
+	}
+
 	// fmt.Printf("Starting `%s`: %s", filepath.Base(p.cmd.Path), strings.Join(p.cmd.Args, " "))
 	p.startTime = time.Now()
 	return p.cmd.Start()
@@ -39,6 +47,10 @@ func (p *process) Start() error {
 
 // Wait implements Instance interface.
 func (p *process) Wait() error {
+	if p == nil {
+		return errNotUp
+	}
+
 	p.waitOnce.Do(func() {
 		p.waitErr = p.cmd.Wait()
 	})
@@ -48,11 +60,18 @@ func (p *process) Wait() error {
 
 // Pid implements Instance interface.
 func (p *process) Pid() int {
+	if p == nil {
+		return 0
+	}
 	return p.cmd.Process.Pid
 }
 
 // Uptime implements Instance interface.
 func (p *process) Uptime() string {
+	if p == nil {
+		return errNotUp.Error()
+	}
+
 	s := p.cmd.ProcessState
 
 	if s != nil {
@@ -64,6 +83,10 @@ func (p *process) Uptime() string {
 }
 
 func (p *process) SetOutputFile(fname string) error {
+	if p == nil {
+		return errNotUp
+	}
+
 	f, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return errors.AddStack(err)
@@ -73,11 +96,19 @@ func (p *process) SetOutputFile(fname string) error {
 }
 
 func (p *process) setOutput(w io.Writer) {
+	if p == nil {
+		return
+	}
+
 	p.cmd.Stdout = w
 	p.cmd.Stderr = w
 }
 
 func (p *process) Cmd() *exec.Cmd {
+	if p == nil {
+		panic(errNotUp)
+	}
+
 	return p.cmd
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


When something is wrong, and tiup did not start the component correctly, playground instance may have a nil `process` pointer. Let us just prevent it from panic.


Refer https://do.pingcap.net/jenkins/blue/organizations/jenkins/tikv%2Fpd%2Fpull_integration_realcluster_test/detail/pull_integration_realcluster_test/809/pipeline/.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Prevent possible panic on corner cases of playground startup failure
```
