### PR TITLE
cluster: Remove duplicate display of dashboard URLs

### DIFF
--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -832,7 +832,7 @@ func (m *Manager) displayDashboards(ctx context.Context, t *spec.Specification, 
 			}
 			if m.logger.GetDisplayMode() == logprinter.DisplayModeJSON && j != nil {
 				j.ClusterMetaInfo.DashboardURL = fmt.Sprintf("%s://%s/dashboard", scheme, addr)
-			} else {
+			} else if len(dashboardAddrs) == 1 {
 				fmt.Printf("Dashboard URL:      %s\n", color.CyanString("%s://%s/dashboard", scheme, addr))
 			}
 		}
@@ -845,7 +845,9 @@ func (m *Manager) displayDashboards(ctx context.Context, t *spec.Specification, 
 	}
 
 	if m.logger.GetDisplayMode() != logprinter.DisplayModeJSON || j == nil {
-		fmt.Printf("Dashboard URLs:     %s\n", strings.Join(dashboardAddrs, ","))
+		if len(dashboardAddrs) > 1 {
+			fmt.Printf("Dashboard URLs:     %s\n", strings.Join(dashboardAddrs, ","))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Note the two lines with `Dashboard URL` here:

```
$ tiup cluster display dvetest1 
Cluster type:       tidb
Cluster name:       dvetest1
Cluster version:    v8.5.0
Deploy user:        tidb
SSH type:           builtin
Dashboard URL:      http://192.168.122.196:2379/dashboard
Dashboard URLs:     http://192.168.122.196:2379/dashboard
Grafana URL:        http://192.168.122.196:3000
ID                     Role        Host             Ports        OS/Arch       Status   Data Dir                    Deploy Dir
--                     ----        ----             -----        -------       ------   --------                    ----------
192.168.122.196:3000   grafana     192.168.122.196  3000         linux/x86_64  Up       -                           /tidb-deploy/grafana-3000
192.168.122.196:2379   pd          192.168.122.196  2379/2380    linux/x86_64  Up|L|UI  /tidb-data/pd-2379          /tidb-deploy/pd-2379
192.168.122.196:9090   prometheus  192.168.122.196  9090/12020   linux/x86_64  Up       /tidb-data/prometheus-9090  /tidb-deploy/prometheus-9090
192.168.122.196:4000   tidb        192.168.122.196  4000/10080   linux/x86_64  Up       -                           /tidb-deploy/tidb-4000
192.168.122.196:20160  tikv        192.168.122.196  20160/20180  linux/x86_64  Up       /tidb-data/tikv-20160       /tidb-deploy/tikv-20160
Total nodes: 5
```

Related: #2472

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)

Now only one line in the output: `Dashboard URL:      http://192.168.122.196:2379/dashboard`



Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
