### PR TITLE
cluster: Persistently disable THP

### DIFF
--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -683,7 +683,11 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder, sy
 		msg = fmt.Sprintf("will try to %s, reboot might be needed", color.HiBlueString("disable SELinux"))
 	case operator.CheckNameTHP:
 		t.Shell(host,
-			fmt.Sprintf(`if [ -d %[1]s ]; then echo never > %[1]s/enabled; fi`, "/sys/kernel/mm/transparent_hugepage"),
+			fmt.Sprintf(
+				`if [ -d %[1]s ]; then echo never > %[1]s/enabled; fi && %s`,
+				"/sys/kernel/mm/transparent_hugepage",
+				`grubby --update-kernel=ALL --args="transparent_hugepage=never"`,
+			),
 			"",
 			sudo)
 		msg = fmt.Sprintf("will try to %s, please check again after reboot", color.HiBlueString("disable THP"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)

```
tiup cluster check topology.yaml --apply
...

And then check `/etc/default/grub`:
```
...
GRUB_CMDLINE_LINUX="crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M resume=/dev/mapper/rl-swap rd.lvm.lv=rl/root rd.lvm.lv=rl/swap transparent_hugepage=never"
...
```


Related changes

 - https://github.com/pingcap/docs/pull/20070 

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
TiUP Cluster Check now disables THP persistently
```
