### PR TITLE
*: polish the trust key notice

### DIFF
--- a/pkg/localdata/profile.go
+++ b/pkg/localdata/profile.go
@@ -275,9 +275,9 @@ func (p *Profile) ResetMirror(addr, root string) error {
 
 	// Only cache remote mirror
 	if strings.HasPrefix(addr, "http") && root != localRoot {
-		if strings.HasPrefix(root, "http") {
-			fmt.Printf("WARN: adding root certificate via internet: %s\n", root)
-			fmt.Printf("You can revoke this by remove %s\n", localRoot)
+		if strings.HasPrefix(root, "http") && !strings.HasPrefix(root, "https") {
+			fmt.Printf("WARN: Trusting component distribution key via insecure Internet: %s\n", root)
+			fmt.Printf("      To revoke TiUP's trust, remove this file: %s\n", localRoot)
 		}
 		_ = utils.Copy(p.Path("bin", "root.json"), localRoot)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently when installing TiUP, a misleading warning will be displayed:

<img width="814" alt="image" src="https://github.com/user-attachments/assets/938667c4-d26c-403e-a480-6eb6f21c8c9f">


### What is changed and how it works?

Only display the warning, when JSON is accessed via insecure Internet.

And also carefully polished the words, to avoid being mis-interpreted as System root certificate.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
