### PR TITLE
cluster: improved error for missing tar

### DIFF
--- a/pkg/cluster/task/install_package.go
+++ b/pkg/cluster/task/install_package.go
@@ -53,7 +53,7 @@ func (c *InstallPackage) Execute(ctx context.Context) error {
 	_, stderr, err := exec.Execute(ctx, cmd, false)
 	if err != nil {
 		if bytes.Contains(stderr, []byte("command not found")) {
-			return errors.New("tar command was not found, please install it")
+			return errors.Errorf("tar command was not found on %s, please install it", c.host)
 		}
 		return errors.Annotatef(err, "stderr: %s", string(stderr))
 	}

--- a/pkg/cluster/task/install_package.go
+++ b/pkg/cluster/task/install_package.go
@@ -54,9 +54,8 @@ func (c *InstallPackage) Execute(ctx context.Context) error {
 	if err != nil {
 		if bytes.Contains(stderr, []byte("command not found")) {
 			return errors.New("tar command was not found, please install it")
-		} else {
-			return errors.Annotatef(err, "stderr: %s", string(stderr))
 		}
+		return errors.Annotatef(err, "stderr: %s", string(stderr))
 	}
 	return nil
 }

--- a/pkg/cluster/task/install_package.go
+++ b/pkg/cluster/task/install_package.go
@@ -14,6 +14,7 @@
 package task
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"path"
@@ -51,7 +52,11 @@ func (c *InstallPackage) Execute(ctx context.Context) error {
 
 	_, stderr, err := exec.Execute(ctx, cmd, false)
 	if err != nil {
-		return errors.Annotatef(err, "stderr: %s", string(stderr))
+		if bytes.Contains(stderr, []byte("command not found")) {
+			return errors.New("tar command was not found, please install it")
+		} else {
+			return errors.Annotatef(err, "stderr: %s", string(stderr))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

With a minimal install of Rocky Linux 9.5 tar isn't installed and the error could be improved

Without this PR:
```
$ tiup cluster check topology.yaml 
The SSH identity key is encrypted. Input its passphrase: 

+ Detect CPU Arch Name
  - Detecting node 192.168.122.196 Arch info ... Done

+ Detect CPU OS Name
  - Detecting node 192.168.122.196 OS info ... Done
+ Download necessary tools
  - Downloading check tools for linux/amd64 ... Done
+ Collect basic system information
  - Getting system info of 192.168.122.196:22 ... Error

Error: stderr: bash: line 1: tar: command not found
: executor.ssh.execute_failed: Failed to execute command over SSH for 'dvaneeden@192.168.122.196:22' {ssh_stderr: bash: line 1: tar: command not found
, ssh_stdout: , ssh_command: export LANG=C; PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin; /usr/bin/sudo -H bash -c "tar --no-same-owner -zxf /tmp/tiup/bin/insight-v0.4.2-linux-amd64.tar.gz -C /tmp/tiup/bin && rm /tmp/tiup/bin/insight-v0.4.2-linux-amd64.tar.gz"}, cause: Process exited with status 127

Verbose debug logs has been written to /home/dvaneeden/.tiup/logs/tiup-cluster-debug-2025-01-21-08-16-43.log.
```

With this PR:
```
$ tiup cluster check topology.yaml 
The SSH identity key is encrypted. Input its passphrase: 

+ Detect CPU Arch Name
  - Detecting node 192.168.122.196 Arch info ... Done

+ Detect CPU OS Name
  - Detecting node 192.168.122.196 OS info ... Done
+ Download necessary tools
  - Downloading check tools for linux/amd64 ... Done
+ Collect basic system information
  - Getting system info of 192.168.122.196:22 ... Error

Error: tar command was not found, please install it

Verbose debug logs has been written to /home/dvaneeden/.tiup/logs/tiup-cluster-debug-2025-01-21-08-42-24.log.
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)



Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
