### PR TITLE
display grafana with grafana patched

### DIFF
--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -325,7 +325,7 @@ func (m *Manager) Display(dopt DisplayOption, opt operator.Options) error {
 func getGrafanaURL(clusterInstInfos []InstInfo) (result []string) {
 	var grafanaURLs []string
 	for _, instance := range clusterInstInfos {
-		if instance.Role == "grafana" {
+		if instance.Role == "grafana" || instance.Role == "grafana (patched)" {
 			grafanaURLs = append(grafanaURLs, "http://"+utils.JoinHostPort(instance.Host, instance.Port))
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

After I patched grafana, the tiup cluster display does not display grafana url information, which causes users to feel confused and think that there is an unknown problem with the patch

### What is changed and how it works?

grafana (patched) judgment added

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
./bin/tiup-cluster display tidb-xx
Cluster type:       tidb
Cluster name:       tidb-xx
Cluster version:    v7.1.5
Deploy user:        tidb
SSH type:           builtin
Dashboard URL:      http://172.16.xxx.xx:2399/dashboard
Dashboard URLs:     http://172.16.xxx.xx:2399/dashboard
Grafana URL:        http://172.16.xxx.xx:3100
ID                   Role               Host           Ports                            OS/Arch       Status   Data Dir                                 Deploy Dir
--                   ----               ----           -----                            -------       ------   --------                                 ----------
172.16.xxx.xx:9193   alertmanager       172.16.xxx.xx  9193/9194                        linux/x86_64  Up       /data2/tiup/tidb-data/alertmanager-9193  /data2/tiup/tidb-deploy/alertmanager-9193
172.16.xxx.xx:8300   cdc                172.16.xxx.xx  8300                             linux/x86_64  Up       /data2/tiup/tidb-data/cdc-8300           /data2/tiup/tidb-deploy/cdc-8300
172.16.xxx.xx:3100   grafana (patched)  172.16.xxx.xx  3100                             linux/x86_64  Up       -                                        /data2/tiup/tidb-deploy/grafana-3100
172.16.xxx.xx:2399   pd                 172.16.xxx.xx  2399/2400                        linux/x86_64  Up|L|UI  /data2/tiup/tidb-data/pd-2399            /data2/tiup/tidb-deploy/pd-2399
172.16.xxx.xx:9103   prometheus         172.16.xxx.xx  9103/12020                       linux/x86_64  Up       /data2/tiup/tidb-data/prometheus-9103    /data2/tiup/tidb-deploy/prometheus-9103
172.16.xxx.xx:4100   tidb               172.16.xxx.xx  4100/10180                       linux/x86_64  Up       -                                        /data2/tiup/tidb-deploy/tidb-4100
172.16.xxx.xx:9000   tiflash            172.16.xxx.xx  9000/3930/20170/20292/8234/8123  linux/x86_64  Up       /data2/tiup/tidb-data/tiflash-9000       /data2/tiup/tidb-deploy/tiflash-9000
172.16.xxx.xx:21160  tikv               172.16.xxx.xx  21160/21180                      linux/x86_64  Up       /data2/tiup/tidb-data/tikv-21160         /data2/tiup/tidb-deploy/tikv-21160
Total nodes: 8

```
