### PR TITLE
cluster: check both SELinux status and config

### DIFF
--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -671,7 +671,7 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder, sy
 		}
 		t.Limit(host, fields[0], fields[1], fields[2], fields[3], sudo)
 		msg = fmt.Sprintf("will try to set '%s'", color.HiBlueString(res.Msg))
-	case operator.CheckNameSELinux:
+	case operator.CheckNameSELinuxConf, operator.CheckNameSELinuxStatus:
 		t.Shell(host,
 			fmt.Sprintf(
 				"sed -i 's/^[[:blank:]]*SELINUX=enforcing/SELINUX=disabled/g' %s && %s",

--- a/pkg/cluster/task/check.go
+++ b/pkg/cluster/task/check.go
@@ -85,7 +85,8 @@ func (c *CheckSys) Execute(ctx context.Context) error {
 		}
 		results = append(
 			results,
-			operator.CheckSELinux(ctx, e, sudo),
+			operator.CheckSELinuxConf(ctx, e, sudo),
+			operator.CheckSELinuxStatus(ctx, e, sudo),
 			operator.CheckTHP(ctx, e, sudo),
 		)
 		storeResults(ctx, c.host, results)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently `tiup cluster check` only checks if SELinux is configured to be disabled. It does not check the current status.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)

```
tiup-cluster check topology.yaml --apply
...
192.168.122.196  selinux_conf    Fail    will try to disable SELinux, reboot might be needed
192.168.122.196  selinux_status  Fail    will try to disable SELinux, reboot might be needed
...
+ Try to apply changes to fix failed checks
  - Applying changes on 192.168.122.196 ... ⠦ Shell: host=192.168.122.196, sudo=true, command=`sed -i 's/^[[:blank:]]*SELINUX=enforcing/...
```

```
tiup-cluster check topology.yaml
192.168.122.196  selinux_status  Warn    SELinux is in Permissive mode, disabling is recommended
192.168.122.196  selinux_conf    Pass    SELinux is disabled in configuration
```

Code changes

 - Has exported function/method change



Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
`tiup cluster check` now checks the SELinux status in addition to the SELinux configuration
```
