### PR TITLE
cluster: add option for tmpdir

### DIFF
--- a/components/cluster/command/check.go
+++ b/components/cluster/command/check.go
@@ -71,6 +71,7 @@ it will check the new instances `,
 	cmd.Flags().BoolVar(&opt.ApplyFix, "apply", false, "Try to fix failed checks")
 	cmd.Flags().BoolVar(&opt.ExistCluster, "cluster", false, "Check existing cluster, the input is a cluster name.")
 	cmd.Flags().Uint64Var(&gOpt.APITimeout, "api-timeout", 10, "Timeout in seconds when querying PD APIs.")
+	cmd.Flags().StringVarP(&opt.TempDir, "tempdir", "t", "/tmp/tiup", "The temporary directory.")
 
 	return cmd
 }

--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -42,8 +42,9 @@ type CheckOptions struct {
 	IdentityFile string // path to the private key file
 	UsePassword  bool   // use password instead of identity file for ssh connection
 	Opr          *operator.CheckOptions
-	ApplyFix     bool // try to apply fixes of failed checks
-	ExistCluster bool // check an exist cluster
+	ApplyFix     bool   // try to apply fixes of failed checks
+	ExistCluster bool   // check an exist cluster
+	TempDir      string // tempdir
 }
 
 // CheckCluster check cluster before deploying or upgrading
@@ -188,6 +189,7 @@ func checkSystemInfo(
 		applyFixTasks      []*task.StepDisplay
 		downloadTasks      []*task.StepDisplay
 	)
+	task.CheckToolsPathDir = opt.TempDir
 	logger := ctx.Value(logprinter.ContextKeyLogger).(*logprinter.Logger)
 	insightVer := ""
 

--- a/pkg/cluster/task/check.go
+++ b/pkg/cluster/task/check.go
@@ -41,7 +41,7 @@ var (
 )
 
 // place the check utilities are stored
-const (
+var (
 	CheckToolsPathDir = "/tmp/tiup"
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If `/tmp` is mounted with `noexec` then copying a binary and running it won't work. This adds an option to specify an alternative directory.


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)

Related changes
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
An option to specify the temporary directory has been added to `tiup cluster check`.
```
