### PR TITLE
Feature/add args config alertmanager

### DIFF
--- a/embed/templates/scripts/run_alertmanager.sh.tpl
+++ b/embed/templates/scripts/run_alertmanager.sh.tpl
@@ -26,4 +26,9 @@ exec bin/alertmanager/alertmanager \
     --cluster.peer="{{$am}}" \
 {{- end}}
 {{- end}}
+{{- if .AdditionalArgs}}
+{{- range .AdditionalArgs}}
+    {{.}} \
+{{- end}}
+{{- end}}
     --cluster.listen-address="{{.ClusterListenAddr}}"

--- a/pkg/cluster/manager/display.go
+++ b/pkg/cluster/manager/display.go
@@ -325,7 +325,7 @@ func (m *Manager) Display(dopt DisplayOption, opt operator.Options) error {
 func getGrafanaURL(clusterInstInfos []InstInfo) (result []string) {
 	var grafanaURLs []string
 	for _, instance := range clusterInstInfos {
-		if instance.Role == "grafana" {
+		if instance.Role == "grafana" || instance.Role == "grafana (patched)" {
 			grafanaURLs = append(grafanaURLs, "http://"+utils.JoinHostPort(instance.Host, instance.Port))
 		}
 	}

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -46,6 +46,7 @@ type AlertmanagerSpec struct {
 	Arch            string               `yaml:"arch,omitempty"`
 	OS              string               `yaml:"os,omitempty"`
 	ConfigFilePath  string               `yaml:"config_file,omitempty" validate:"config_file:editable"`
+	AdditionalArgs  []string             `yaml:"additional_args,omitempty" validate:"additional_args:ignore"`
 }
 
 // Role returns the component role of the instance
@@ -199,6 +200,8 @@ func (i *AlertManagerInstance) InitConfig(
 		DataDir:   paths.Data[0],
 
 		NumaNode: spec.NumaNode,
+		// This field allows users to define additional arguments for customization.
+		AdditionalArgs: spec.AdditionalArgs,
 	}
 
 	// doesn't work

--- a/pkg/cluster/spec/alertmanager.go
+++ b/pkg/cluster/spec/alertmanager.go
@@ -43,10 +43,11 @@ type AlertmanagerSpec struct {
 	LogDir          string               `yaml:"log_dir,omitempty"`
 	NumaNode        string               `yaml:"numa_node,omitempty" validate:"numa_node:editable"`
 	ResourceControl meta.ResourceControl `yaml:"resource_control,omitempty" validate:"resource_control:editable"`
-	Arch            string               `yaml:"arch,omitempty"`
-	OS              string               `yaml:"os,omitempty"`
-	ConfigFilePath  string               `yaml:"config_file,omitempty" validate:"config_file:editable"`
-	AdditionalArgs  []string             `yaml:"additional_args,omitempty" validate:"additional_args:ignore"`
+	// This field allows users to define additional arguments for customization.
+	AdditionalArgs []string `yaml:"additional_args,omitempty" validate:"additional_args:ignore"`
+	Arch           string   `yaml:"arch,omitempty"`
+	OS             string   `yaml:"os,omitempty"`
+	ConfigFilePath string   `yaml:"config_file,omitempty" validate:"config_file:editable"`
 }
 
 // Role returns the component role of the instance

--- a/pkg/cluster/template/scripts/alertmanager.go
+++ b/pkg/cluster/template/scripts/alertmanager.go
@@ -33,7 +33,8 @@ type AlertManagerScript struct {
 	LogDir    string
 	DataDir   string
 
-	NumaNode string
+	NumaNode       string
+	AdditionalArgs []string
 }
 
 // ConfigToFile write config content to specific path


### PR DESCRIPTION

---

<!--  
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.  
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR solves the problem of limited customization when configuring Alertmanager. Previously, users could not pass additional arguments to the Alertmanager process, which restricted flexibility in certain deployment scenarios.

### What is changed and how it works?

**What's Changed:**

- Added a new field `AdditionalArgs` to the `AlertmanagerSpec` struct, allowing users to define additional arguments for Alertmanager in the YAML configuration.
- Modified the Alertmanager startup script template (`run_alertmanager.sh.tpl`) to append the user-defined arguments to the startup command.
- Updated related struct definitions (`AlertManagerScript`, etc.) to support passing `AdditionalArgs` through the deployment pipeline.

**How it Works:**

- Users can specify custom arguments in the `additional_args` field of the YAML configuration file. These arguments are then included in the Alertmanager startup command when TiUP deploys the component.

Example usage in the YAML configuration:
```yaml
alertmanager_servers:
- host: "127.0.0.1"
  additional_args:
  - --cluster.pushpull-interval=15s
  - --cluster.probe-timeout=3s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
![image](https://github.com/user-attachments/assets/c8784738-c9a7-4f7c-a9ee-7fd931729390)
![image](https://github.com/user-attachments/assets/f68dc22f-8254-4f94-96a8-baf936f13f0c)
![image](https://github.com/user-attachments/assets/193dded1-b099-4bc0-b87c-b6a28ccb43be)

- [ ] No code

**Manual Test Steps:**

1. Define a cluster YAML configuration with `additional_args` under `alertmanager_servers`.
2. Deploy the cluster using TiUP.
3. Verify the Alertmanager process includes the specified arguments (`ps -ef | grep alertmanager`).

Code changes

- [x] Has exported function/method change
- [x] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [x] Need to update the documentation

### Release notes:
<!--  
If no, just leave the release note block below as is.  
If yes, a release note is required:  
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".  
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.  
-->
```release-note
Support user-defined arguments for Alertmanager via the `additional_args` field in the YAML configuration.
```