### PR TITLE
tiup-cluster: feat: support prometheus web_basic_auth

### DIFF
--- a/embed/examples/cluster/topology.example.yaml
+++ b/embed/examples/cluster/topology.example.yaml
@@ -353,6 +353,8 @@ monitoring_servers:
     # port: 9090
     # # ng-monitoring servive communication port
     # ng_port: 12020
+    # #prometheus web basic_auth_password
+    # basic_auth_password: admin
     # # Prometheus deployment file, startup script, configuration file storage directory.
     # deploy_dir: "/tidb-deploy/prometheus-8249"
     # # Prometheus data storage directory.

--- a/embed/templates/config/datasource.yml.tpl
+++ b/embed/templates/config/datasource.yml.tpl
@@ -10,3 +10,8 @@ datasources:
     tlsAuthWithCACert: false
     version: 1
     editable: true
+{{- if .AuthPassword}}
+    basicAuth: true
+    basicAuthUser: admin
+    basicAuthPassword: {{.AuthPassword}}
+{{- end}}    

--- a/embed/templates/config/web.config.yml.tpl
+++ b/embed/templates/config/web.config.yml.tpl
@@ -1,0 +1,2 @@
+basic_auth_users:
+  admin: {{.BasicAuthPassword}}

--- a/embed/templates/scripts/run_prometheus.sh.tpl
+++ b/embed/templates/scripts/run_prometheus.sh.tpl
@@ -39,6 +39,9 @@ exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/prometheus/
 exec bin/prometheus/prometheus \
 {{- end}}
     --config.file="{{.DeployDir}}/conf/prometheus.yml" \
+{{- if .BasicAuthPassword}}
+    --web.config.file="{{.DeployDir}}/conf/web.config.yml" \
+{{- end}}
     --web.listen-address=":{{.Port}}" \
     --web.external-url="{{.WebExternalURL}}/" \
     --web.enable-admin-api \

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -275,8 +275,9 @@ func (i *GrafanaInstance) InitConfig(
 	}
 	fp = filepath.Join(paths.Cache, fmt.Sprintf("datasource_%s.yml", i.GetHost()))
 	datasourceCfg := &config.DatasourceConfig{
-		ClusterName: clusterName,
-		URL:         fmt.Sprintf("http://%s", utils.JoinHostPort(monitors[0].Host, monitors[0].Port)),
+		ClusterName:  clusterName,
+		URL:          fmt.Sprintf("http://%s", utils.JoinHostPort(monitors[0].Host, monitors[0].Port)),
+		AuthPassword: monitors[0].BasicAuthPassword,
 	}
 	if err := datasourceCfg.ConfigToFile(fp); err != nil {
 		return err

--- a/pkg/cluster/template/config/datasource.go
+++ b/pkg/cluster/template/config/datasource.go
@@ -24,8 +24,9 @@ import (
 
 // DatasourceConfig represent the data to generate Datasource config
 type DatasourceConfig struct {
-	ClusterName string
-	URL         string
+	ClusterName  string
+	URL          string
+	AuthPassword string
 }
 
 // ConfigToFile write config content to specific path


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
tiup cluster部署prometheus组件时，支持填写basic_auth_password，用于设置web auth。

### What is changed and how it works?
新增一个web.config.yml.tpl 模版文件，在用户设置basic_auth_password密码后，生成对应的prometheus配置文件。修改run_prometheus.sh.tpl，在设置了密码后，在启动脚本里添加prometheus的wen.config项目。同时cluster display 也支持密码认证的prometheus健康检查。

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
