### PR TITLE
cluster: remove created directories after fio test in `tiup cluster check`

### DIFF
--- a/pkg/cluster/task/check.go
+++ b/pkg/cluster/task/check.go
@@ -314,7 +314,7 @@ func (c *CheckSys) runFIO(ctx context.Context) (outRR []byte, outRW []byte, outL
 	// cleanup
 	dirToRm := testWd
 	if !checkDirExists {
-		dirToRm = filepath.Join(checkDir, testWd)
+		dirToRm = checkDir
 	}
 	_, stderr, err = e.Execute(
 		ctx,

--- a/pkg/cluster/task/check.go
+++ b/pkg/cluster/task/check.go
@@ -16,6 +16,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -185,6 +186,10 @@ func (c *CheckSys) runFIO(ctx context.Context) (outRR []byte, outRW []byte, outL
 	}
 
 	checkDir := spec.Abs(c.topo.GlobalOptions.User, c.checkDir)
+	checkDirExists := true
+	if _, err := os.Stat(checkDir); err != nil && os.IsNotExist(err) {
+		checkDirExists = false
+	}
 	testWd := filepath.Join(checkDir, "tiup-fio-test")
 	fioBin := filepath.Join(CheckToolsPathDir, "bin", "fio")
 
@@ -307,9 +312,13 @@ func (c *CheckSys) runFIO(ctx context.Context) (outRR []byte, outRW []byte, outL
 	}
 
 	// cleanup
+	dirToRm := testWd
+	if !checkDirExists {
+		dirToRm = filepath.Join(checkDir, testWd)
+	}
 	_, stderr, err = e.Execute(
 		ctx,
-		fmt.Sprintf("rm -rf %s", testWd),
+		fmt.Sprintf("rm -rf %s", dirToRm),
 		false,
 	)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close https://github.com/pingcap/tiup/issues/2159, https://github.com/pingcap/tiup/issues/2497
In `tiup cluster check topology.yaml --enable-disk=true`, the parent directories of `tiup-fio-test` are created with root but are not removed after the test. The subsequent operations will fail because the directories exist but the user doesn't have permission.

### What is changed and how it works?
Before creating `tiup-fio-test`, check which parent directory doesn't exist and should be removed.
After testing, remove the parent directory.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - No code

1. Remove `/home/xxx/data` and execute `tiup cluster check --enable-disk=true`. After the test, check that `/home/xxx/data` is removed.
2. Create ``/home/xxx/data` and execute `tiup cluster check --enable-disk=true`. After the test, check that `/home/xxx/data` still exists but it is empty.

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
- Fix that the newly created directory is not removed after `tiup cluster check --enable-disk=true`.
```
