### PR TITLE
*: Fix misc spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ TiUP Changelog
 - Fix possible panic when `tiup-playground` failed to start (#2457, @xhebox)
 - Respect `component_versions` when `tiup-cluster` scales (#2451, @djshow832)
 - Code clean: replace 'math/rand' with 'crypto/rand' (#2455, @bb7133)
-- Fix tiup cannot update itself when tiup comonent exist (#2443, @nexustar)
+- Fix tiup cannot update itself when tiup component exist (#2443, @nexustar)
 - Do not check HTTP port for TiFlash 7.1.0 or above (#2440, @Lloyd-Pottiger)
 - Also hide other password args (#2436, @xhebox)
 
@@ -114,7 +114,7 @@ TiUP Changelog
 
 - Support use different component versions in `tiup-cluster` (#2010 #2264 #2306, @nexustar)
 - Add global listen_host config in `tiup-cluster` and `tiup-dm` (#2303, @nexustar)
-- Add gloabl component_sources config in `tiup-cluster` and `tiup-dm` (#2320, @nexustar)
+- Add global component_sources config in `tiup-cluster` and `tiup-dm` (#2320, @nexustar)
 - Support TiDB upgrade API to automatically pause DDL when upgrade in `tiup-cluster`(#2287 #2289, @nexustar)
 - Support TiProxy in `tiup-cluster` (#2271, @xhebox)
 - Support scheduling service in `tiup-playground` (#2273, @rleungx)
@@ -381,7 +381,7 @@ TiUP Changelog
 - Add support of completion of cluster name with Tab button for `tiup-cluster` ([#1891](https://github.com/pingcap/tiup/pull/1891), [@nexustar](https://github.com/nexustar))
 - Add support of checking timezone consistency among servers in `check` command of `tiup-cluster` ([#1890](https://github.com/pingcap/tiup/pull/1890), [@nexustar](https://github.com/nexustar))
 - Add support of deploying on RHEL 8 in `tiup-cluster` ([#1896](https://github.com/pingcap/tiup/pull/1896), [@nexustar](https://github.com/nexustar))
-- Add support of specifing custom key directory when rotating `root.json` in `tiup mirror` command ([#1848](https://github.com/pingcap/tiup/pull/1848), [@AstroProfundis](https://github.com/AstroProfundis))
+- Add support of specifying custom key directory when rotating `root.json` in `tiup mirror` command ([#1848](https://github.com/pingcap/tiup/pull/1848), [@AstroProfundis](https://github.com/AstroProfundis))
 
 ### Fixes
 
@@ -478,7 +478,7 @@ TiUP Changelog
 - Add support of enabling and disabling TLS encryption for deployed TiDB cluster in `tiup-cluster` ([#1657](https://github.com/pingcap/tiup/pull/1657), [@srstack](https://github.com/srstack))
 - Add support of deploying TLS enabled DM clusters in `tiup-dm` ([#1745](https://github.com/pingcap/tiup/pull/1745), [@nexustar](https://github.com/nexustar))
 - Add support of changing owner of a component in `tiup mirror` and `tiup-server` ([#1676](https://github.com/pingcap/tiup/pull/1676), [@AstroProfundis](https://github.com/AstroProfundis))
-- Add support of specifing IP address to bind for AlertManager in `tiup-cluster` ([#1665](https://github.com/pingcap/tiup/pull/1665) [#1669](https://github.com/pingcap/tiup/pull/1669), [@srstack](https://github.com/srstack))
+- Add support of specifying IP address to bind for AlertManager in `tiup-cluster` ([#1665](https://github.com/pingcap/tiup/pull/1665) [#1669](https://github.com/pingcap/tiup/pull/1669), [@srstack](https://github.com/srstack))
 - Add support of initialing random root password for TiDB in `tiup-cluster` ([#1700](https://github.com/pingcap/tiup/pull/1700), [@AstroProfundis](https://github.com/AstroProfundis))
 - Add support of `check` before scaling out a cluster in `tiup-cluster` ([#1659](https://github.com/pingcap/tiup/pull/1659), [@srstack](https://github.com/srstack))
 - Add support of customizing Grafana configurations in `server_configs` section in `tiup-cluster` and `tiup-dm` ([#1703](https://github.com/pingcap/tiup/pull/1703), [@nexustar](https://github.com/nexustar))
@@ -542,7 +542,7 @@ TiUP Changelog
 - Add support of next-generation monitor (`ng-monitor`) in `tiup-playground` ([#1648](https://github.com/pingcap/tiup/pull/1648), [@nexustar](https://github.com/nexustar))
 - Add support of inserting custom `scrape_configs` to Prometheus configs in `tiup-cluster` ([#1641](https://github.com/pingcap/tiup/pull/1641), [@nexustar](https://github.com/nexustar))
 - [experimental] Support 2-staged scaling out for `tiup-cluster` ([#1638](https://github.com/pingcap/tiup/pull/1638) [#1642](https://github.com/pingcap/tiup/pull/1642), [@srstack](https://github.com/srstack))
-  - Scaling out of a TiDB cluster can be devided with `--stage1` and `--stage2` arguments, the stage 1 deploys files and configs but not starting the new instances, and the stage 2 actually starts the new instances and reload necessary configs
+  - Scaling out of a TiDB cluster can be divided with `--stage1` and `--stage2` arguments, the stage 1 deploys files and configs but not starting the new instances, and the stage 2 actually starts the new instances and reload necessary configs
   - This could be useful if you want to modify config of the new instances or use a custom binary with `patch` **before** the first start of the new instances
 - [experimental] Implement plain text output and support custom output writer for logs ([#1646](https://github.com/pingcap/tiup/pull/1646), [@AstroProfundis](https://github.com/AstroProfundis))
 
@@ -660,7 +660,7 @@ TiUP Changelog
 
 - Allow editing of `lerner_config` field in TiFlash spec ([#1494](https://github.com/pingcap/tiup/pull/1494), [@AstroProfundis](https://github.com/AstroProfundis))
 - Fix incorrect timeout for telemetry requests ([#1500](https://github.com/pingcap/tiup/pull/1500), [@AstroProfundis](https://github.com/AstroProfundis))
-- Ingore `data_dir` of monitor agents when checking for directory overlaps ([#1510](https://github.com/pingcap/tiup/pull/1510), [@AstroProfundis](https://github.com/AstroProfundis))
+- Ignore `data_dir` of monitor agents when checking for directory overlaps ([#1510](https://github.com/pingcap/tiup/pull/1510), [@AstroProfundis](https://github.com/AstroProfundis))
 
 ### Improvements
 
@@ -885,7 +885,7 @@ TiUP Changelog
 
 ### Fixes
 
-- Fix the issue that tiup-cluster can't gernerate prometheus config ([#1185](https://github.com/pingcap/tiup/pull/1185), [@lucklove](https://github.com/lucklove))
+- Fix the issue that tiup-cluster can't generate prometheus config ([#1185](https://github.com/pingcap/tiup/pull/1185), [@lucklove](https://github.com/lucklove))
 - Fix the issue that tiup may choose yanked version if it's already installed ([#1191](https://github.com/pingcap/tiup/pull/1191), [@lucklove](https://github.com/lucklove))
 
 ## [1.3.3] 2021.03.04
@@ -937,11 +937,11 @@ TiUP Changelog
 
 ### Improvements
 
-- Reduce display duration when PD nodes encounter network problems and droping packages ([#986](https://github.com/pingcap/tiup/pull/986), [@9547](https://github.com/9547))
+- Reduce display duration when PD nodes encounter network problems and dropping packages ([#986](https://github.com/pingcap/tiup/pull/986), [@9547](https://github.com/9547))
 - cluster, dm: support version input without leading 'v' ([#1009](https://github.com/pingcap/tiup/pull/1009), [@AstroProfundis](https://github.com/AstroProfundis))
 - Add a warning to explain that we will stop the cluster before clean logs ([#1029](https://github.com/pingcap/tiup/pull/1029), [@lucklove](https://github.com/lucklove))
   - When a user try to clean logs with the command `tiup cluster clean --logs`, he may expect that the cluster is still running during the clean operation
-  - The actual situation is not what he expect, which may suprise the user (risk)
+  - The actual situation is not what he expect, which may surprise the user (risk)
 
 ## [1.3.0] 2020.12.17
 
@@ -964,7 +964,7 @@ TiUP Changelog
 
 - Fixed the issue that the public key created by TiUP was not removed after the cluster was destroyed ([#910](https://github.com/pingcap/tiup/pull/910), [@9547](https://github.com/9547))
 - Fix the issue that user defined grafana username and password not imported from tidb-ansible cluster correctly ([#937](https://github.com/pingcap/tiup/pull/937), [@AstroProfundis](https://github.com/AstroProfundis))
-- Fix the issue that playground cluster not quiting components with correct order: TiDB -> TiKV -> PD ([#933](https://github.com/pingcap/tiup/pull/933), [@unbyte](https://github.com/unbyte))
+- Fix the issue that playground cluster not quitting components with correct order: TiDB -> TiKV -> PD ([#933](https://github.com/pingcap/tiup/pull/933), [@unbyte](https://github.com/unbyte))
 - Fix the issue that TiKV reports wrong advertise address when `--status-addr` is set to a wildcard address like `0.0.0.0` ([#951](https://github.com/pingcap/tiup/pull/951), [@lucklove](https://github.com/lucklove))
 - Fix the issue that Prometheus doesn't reload target after scale-in action ([#958](https://github.com/pingcap/tiup/pull/958), [@9547](https://github.com/9547))
 - Fix the issue that the config file for TiFlash missing in playground cluster ([#969](https://github.com/pingcap/tiup/pull/969), [@unbyte](https://github.com/unbyte))
@@ -1054,7 +1054,7 @@ TiUP Changelog
 - Support limiting core dump size ([#817](https://github.com/pingcap/tiup/pull/817), [@lucklove](https://github.com/lucklove))
 - Support using latest Spark and TiSpark release ([#779](https://github.com/pingcap/tiup/pull/779), [@lucklove](https://github.com/lucklove))
 - Support new cdc arguments `gc-ttl` and `tz` ([#770](https://github.com/pingcap/tiup/pull/770), [@lichunzhu](https://github.com/lichunzhu))
-- Support specifing custom ssh and scp path ([#734](https://github.com/pingcap/tiup/pull/734), [@9547](https://github.com/9547))
+- Support specifying custom ssh and scp path ([#734](https://github.com/pingcap/tiup/pull/734), [@9547](https://github.com/9547))
 
 ### Fixes
 
@@ -1066,9 +1066,9 @@ TiUP Changelog
 
 ### Improvements
 
-- Automaticlly check if TiKV's label is set ([#800](https://github.com/pingcap/tiup/pull/800), [@lucklove](https://github.com/lucklove))
+- Automatically check if TiKV's label is set ([#800](https://github.com/pingcap/tiup/pull/800), [@lucklove](https://github.com/lucklove))
 - Download component with stream mode to avoid memory explosion ([#755](https://github.com/pingcap/tiup/pull/755), [@9547](https://github.com/9547))
-- Save and display absolute path for deploy directory, data dirctory and log directory to avoid confusion ([#822](https://github.com/pingcap/tiup/pull/822), [@lucklove](https://github.com/lucklove))
+- Save and display absolute path for deploy directory, data directory and log directory to avoid confusion ([#822](https://github.com/pingcap/tiup/pull/822), [@lucklove](https://github.com/lucklove))
 - Redirect DM stdout to log files ([#815](https://github.com/pingcap/tiup/pull/815), [@csuzhangxc](https://github.com/csuzhangxc))
 - Skip download nightly package when it exists ([#793](https://github.com/pingcap/tiup/pull/793), [@lucklove](https://github.com/lucklove))
 
@@ -1134,7 +1134,7 @@ TiUP Changelog
 
 * Validate topology changes after edit-config [#609](https://github.com/pingcap/tiup/pull/609)
 * Allow continue editing when new topology has errors [#624](https://github.com/pingcap/tiup/pull/624)
-* Fix wrongly setted data_dir of TiFlash when import from ansible [#612](https://github.com/pingcap/tiup/pull/612)
+* Fix wrongly set data_dir of TiFlash when import from ansible [#612](https://github.com/pingcap/tiup/pull/612)
 * Support native ssh client [#615](https://github.com/pingcap/tiup/pull/615)
 * Support refresh configuration only when reload [#625](https://github.com/pingcap/tiup/pull/625)
 * Apply config file on scaled pd server [#627](https://github.com/pingcap/tiup/pull/627)

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -233,7 +233,7 @@ func newMirrorGrantCmd() *cobra.Command {
 				name = id
 			}
 
-			// the privPath can point to a public key becase the Public method of KeyInfo works on both priv and pub keys
+			// the privPath can point to a public key because the Public method of KeyInfo works on both priv and pub keys
 			privKey, err := loadPrivKey(privPath)
 			if err != nil {
 				return err
@@ -826,7 +826,7 @@ func newMirrorGenkeyCmd() *cobra.Command {
 // the `mirror init` sub command
 func newMirrorInitCmd() *cobra.Command {
 	var (
-		keyDir string // Directory to write genreated key files
+		keyDir string // Directory to write generated key files
 	)
 	cmd := &cobra.Command{
 		Use:   "init <path>",

--- a/components/cluster/command/root.go
+++ b/components/cluster/command/root.go
@@ -163,7 +163,7 @@ func init() {
 	// start/stop operations is 90s, the default value of this argument is better be longer than that
 	rootCmd.PersistentFlags().Uint64Var(&gOpt.OptTimeout, "wait-timeout", 120, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 	rootCmd.PersistentFlags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip all confirmations and assumes 'yes'")
-	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "(EXPERIMENTAL) Use the native SSH client installed on local system instead of the build-in one.")
+	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "(EXPERIMENTAL) Use the native SSH client installed on local system instead of the built-in one.")
 	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "(EXPERIMENTAL) The executor type: 'builtin', 'system', 'none'.")
 	rootCmd.PersistentFlags().IntVarP(&gOpt.Concurrency, "concurrency", "c", 5, "max number of parallel tasks allowed")
 	rootCmd.PersistentFlags().StringVar(&gOpt.DisplayMode, "format", "default", "(EXPERIMENTAL) The format of output, available values are [default, json]")

--- a/components/cluster/command/telemetry.go
+++ b/components/cluster/command/telemetry.go
@@ -44,7 +44,7 @@ func newTelemetryCmd() *cobra.Command {
 	return cmd
 }
 
-// nodeInfo dispaly telemetry.NodeInfo in stdout.
+// nodeInfo display telemetry.NodeInfo in stdout.
 func nodeInfo(ctx context.Context) error {
 	info := new(telemetry.NodeInfo)
 	err := telemetry.FillNodeInfo(ctx, info)

--- a/components/dm/ansible/import.go
+++ b/components/dm/ansible/import.go
@@ -125,7 +125,7 @@ type Importer struct {
 	sources map[string]*SourceConfig // addr(ip:port) -> SourceConfig
 
 	// only use for test.
-	// when setted, we use this executor instead of getting a truly one.
+	// when set, we use this executor instead of getting a truly one.
 	testExecutorGetter ExecutorGetter
 }
 

--- a/components/dm/command/root.go
+++ b/components/dm/command/root.go
@@ -129,7 +129,7 @@ please backup your data before process.`,
 	rootCmd.PersistentFlags().Uint64Var(&gOpt.SSHTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection.")
 	rootCmd.PersistentFlags().Uint64Var(&gOpt.OptTimeout, "wait-timeout", 120, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 	rootCmd.PersistentFlags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip all confirmations and assumes 'yes'")
-	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "Use the SSH client installed on local system instead of the build-in one.")
+	rootCmd.PersistentFlags().BoolVar(&gOpt.NativeSSH, "native-ssh", gOpt.NativeSSH, "Use the SSH client installed on local system instead of the built-in one.")
 	rootCmd.PersistentFlags().StringVar((*string)(&gOpt.SSHType), "ssh", "", "The executor type: 'builtin', 'system', 'none'")
 	rootCmd.PersistentFlags().IntVarP(&gOpt.Concurrency, "concurrency", "c", 5, "max number of parallel tasks allowed")
 	rootCmd.PersistentFlags().StringVar(&gOpt.DisplayMode, "format", "default", "(EXPERIMENTAL) The format of output, available values are [default, json]")

--- a/doc/design/checkpoint.md
+++ b/doc/design/checkpoint.md
@@ -1,4 +1,4 @@
-# The checkpoint implemention for tiup-cluster and tiup-dm
+# The checkpoint implementation for tiup-cluster and tiup-dm
 
 When there is an occasional error on `tiup cluster` or `tiup dm` command, some users may want to retry previews action from the fail point instead of from scratch.
 

--- a/doc/design/manifest.md
+++ b/doc/design/manifest.md
@@ -39,7 +39,7 @@ TiUp itself can be treated as a component and I think does not need to be treate
 * Zero-trust access control.
 * Minimise the number of keys and the frequency with which they must be replaced.
 * Uploads and downloads should be secure.
-* All operations should be idempotent or at least repeatable. If an operation is interupted, the user can just retry until it succeeds.
+* All operations should be idempotent or at least repeatable. If an operation is interrupted, the user can just retry until it succeeds.
 * There should be no 'transaction' mechanism between client and server, groups of operations should not require atomicity.
 * Minimise required knowledge in the client - the metadata should direct the client how to perform operations with minimal knowledge of the server's data layout, etc.
 * We should not require consistency between files in the repo (beyond hashes and keys).
@@ -471,7 +471,7 @@ Adding a repo is trivial - we just need a URL and trusted root manifest, then fo
 Whether a key is rotated due to it being compromised or due to regular rotation, the procedure is the same. A top-level key cannot be removed without being replaced. This is an entirely server-side action.
 
 * Produce a new key pair.
-* Store the new private key or give it to the adminstrator to store securely.
+* Store the new private key or give it to the administrator to store securely.
 * Update root.json to add the new public key and remove the old one.
 * If replacing a root key, the new root.json should be signed with both the old and the new keys.
 * If a non-root key is replaced, create a new version of the relevant manifest and sign with the new key (and any older, non-replaced keys).

--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -113,7 +113,7 @@ dm                 pingcap    Data Migration Platform manager
 dm-master          pingcap    dm-master component of Data Migration Platform
 dm-worker          pingcap    dm-worker component of Data Migration Platform
 dmctl              pingcap    dmctl component of Data Migration Platform
-drainer            pingcap    The drainer componet of TiDB binlog service
+drainer            pingcap    The drainer component of TiDB binlog service
 dumpling           pingcap    Dumpling is a CLI tool that helps you dump MySQL/TiDB data
 errdoc             pingcap    Document about TiDB errors
 grafana            pingcap    Grafana is the open source analytics & monitoring solution for every database
@@ -124,7 +124,7 @@ pd                 pingcap    PD is the abbreviation for Placement Driver. It is
 pd-recover         pingcap    PD Recover is a disaster recovery tool of PD, used to recover the PD cluster which cannot start or provide services normally
 playground         pingcap    Bootstrap a local TiDB cluster for fun
 prometheus         pingcap    The Prometheus monitoring system and time series database
-pump               pingcap    The pump componet of TiDB binlog service
+pump               pingcap    The pump component of TiDB binlog service
 pushgateway        pingcap    Push acceptor for ephemeral and batch jobs
 server             pingcap    TiUP publish/cache server
 spark              pingcap    Spark is a fast and general cluster computing system for Big Data

--- a/embed/templates/config/grafana.ini.tpl
+++ b/embed/templates/config/grafana.ini.tpl
@@ -114,7 +114,7 @@ server_from_sub_path = true
 ;reporting_enabled = true
 
 # Set to false to disable all checks to https://grafana.net
-# for new vesions (grafana itself and plugins), check is used
+# for new versions (grafana itself and plugins), check is used
 # in some UI views to notify that grafana or plugin update exists
 # This option does not cause any auto updates, nor send any information
 # only a GET request to http://grafana.net to get latest versions

--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ sgr0=$(tput sgr0 2>/dev/null)
 
 echo
 
-# Refrence: https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix
+# Reference: https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix
 shell=$(echo $SHELL | awk 'BEGIN {FS="/";} { print $NF }')
 echo "Detected shell: ${bold}$shell${sgr0}"
 if [ -f "${HOME}/.${shell}_profile" ]; then

--- a/pkg/cluster/api/dmpb/dmworker.pb.go
+++ b/pkg/cluster/api/dmpb/dmworker.pb.go
@@ -955,7 +955,7 @@ func (m *SyncStatus) GetSecondsBehindMaster() int64 {
 	return 0
 }
 
-// SourceStatus represents status for source runing on dm-worker
+// SourceStatus represents status for source running on dm-worker
 type SourceStatus struct {
 	Source      string         `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
 	Worker      string         `protobuf:"bytes,2,opt,name=worker,proto3" json:"worker,omitempty"`
@@ -1909,7 +1909,7 @@ func (m *SubTaskErrorList) GetError() []*SubTaskError {
 //
 //	when Stop or Pause is requested from external, isCanceled will be true
 //
-// errors: includes all (potential) errors occured when processing
+// errors: includes all (potential) errors occurred when processing
 type ProcessResult struct {
 	IsCanceled bool            `protobuf:"varint,1,opt,name=isCanceled,proto3" json:"isCanceled,omitempty"`
 	Errors     []*ProcessError `protobuf:"bytes,2,rep,name=errors,proto3" json:"errors,omitempty"`

--- a/pkg/cluster/executor/executor.go
+++ b/pkg/cluster/executor/executor.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pingcap/tiup/pkg/localdata"
 )
 
-// SSHType represent the type of the chanel used by ssh
+// SSHType represent the type of the channel used by ssh
 type SSHType string
 
 var (
@@ -47,7 +47,7 @@ var (
 
 	// This command will be execute once the NativeSSHExecutor is created.
 	// It's used to predict if the connection can establish success in the future.
-	// Its main purpose is to avoid sshpass hang when user speficied a wrong prompt.
+	// Its main purpose is to avoid sshpass hang when user specified a wrong prompt.
 	connectionTestCommand = "echo connection test, if killed, check the password prompt"
 
 	// SSH authorized_keys file

--- a/pkg/cluster/executor/scp.go
+++ b/pkg/cluster/executor/scp.go
@@ -87,7 +87,7 @@ func ScpDownload(session *ssh.Session, client *ssh.Client, src, dst string, limi
 			}
 
 			fp := filepath.Join(wd, name)
-			// fisrt scp command is 'C' means src is a single file
+			// first scp command is 'C' means src is a single file
 			if firstCommand {
 				fp = dst
 			}
@@ -121,7 +121,7 @@ func ScpDownload(session *ssh.Session, client *ssh.Client, src, dst string, limi
 			// normally, workdir is like this
 			wd = filepath.Join(wd, name)
 
-			// fisrt scp command is 'D' means src is a dir
+			// first scp command is 'D' means src is a dir
 			if firstCommand {
 				fi, err := os.Stat(dst)
 				if err != nil && !os.IsNotExist(err) {

--- a/pkg/cluster/manager/builder.go
+++ b/pkg/cluster/manager/builder.go
@@ -711,7 +711,7 @@ func buildDownloadCompTasks(
 		if found := uniqueTaskList.Exist(key); !found {
 			uniqueTaskList.Insert(key)
 
-			// we don't set version for tispark, so the lastest tispark will be used
+			// we don't set version for tispark, so the latest tispark will be used
 			var version string
 			if inst.ComponentName() == spec.ComponentTiSpark {
 				// download spark as dependency of tispark

--- a/pkg/cluster/manager/patch.go
+++ b/pkg/cluster/manager/patch.go
@@ -235,7 +235,7 @@ func instancesToPatch(topo spec.Topology, options operator.Options) ([]spec.Inst
 	}
 
 	if len(instances) == 0 {
-		return nil, fmt.Errorf("no instance found on specifid role(%v) and nodes(%v)", options.Roles, options.Nodes)
+		return nil, fmt.Errorf("no instance found on specified role(%v) and nodes(%v)", options.Roles, options.Nodes)
 	}
 
 	return instances, nil

--- a/pkg/cluster/manager/scale_out.go
+++ b/pkg/cluster/manager/scale_out.go
@@ -268,7 +268,7 @@ func checkForGlobalConfigs(logger *logprinter.Logger, topoFile string, skipConfi
 			logger.Warnf(`You have one or more of %s fields configured in
 	the scale out topology, but they will be ignored during the scaling out process.
 	If you want to use configs different from the existing cluster, cancel now and
-	set them in the specification fileds for each host.`, color.YellowString(`["global", "monitored", "server_configs"]`))
+	set them in the specification fields for each host.`, color.YellowString(`["global", "monitored", "server_configs"]`))
 			if !skipConfirm {
 				if err := tui.PromptForConfirmOrAbortError("Do you want to continue? [y/N]: "); err != nil {
 					return err

--- a/pkg/cluster/operation/action.go
+++ b/pkg/cluster/operation/action.go
@@ -640,7 +640,7 @@ func StopComponent(ctx context.Context,
 	return errg.Wait()
 }
 
-// toFailedActionError formats the errror msg for failed action
+// toFailedActionError formats the error msg for failed action
 func toFailedActionError(err error, action string, host, service, logDir string) error {
 	return errors.Annotatef(err,
 		"failed to %s: %s %s, please check the instance's log(%s) for more detail.",

--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -648,7 +648,7 @@ func CheckPartitions(opt *CheckOptions, host string, topo *spec.Specification, r
 	flt := flatPartitions(insightInfo.Partitions)
 	parts := sortPartitions(flt)
 
-	// check if multiple instances are using the same partition as data storeage
+	// check if multiple instances are using the same partition as data storage
 	type storePartitionInfo struct {
 		comp string
 		path string

--- a/pkg/cluster/operation/operation.go
+++ b/pkg/cluster/operation/operation.go
@@ -37,7 +37,7 @@ type Options struct {
 	OptTimeout          uint64           // timeout in seconds for operations that support it, not to confuse with SSH timeout
 	APITimeout          uint64           // timeout in seconds for API operations that support it, like transferring store leader
 	IgnoreConfigCheck   bool             // should we ignore the config check result after init config
-	NativeSSH           bool             // should use native ssh client or builtin easy ssh (deprecated, shoule use SSHType)
+	NativeSSH           bool             // should use native ssh client or builtin easy ssh (deprecated, should use SSHType)
 	SSHType             executor.SSHType // the ssh type: 'builtin', 'system', 'none'
 	Concurrency         int              // max number of parallel tasks to run
 	SSHProxyHost        string           // the ssh proxy host

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	// Timeout in second when quering node status
+	// Timeout in second when querying node status
 	statusQueryTimeout = 10 * time.Second
 
 	// the prometheus metric name of start time of the process since unix epoch in seconds.

--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -85,7 +85,7 @@ const (
 	// a label key of EngineLabelKey.
 	EngineLabelTiFlash = "tiflash"
 	// EngineLabelTiFlashCompute is for disaggregated tiflash mode,
-	// it's the lable of tiflash_compute nodes.
+	// it's the label of tiflash_compute nodes.
 	EngineLabelTiFlashCompute = "tiflash_compute"
 	// EngineRoleLabelKey is the label that indicates if the TiFlash instance is a write node.
 	EngineRoleLabelKey = "engine_role"

--- a/pkg/cluster/spec/tikv.go
+++ b/pkg/cluster/spec/tikv.go
@@ -532,7 +532,7 @@ func genLeaderCounter(topo *Specification, tlsCfg *tls.Config) func(string) (int
 func makeTransport(tlsCfg *tls.Config) *http.Transport {
 	// Start with the DefaultTransport for sane defaults.
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	// Conservatively disable HTTP keep-alives as this program will only
+	// Conservatively disable HTTP keep-alive as this program will only
 	// ever need a single HTTP request.
 	transport.DisableKeepAlives = true
 	// Timeout early if the server doesn't even return the headers.

--- a/pkg/cluster/spec/tispark.go
+++ b/pkg/cluster/spec/tispark.go
@@ -153,7 +153,7 @@ func (c *TiSparkMasterComponent) CalculateVersion(clusterVersion string) string 
 
 // SetVersion implements Component interface.
 func (c *TiSparkMasterComponent) SetVersion(version string) {
-	// should never be calles
+	// should never be calls
 }
 
 // Instances implements Component interface.
@@ -208,7 +208,7 @@ func (i *TiSparkMasterInstance) GetCustomFields() map[string]any {
 	return v.Interface().(map[string]any)
 }
 
-// GetCustomEnvs get custom spark envionment variables of the instance
+// GetCustomEnvs get custom spark environment variables of the instance
 func (i *TiSparkMasterInstance) GetCustomEnvs() map[string]string {
 	v := reflect.Indirect(reflect.ValueOf(i.InstanceSpec)).FieldByName("SparkEnvs")
 	if !v.IsValid() {

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -247,7 +247,7 @@ func CheckClusterDirOverlap(entries []DirEntry) error {
 				}
 
 				// overlap is allowed in the case one side is data dir of a monitor instance,
-				// as the *_exporter don't need data dir, the field is only kept for compatiability
+				// as the *_exporter don't need data dir, the field is only kept for compatibility
 				// with legacy tidb-ansible deployments.
 				if (strings.HasPrefix(d1.dirKind, "monitor data directory")) ||
 					(strings.HasPrefix(d2.dirKind, "monitor data directory")) {

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -692,7 +692,7 @@ pump_servers:
 	err = CheckClusterDirConflict(clsList, "topo", &topo4)
 	c.Assert(err, IsNil)
 
-	// component with reletive dir has no dir conflic
+	// component with relative dir has no dir conflic
 	err = yaml.Unmarshal([]byte(`
 monitored:
   node_exporter_port: 9102

--- a/pkg/cluster/task/ssh.go
+++ b/pkg/cluster/task/ssh.go
@@ -44,7 +44,7 @@ type RootSSH struct {
 	proxyKeyFile    string           // path to the private key file
 	proxyPassphrase string           // passphrase of the private key file
 	proxyTimeout    uint64           // timeout in seconds when connecting via SSH
-	sshType         executor.SSHType // the type of SSH chanel
+	sshType         executor.SSHType // the type of SSH channel
 	sudo            bool
 }
 

--- a/pkg/cluster/template/install/local_install.sh.go
+++ b/pkg/cluster/template/install/local_install.sh.go
@@ -91,7 +91,7 @@ sgr0=$(tput sgr0 2>/dev/null)
 
 echo
 
-# Refrence: https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix
+# Reference: https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix
 shell=$(echo $SHELL | awk 'BEGIN {FS="/";} { print $NF }')
 echo "Detected shell: ${bold}$shell${sgr0}"
 if [ -f "${HOME}/.${shell}_profile" ]; then

--- a/pkg/cluster/template/systemd/system.go
+++ b/pkg/cluster/template/systemd/system.go
@@ -35,7 +35,7 @@ type Config struct {
 	DisableSendSigkill  bool
 	GrantCapNetRaw      bool
 	// Takes one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always.
-	// The Template set as always if this is not setted.
+	// The Template set as always if this is not set.
 	Restart     string
 	SystemdMode string
 }

--- a/pkg/cluster/template/systemd/tispark.go
+++ b/pkg/cluster/template/systemd/tispark.go
@@ -30,7 +30,7 @@ type TiSparkConfig struct {
 	DeployDir   string
 	JavaHome    string
 	// Takes one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always.
-	// The Template set as always if this is not setted.
+	// The Template set as always if this is not set.
 	Restart string
 }
 

--- a/pkg/logger/printer/logger.go
+++ b/pkg/logger/printer/logger.go
@@ -27,7 +27,7 @@ type ContextKey string
 // ContextKeyLogger is the key used for logger stored in context
 const ContextKeyLogger ContextKey = "logger"
 
-// Logger is a set of fuctions writing output to custom writters, but still
+// Logger is a set of functions writing output to custom writters, but still
 // using the global zap logger as our default config does not writes everything
 // to a memory buffer.
 // TODO: use also separate zap loggers

--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -447,7 +447,7 @@ func combineVersions(componentVersions *[]string,
 					if selectedVersion == utils.LatestVersionAlias {
 						latest := manifest.LatestVersion(platform)
 						if latest != "" {
-							fmt.Printf("%s %s/%s found the lastest version %s\n", manifest.ID, os, arch, latest)
+							fmt.Printf("%s %s/%s found the latest version %s\n", manifest.ID, os, arch, latest)
 							// set latest version
 							selectedVersion = latest
 						}
@@ -471,7 +471,7 @@ func combineVersions(componentVersions *[]string,
 							continue
 						}
 
-						fmt.Printf("%s %s/%s found the lastest version %s\n", manifest.ID, os, arch, latest)
+						fmt.Printf("%s %s/%s found the latest version %s\n", manifest.ID, os, arch, latest)
 						// set latest version
 						selectedVersion = latest
 					}

--- a/pkg/repository/merge_mirror.go
+++ b/pkg/repository/merge_mirror.go
@@ -239,7 +239,7 @@ func mapOwnerKeys(base Mirror, keys map[string]*v1manifest.KeyInfo) (map[string]
 			}
 		}
 		if len(keyList[ownerID]) < owner.Threshold {
-			// We set keys of this owner to empty becase we can't clone components belong to this owner
+			// We set keys of this owner to empty because we can't clone components belong to this owner
 			keyList[ownerID] = nil
 		}
 	}

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -420,7 +420,7 @@ func (l *httpMirror) Publish(manifest *v1manifest.Manifest, info model.Component
 		defer resp.Body.Close()
 
 		if resp.StatusCode >= 300 {
-			return errors.Errorf("error on uplaod tarbal, server returns %d", resp.StatusCode)
+			return errors.Errorf("error on uplaod tarball, server returns %d", resp.StatusCode)
 		}
 	}
 

--- a/pkg/repository/model/model.go
+++ b/pkg/repository/model/model.go
@@ -134,7 +134,7 @@ func (m *model) Rotate(manifest *v1manifest.Manifest) error {
 			return err
 		}
 
-		// write new 'root.json' file with verion prefix
+		// write new 'root.json' file with version prefix
 		manifestFilename := fmt.Sprintf("%d.root.json", root.Version)
 		if err := m.txn.WriteManifest(manifestFilename, manifest); err != nil {
 			return err
@@ -198,7 +198,7 @@ func (m *model) Publish(manifest *v1manifest.Manifest, info ComponentInfo) error
 		var owner *v1manifest.Owner
 		if err := m.updateIndexManifest(initTime, func(im *v1manifest.Manifest) (*v1manifest.Manifest, error) {
 			// We only update index.json when it's a new component
-			// or the yanked, standalone, hidden fileds changed,
+			// or the yanked, standalone, hidden fields changed,
 			// or the owner of component changed
 			var (
 				compItem  v1manifest.ComponentItem

--- a/pkg/repository/model/publish.go
+++ b/pkg/repository/model/publish.go
@@ -15,11 +15,11 @@ package model
 
 import "io"
 
-// ComponentData is used to represent the tarbal
+// ComponentData is used to represent the tarball
 type ComponentData interface {
 	io.Reader
 
-	// Filename is the name of tarbal
+	// Filename is the name of tarball
 	Filename() string
 }
 

--- a/pkg/repository/store/store.go
+++ b/pkg/repository/store/store.go
@@ -38,7 +38,7 @@ type FsTxn interface {
 	Rollback() error
 }
 
-// New returns a Store, curretly only qcloud supported
+// New returns a Store, currently only qcloud supported
 func New(root string, upstream string) Store {
 	return newLocalStore(root, upstream)
 }

--- a/pkg/repository/store/txn.go
+++ b/pkg/repository/store/txn.go
@@ -34,7 +34,7 @@ var (
 	ErrorFsCommitConflict = errors.New("conflict on fs commit")
 )
 
-// The localTxn is used to implment a filesystem transaction, the basic principle is to
+// The localTxn is used to implement a filesystem transaction, the basic principle is to
 // record the timestamp before access any manifest file, and when writing them back, check
 // if the origin files' timestamp is newer than recorded one, if so, a conflict is detected.
 //
@@ -56,7 +56,7 @@ var (
 // To commit a localTxn:
 //  1. for every accessed file, get the recorded timestamp
 //  2. for every accessed file, get the current modify time of their origin file in root directory
-//  3. check if the origin file is newer thant recorded timestamp, if so, there must be conflict
+//  3. check if the origin file is newer than recorded timestamp, if so, there must be conflict
 //  4. copy every file in temporary directory to root directory, if there is a timestamp.json in
 //     temporary directory, it should be the last one to copy
 type localTxn struct {

--- a/pkg/repository/v1manifest/types.go
+++ b/pkg/repository/v1manifest/types.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-// Manifest representation for ser/de.
+// Manifest representation for set/de.
 type Manifest struct {
 	// Signatures value
 	Signatures []Signature `json:"signatures"`
@@ -31,7 +31,7 @@ type Manifest struct {
 	Signed ValidManifest `json:"signed"`
 }
 
-// RawManifest representation for ser/de.
+// RawManifest representation for set/de.
 type RawManifest struct {
 	// Signatures value
 	Signatures []Signature `json:"signatures"`
@@ -297,7 +297,7 @@ func (manifest *Component) VersionListWithYanked(platform string) map[string]Ver
 // ErrLoadManifest is an empty object of LoadManifestError, useful for type check
 var ErrLoadManifest = &LoadManifestError{}
 
-// LoadManifestError is the error type used when loading manifest failes
+// LoadManifestError is the error type used when loading manifest fails
 type LoadManifestError struct {
 	manifest string // manifest name
 	err      error  // wrapped error

--- a/pkg/telemetry/report.pb.go
+++ b/pkg/telemetry/report.pb.go
@@ -242,7 +242,7 @@ type ClusterReport struct {
 	Command          string `protobuf:"bytes,2,opt,name=command,proto3" json:"command,omitempty"`
 	TakeMilliseconds uint64 `protobuf:"varint,3,opt,name=take_milliseconds,json=takeMilliseconds,proto3" json:"take_milliseconds,omitempty"`
 	ExitCode         int32  `protobuf:"varint,4,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
-	// only deploy and scale-out is setted:
+	// only deploy and scale-out is set:
 	Topology             string      `protobuf:"bytes,5,opt,name=topology,proto3" json:"topology,omitempty"`
 	Nodes                []*NodeInfo `protobuf:"bytes,6,rep,name=nodes,proto3" json:"nodes,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`

--- a/pkg/telemetry/report.proto
+++ b/pkg/telemetry/report.proto
@@ -30,7 +30,7 @@ message ClusterReport {
 	uint64 take_milliseconds = 3;
 	int32 exit_code = 4;
 
-	// only deploy and scale-out is setted:
+	// only deploy and scale-out is set:
 	string topology = 5;// topology.yaml of the cluster, with all the value scrubbed.
 	repeated NodeInfo nodes = 6;
 }

--- a/pkg/tui/progress/display_props.go
+++ b/pkg/tui/progress/display_props.go
@@ -58,7 +58,7 @@ func (m *Mode) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	switch strings.ToLower(s) {
-	case "spinner", "running": // keep "spinner" for compatiability
+	case "spinner", "running": // keep "spinner" for compatibility
 		*m = ModeSpinner
 	case "progress":
 		*m = ModeProgress

--- a/pkg/tui/progress/single_bar.go
+++ b/pkg/tui/progress/single_bar.go
@@ -41,7 +41,7 @@ func (b *singleBarCore) renderDoneOrError(w io.Writer, dp *DisplayProps) {
 		tail = errorTail
 		tailColor = colorError
 	default:
-		panic("Unexpect dp.Mode")
+		panic("Unexpected dp.Mode")
 	}
 	var displayPrefix string
 	midWidth := 1 + 3 + 1 + len(tail)

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -112,7 +112,7 @@ func (s *sessionManager) Read(id string) (string, io.ReadCloser, error) {
 	return name, file, nil
 }
 
-// Delele delete a session
+// Delete a session
 func (s *sessionManager) Delete(id string) {
 	logprinter.Debugf("Delete session: %s", id)
 	n, ok := s.m.Load(id)

--- a/tests/tiup-dm/test_import.sh
+++ b/tests/tiup-dm/test_import.sh
@@ -84,7 +84,7 @@ EOF
     cp /root/.tiup/bin/root.json /home/tidb/.tiup/bin/
     chown -R tidb:tidb /home/tidb/.tiup
 
-    # import ans start new cluster
+    # import and start new cluster
 su tidb <<EOF
     tiup-dm --yes import --dir /home/tidb/dm-ansible --cluster-version v2.0.0-rc
     tiup-dm --yes start test-cluster


### PR DESCRIPTION
Replace misspelled words:

    adminstrator
    ans
    automaticlly
    becase
    build-in
    calles
    chanel
    comonent
    compatiability
    componet
    curretly
    devided
    dirctory
    dispaly
    droping
    envionment
    errror
    failes
    fileds
    fisrt
    fuctions
    genreated
    gernerate
    gloabl
    implemention
    implment
    ingore
    interupted
    keep-alives
    lable
    lastest
    occured
    unexpect
    quering
    quiting
    refrence
    reletive
    runing
    setted
    shoule
    specifid
    specifing
    speficied
    storeage
    suprise
    tarbal
    thant
    verion
    vesions

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
