### PR TITLE
playground: add warning for deletion of data dir

### DIFF
--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -279,7 +279,7 @@ Note: Version constraint [bold]%s[reset] is resolved to [green][bold]%s[reset]. 
 
 	rootCmd.Flags().StringVar(&options.Mode, "mode", "tidb", "TiUP playground mode: 'tidb', 'tidb-cse', 'tikv-slim'")
 	rootCmd.Flags().StringVar(&options.PDMode, "pd.mode", "pd", "PD mode: 'pd', 'ms'")
-	rootCmd.PersistentFlags().StringVarP(&tag, "tag", "T", "", "Specify a tag for playground") // Use `PersistentFlags()` to make it available to subcommands.
+	rootCmd.PersistentFlags().StringVarP(&tag, "tag", "T", "", "Specify a tag for playground, data dir of this tag will not be removed after exit")
 	rootCmd.Flags().Bool("without-monitor", false, "Don't start prometheus and grafana component")
 	rootCmd.Flags().BoolVar(&options.Monitor, "monitor", true, "Start prometheus and grafana component")
 	_ = rootCmd.Flags().MarkDeprecated("monitor", "Please use --without-monitor to control whether to disable monitor.")

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -122,7 +122,7 @@ Examples:
   $ tiup playground nightly --without-monitor       # Start a local cluster and disable monitor system
   $ tiup playground --pd.config ~/config/pd.toml    # Start a local cluster with specified configuration file
   $ tiup playground --db.binpath /xx/tidb-server    # Start a local cluster with component binary path
-  $ tiup playground -T xx                           # Start a local cluster with data dir named 'xx' and uncleaned after exit
+  $ tiup playground --tag xx                           # Start a local cluster with data dir named 'xx' and uncleaned after exit
   $ tiup playground --mode tikv-slim                # Start a local tikv only cluster (No TiDB or TiFlash Available)
   $ tiup playground --mode tikv-slim --kv 3 --pd 3  # Start a local tikv only cluster with 6 nodes`,
 		SilenceUsage:  true,

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -122,6 +122,7 @@ Examples:
   $ tiup playground nightly --without-monitor       # Start a local cluster and disable monitor system
   $ tiup playground --pd.config ~/config/pd.toml    # Start a local cluster with specified configuration file
   $ tiup playground --db.binpath /xx/tidb-server    # Start a local cluster with component binary path
+  $ tiup playground -T xx                           # Start a local cluster with data dir named 'xx' and uncleaned after exit
   $ tiup playground --mode tikv-slim                # Start a local tikv only cluster (No TiDB or TiFlash Available)
   $ tiup playground --mode tikv-slim --kv 3 --pd 3  # Start a local tikv only cluster with 6 nodes`,
 		SilenceUsage:  true,

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1252,6 +1252,9 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		p.waitAllTiFlashUp()
 
 		fmt.Println()
+		color.New(color.FgYellow, color.Bold).Println("TiDB Playground Cluster will delete all data after exit. Please use --tag xx to pin the data dir.")
+
+		fmt.Println()
 		color.New(color.FgGreen, color.Bold).Println("🎉 TiDB Playground Cluster is started, enjoy!")
 		fmt.Println()
 		mysql := mysqlCommand()

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1252,7 +1252,7 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		p.waitAllTiFlashUp()
 
 		fmt.Println()
-		color.New(color.FgYellow, color.Bold).Println("TiDB Playground Cluster will delete all data after exit. Please use --tag xx to pin the data dir.")
+		color.New(color.FgYellow, color.Bold).Println("TiDB Playground Cluster will delete all data of the cluster after exit. Please use --tag xx to pin the data dir.")
 
 		fmt.Println()
 		color.New(color.FgGreen, color.Bold).Println("🎉 TiDB Playground Cluster is started, enjoy!")

--- a/doc/user/playground.md
+++ b/doc/user/playground.md
@@ -55,7 +55,7 @@ Flags:
       --pump int                 Pump instance number
       --pump.binpath string      Pump instance binary path
       --pump.config string       Pump instance configuration file
-  -T, --tag string               Specify a tag for playground
+  -T, --tag string               Specify a tag for playground, data dir of this tag will not be removed after exit
       --ticdc int                TiCDC instance number
       --ticdc.binpath string     TiCDC instance binary path
       --ticdc.config string      TiCDC instance configuration file


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com><!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 ```
TiDB Playground Cluster will delete all data after exit. Please use --tag xx to pin the data dir.

🎉 TiDB Playground Cluster is started, enjoy!

Connect TiDB:    mysql --host 127.0.0.1 --port 4000 -u root
```
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
