### PR TITLE
cluster: improve SELinux compatibility

### DIFF
--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -231,7 +231,7 @@ func (i *BaseInstance) InitConfig(ctx context.Context, e ctxt.Executor, opt Glob
 	// - We don't support SELinux in Enforcing mode
 	// - restorecon might not be available (Ubuntu doesn't install SELinux tools by default)
 	cmd = fmt.Sprintf("restorecon %s%s-%d.service", systemdDir, comp, port)
-	e.Execute(ctx, cmd, sudo)
+	e.Execute(ctx, cmd, sudo) //nolint
 
 	// doesn't work
 	if _, err := i.setTLSConfig(ctx, false, nil, paths); err != nil {

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -224,6 +224,15 @@ func (i *BaseInstance) InitConfig(ctx context.Context, e ctxt.Executor, opt Glob
 		return errors.Annotatef(err, "execute: %s", cmd)
 	}
 
+	// restorecon restores SELinux Contexts
+	// Check with: ls -lZ /path/to/file
+	// If the context is wrong systemctl will complain about a missing unit file
+	// Note that we won't check for errors here because:
+	// - We don't support SELinux in Enforcing mode
+	// - restorecon might not be available (Ubuntu doesn't install SELinux tools by default)
+	cmd = fmt.Sprintf("restorecon %s%s-%d.service", systemdDir, comp, port)
+	e.Execute(ctx, cmd, sudo)
+
 	// doesn't work
 	if _, err := i.setTLSConfig(ctx, false, nil, paths); err != nil {
 		return err

--- a/pkg/cluster/spec/tispark.go
+++ b/pkg/cluster/spec/tispark.go
@@ -267,6 +267,15 @@ func (i *TiSparkMasterInstance) InitConfig(
 		return errors.Annotatef(err, "execute: %s", cmd)
 	}
 
+	// restorecon restores SELinux Contexts
+	// Check with: ls -lZ /path/to/file
+	// If the context is wrong systemctl will complain about a missing unit file
+	// Note that we won't check for errors here because:
+	// - We don't support SELinux in Enforcing mode
+	// - restorecon might not be available (Ubuntu doesn't install SELinux tools by default)
+	cmd = fmt.Sprintf("restorecon %s%s-%d.service", systemdDir, comp, port)
+	e.Execute(ctx, cmd, sudo)
+
 	// transfer default config
 	pdList := topo.GetPDList()
 	masterList := make([]string, 0)

--- a/pkg/cluster/spec/tispark.go
+++ b/pkg/cluster/spec/tispark.go
@@ -274,7 +274,7 @@ func (i *TiSparkMasterInstance) InitConfig(
 	// - We don't support SELinux in Enforcing mode
 	// - restorecon might not be available (Ubuntu doesn't install SELinux tools by default)
 	cmd = fmt.Sprintf("restorecon %s%s-%d.service", systemdDir, comp, port)
-	e.Execute(ctx, cmd, sudo)
+	e.Execute(ctx, cmd, sudo) //nolint
 
 	// transfer default config
 	pdList := topo.GetPDList()

--- a/pkg/cluster/task/monitored_config.go
+++ b/pkg/cluster/task/monitored_config.go
@@ -138,6 +138,16 @@ func (m *MonitoredConfig) syncMonitoredSystemConfig(ctx context.Context, exec ct
 		}
 		return err
 	}
+
+	// restorecon restores SELinux Contexts
+	// Check with: ls -lZ /path/to/file
+	// If the context is wrong systemctl will complain about a missing unit file
+	// Note that we won't check for errors here because:
+	// - We don't support SELinux in Enforcing mode
+	// - restorecon might not be available (Ubuntu doesn't install SELinux tools by default)
+	cmd := fmt.Sprintf("restorecon %s%s-%d.service", systemdDir, comp, port)
+	exec.Execute(ctx, cmd, sudo)
+
 	return nil
 }
 

--- a/pkg/cluster/task/monitored_config.go
+++ b/pkg/cluster/task/monitored_config.go
@@ -146,7 +146,7 @@ func (m *MonitoredConfig) syncMonitoredSystemConfig(ctx context.Context, exec ct
 	// - We don't support SELinux in Enforcing mode
 	// - restorecon might not be available (Ubuntu doesn't install SELinux tools by default)
 	cmd := fmt.Sprintf("restorecon %s%s-%d.service", systemdDir, comp, port)
-	exec.Execute(ctx, cmd, sudo)
+	exec.Execute(ctx, cmd, sudo) //nolint
 
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- Improve SELinux compatibility
- Fix the context of the systemd files after moving them from `/tmp` to `/etc/systemd`

This doesn't change the SELinux policy. We *could* do that later if we want. So no docs changes for now.

Because of this we don't change the `tiup cluster check` for SELinux.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Tested:
- Deploy cluster
- Start/Stop cluster

 - Manual test (add detailed scripts or steps below)


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
