### PR TITLE
playground: Add --dry-run for preparing binaries in CI

### DIFF
--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -58,6 +58,7 @@ type BootOptions struct {
 	Mode           string              `yaml:"mode"`
 	PDMode         string              `yaml:"pd_mode"`
 	Version        string              `yaml:"version"`
+	DryRun         bool                `yaml:"dry_run"`
 	PD             instance.Config     `yaml:"pd"`         // will change to api when pd_mode == ms
 	TSO            instance.Config     `yaml:"tso"`        // Only available when pd_mode == ms
 	Scheduling     instance.Config     `yaml:"scheduling"` // Only available when pd_mode == ms
@@ -284,6 +285,8 @@ Note: Version constraint [bold]%s[reset] is resolved to [green][bold]%s[reset]. 
 	_ = rootCmd.Flags().MarkDeprecated("monitor", "Please use --without-monitor to control whether to disable monitor.")
 	rootCmd.Flags().IntVar(&options.GrafanaPort, "grafana.port", 3000, "grafana port. If not provided, grafana will use 3000 as its port.")
 	rootCmd.Flags().IntVar(&options.PortOffset, "port-offset", 0, "If specified, all components will use default_port+port_offset as the port. This argument is useful when you want to start multiple playgrounds on the same host. Recommend to set to 10000, 20000, etc.")
+
+	rootCmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "Do not actually run any component. Useful to prepare binaries in CI environment, or checkout what will be started.")
 
 	// NOTE: Do not set default values if they may be changed in different modes.
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Sometimes we want to prepare binaries but do not run them. For example, we may want to prepare the binaries in a Docker build step, so that when image is used later (like in CI) there will be no repeated downloads.

### What is changed and how it works?

This PR introduce --dry-run exactly for this kind of purpose.

When playground is called with --dry-run, everything will be as usual except that no instance will be run actually, and TiUP playground will stop immediately after everything is prepared.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

```
$ bin/tiup-playground nightly --dry-run
The component `pd` version v8.5.0-alpha-nightly is not installed; downloading from repository.
download ...
Start pd instance: v8.5.0-alpha-nightly
The component `tikv` version v8.5.0-alpha-nightly is not installed; downloading from repository.
download ...
Start tikv instance: v8.5.0-alpha-nightly
The component `tidb` version v8.5.0-alpha-nightly is not installed; downloading from repository.
download ..
Start tidb instance: v8.5.0-alpha-nightly
The component `prometheus` version v8.5.0-alpha-nightly is not installed; downloading from repository.
download ...
The component `tiflash` version v8.5.0-alpha-nightly is not installed; downloading from repository.
download ...
Start tiflash instance: v8.5.0-alpha-nightly
```


 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
