### PR TITLE
drop some useless metrics in the prometheus config file

### DIFF
--- a/embed/templates/config/prometheus.yml.tpl
+++ b/embed/templates/config/prometheus.yml.tpl
@@ -97,6 +97,11 @@ scrape_configs:
 {{- end}}
   - job_name: "tidb"
     honor_labels: true # don't overwrite job & instance labels
+    metric_relabel_configs:
+      - action: drop
+        regex: tidb_tikvclient_source_request_seconds_count|tidb_tikvclient_batch_requests_sum|tidb_tikvclient_batch_requests_count|tidb_tikvclient_batch_pending_requests_sum|tidb_tikvclient_batch_pending_requests_count
+        source_labels:
+        - __name__
 {{- if .TLSEnabled}}
     scheme: https
     tls_config:


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
ref https://github.com/pingcap/tidb/issues/59815

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
1. tiup cluster deploy and check the config file of prometheus
```
...
scrape_configs:
  - job_name: "overwritten-nodes"
    honor_labels: true # don't overwrite job & instance labels
    static_configs:
    - targets:
      - '127.0.0.1:9120'
  - job_name: "tidb"
    honor_labels: true # don't overwrite job & instance labels
    metric_relabel_configs:
      - action: drop
        regex: tidb_tikvclient_source_request_seconds_count|tidb_tikvclient_batch_requests_sum|tidb_tikvclient_batch_requests_count|tidb_tikvclient_batch_pending_requests_sum|tidb_tikvclient_batch_pending_requests_count
        source_labels:
        - __name__
    static_configs:
    - targets:
      - '127.0.0.1:10030'
...
```
2. The cluster is deployed successfully. Use tiup diag to collect the metrics, and the metrics are dropped successfully.
``` shell
╰─$ ./tiup diag collect tidb-test-prom -f="2025-03-26T13:00:00+08:00" -t="2025-03-26T13:10:00+08:00" --exclude="log,config,system" --metricsfilter="tidb"                          

╰─$ if find ./ -type f | grep -q -E '/(tidb_tikvclient_source_request_seconds_count|tidb_tikvclient_batch_requests_sum|tidb_tikvclient_batch_requests_count|tidb_tikvclient_batch_pending_requests_sum|tidb_tikvclient_batch_pending_requests_count)'; then
  echo "Matched file found."
else
  echo "No matching files."
fi

No matching files.
```


 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Updated the default Prometheus configuration to drop the following TiDB metrics via metric_relabel_configs:
- tidb_tikvclient_source_request_seconds_count
- tidb_tikvclient_batch_requests_sum
- tidb_tikvclient_batch_requests_count
- tidb_tikvclient_batch_pending_requests_sum
- tidb_tikvclient_batch_pending_requests_count

To re-enable these metrics, remove the corresponding metric_relabel_configs entries from the Prometheus configuration and restart the service.
```
