### PR TITLE
cluster: feat: support prometheus web_basic_auth

### DIFF
--- a/embed/examples/cluster/topology.example.yaml
+++ b/embed/examples/cluster/topology.example.yaml
@@ -353,6 +353,8 @@ monitoring_servers:
     # port: 9090
     # # ng-monitoring servive communication port
     # ng_port: 12020
+    # #prometheus web basic_auth_password
+    # basic_auth_password: admin
     # # Prometheus deployment file, startup script, configuration file storage directory.
     # deploy_dir: "/tidb-deploy/prometheus-8249"
     # # Prometheus data storage directory.

--- a/embed/templates/config/datasource.yml.tpl
+++ b/embed/templates/config/datasource.yml.tpl
@@ -10,3 +10,8 @@ datasources:
     tlsAuthWithCACert: false
     version: 1
     editable: true
+{{- if .AuthPassword}}
+    basicAuth: true
+    basicAuthUser: admin
+    basicAuthPassword: {{.AuthPassword}}
+{{- end}}    

--- a/embed/templates/config/web.config.yml.tpl
+++ b/embed/templates/config/web.config.yml.tpl
@@ -1,0 +1,2 @@
+basic_auth_users:
+  admin: {{.BasicAuthPassword}}

--- a/embed/templates/scripts/run_prometheus.sh.tpl
+++ b/embed/templates/scripts/run_prometheus.sh.tpl
@@ -40,7 +40,7 @@ exec bin/prometheus/prometheus \
 {{- end}}
     --config.file="{{.DeployDir}}/conf/prometheus.yml" \
 {{- if .BasicAuthPassword}}
-    --web.config.file="{{.DeployDir}}/conf/web_config.yml" \
+    --web.config.file="{{.DeployDir}}/conf/web.config.yml" \
 {{- end}}
     --web.listen-address=":{{.Port}}" \
     --web.external-url="{{.WebExternalURL}}/" \

--- a/embed/templates/scripts/run_prometheus.sh.tpl
+++ b/embed/templates/scripts/run_prometheus.sh.tpl
@@ -39,6 +39,9 @@ exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/prometheus/
 exec bin/prometheus/prometheus \
 {{- end}}
     --config.file="{{.DeployDir}}/conf/prometheus.yml" \
+{{- if .BasicAuthPassword}}
+    --web.config.file="{{.DeployDir}}/conf/web_config.yml" \
+{{- end}}
     --web.listen-address=":{{.Port}}" \
     --web.external-url="{{.WebExternalURL}}/" \
     --web.enable-admin-api \

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -275,8 +275,9 @@ func (i *GrafanaInstance) InitConfig(
 	}
 	fp = filepath.Join(paths.Cache, fmt.Sprintf("datasource_%s.yml", i.GetHost()))
 	datasourceCfg := &config.DatasourceConfig{
-		ClusterName: clusterName,
-		URL:         fmt.Sprintf("http://%s", utils.JoinHostPort(monitors[0].Host, monitors[0].Port)),
+		ClusterName:  clusterName,
+		URL:          fmt.Sprintf("http://%s", utils.JoinHostPort(monitors[0].Host, monitors[0].Port)),
+		AuthPassword: monitors[0].BasicAuthPassword,
 	}
 	if err := datasourceCfg.ConfigToFile(fp); err != nil {
 		return err

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -44,6 +44,7 @@ type PrometheusSpec struct {
 	Patched               bool                   `yaml:"patched,omitempty"`
 	IgnoreExporter        bool                   `yaml:"ignore_exporter,omitempty"`
 	Port                  int                    `yaml:"port" default:"9090"`
+	BasicAuthPassword     string                 `yaml:"basic_auth_password,omitempty"`
 	NgPort                int                    `yaml:"ng_port,omitempty" validate:"ng_port:editable"` // ng_port is usable since v5.3.0 and default as 12020 since v5.4.0, so the default value is set in spec.go/AdjustByVersion
 	DeployDir             string                 `yaml:"deploy_dir,omitempty"`
 	DataDir               string                 `yaml:"data_dir,omitempty"`
@@ -172,9 +173,15 @@ func (c *MonitorComponent) Instances() []Instance {
 				s.DataDir,
 			},
 			StatusFn: func(_ context.Context, timeout time.Duration, _ *tls.Config, _ ...string) string {
+				if s.BasicAuthPassword != "" {
+					return statusByHostWithAuth(s.BasicAuthPassword, s.GetManageHost(), s.Port, "/-/ready", timeout, nil)
+				}
 				return statusByHost(s.GetManageHost(), s.Port, "/-/ready", timeout, nil)
 			},
 			UptimeFn: func(_ context.Context, timeout time.Duration, tlsCfg *tls.Config) time.Duration {
+				if s.BasicAuthPassword != "" {
+					return UptimeByHostWithAuth(s.BasicAuthPassword, s.GetManageHost(), s.Port, timeout, tlsCfg)
+				}
 				return UptimeByHost(s.GetManageHost(), s.Port, timeout, tlsCfg)
 			},
 			Component: c,
@@ -224,6 +231,16 @@ func (i *MonitorInstance) InitConfig(
 		NumaNode: spec.NumaNode,
 
 		AdditionalArgs: spec.AdditionalArgs,
+	}
+
+	// transfer web config
+	srcfp := filepath.Join(paths.Cache, fmt.Sprintf("web_config_%s_%d.yml", i.GetHost(), i.GetPort()))
+	if err := cfg.WebConfigToFile(srcfp); err != nil {
+		return err
+	}
+	dstfp := filepath.Join(paths.Deploy, "conf", "web_config.yml")
+	if err := e.Transfer(ctx, srcfp, dstfp, false, 0, false); err != nil {
+		return err
 	}
 
 	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_prometheus_%s_%d.sh", i.GetHost(), i.GetPort()))

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -234,11 +234,11 @@ func (i *MonitorInstance) InitConfig(
 	}
 
 	// transfer web config
-	srcfp := filepath.Join(paths.Cache, fmt.Sprintf("web_config_%s_%d.yml", i.GetHost(), i.GetPort()))
+	srcfp := filepath.Join(paths.Cache, fmt.Sprintf("web.config_%s_%d.yml", i.GetHost(), i.GetPort()))
 	if err := cfg.WebConfigToFile(srcfp); err != nil {
 		return err
 	}
-	dstfp := filepath.Join(paths.Deploy, "conf", "web_config.yml")
+	dstfp := filepath.Join(paths.Deploy, "conf", "web.config.yml")
 	if err := e.Transfer(ctx, srcfp, dstfp, false, 0, false); err != nil {
 		return err
 	}

--- a/pkg/cluster/template/config/datasource.go
+++ b/pkg/cluster/template/config/datasource.go
@@ -24,8 +24,9 @@ import (
 
 // DatasourceConfig represent the data to generate Datasource config
 type DatasourceConfig struct {
-	ClusterName string
-	URL         string
+	ClusterName  string
+	URL          string
+	AuthPassword string
 }
 
 // ConfigToFile write config content to specific path

--- a/pkg/cluster/template/scripts/monitoring.go
+++ b/pkg/cluster/template/scripts/monitoring.go
@@ -15,19 +15,22 @@ package scripts
 
 import (
 	"bytes"
+	"os"
 	"path"
 	"text/template"
 
 	"github.com/pingcap/tiup/embed"
 	"github.com/pingcap/tiup/pkg/utils"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // PrometheusScript represent the data to generate Prometheus config
 type PrometheusScript struct {
-	Port           int
-	WebExternalURL string
-	Retention      string
-	EnableNG       bool
+	Port              int
+	WebExternalURL    string
+	BasicAuthPassword string
+	Retention         string
+	EnableNG          bool
 
 	DeployDir string
 	DataDir   string
@@ -57,4 +60,31 @@ func (c *PrometheusScript) ConfigToFile(file string) error {
 	}
 
 	return utils.WriteFile(file, content.Bytes(), 0755)
+}
+
+func (c *PrometheusScript) WebConfigToFile(file string) error {
+	fp := path.Join("templates", "config", "web_config.yml.tpl")
+	tpl, err := embed.ReadTemplate(fp)
+	if err != nil {
+		return err
+	}
+	tmpl, err := template.New("web_config").Parse(string(tpl))
+	if err != nil {
+		return err
+	}
+
+	pswHash, err := bcrypt.GenerateFromPassword([]byte(c.BasicAuthPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+	tmp := struct {
+		BasicAuthPassword string
+	}{BasicAuthPassword: string(pswHash)}
+
+	content := bytes.NewBufferString("")
+	if err := tmpl.Execute(content, tmp); err != nil {
+		return err
+	}
+
+	return os.WriteFile(file, content.Bytes(), 0755)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
tiup cluster 部署时支持prometheus组件时设置 web basic_auth。同时displa可以正常检查prometheus组件信息。

### What is changed and how it works?
添加一个prometheus的web.config.yml.tpl 模版文件，用户在topology.yaml中加入basic_auth_password字段，为prometheus的admin用户设置密码。设置后生成对应的web.config.yml文件，并修改run_prometheus.sh启动脚本。


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
