### PR TITLE
*: Support changing the data source when multiple data sources exist

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   install:
     name: Install
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
     steps:

--- a/.github/workflows/integrate-cluster-cmd.yaml
+++ b/.github/workflows/integrate-cluster-cmd.yaml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   cluster:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/integrate-cluster-scale.yaml
+++ b/.github/workflows/integrate-cluster-scale.yaml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   cluster:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/integrate-dm.yaml
+++ b/.github/workflows/integrate-dm.yaml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   dm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/integrate-playground.yaml
+++ b/.github/workflows/integrate-playground.yaml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   playground:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
       fail-fast: true

--- a/.github/workflows/integrate-tiup.yaml
+++ b/.github/workflows/integrate-tiup.yaml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   tiup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
       fail-fast: true

--- a/.github/workflows/release-tiup.yaml
+++ b/.github/workflows/release-tiup.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     outputs:
       REL_VER: ${{ steps.build_tiup.outputs.REL_VER }}

--- a/.github/workflows/reprotest.yaml
+++ b/.github/workflows/reprotest.yaml
@@ -30,7 +30,7 @@ on:
 jobs:
   reprotest:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/pkg/cluster/manager/reload.go
+++ b/pkg/cluster/manager/reload.go
@@ -118,6 +118,13 @@ func (m *Manager) Reload(name string, gOpt operator.Options, skipRestart, skipCo
 		b.ParallelStep("+ Refresh monitor configs", gOpt.Force, monitorConfigTasks...)
 	}
 
+	// Save the updated topology back to file after configs are refreshed
+	// This ensures any modifications made during InitConfig (like handleRemoteWrite) are persisted
+	b.Func("Save updated topology", func(ctx context.Context) error {
+		// Save metadata back to file
+		return m.specManager.SaveMeta(name, metadata)
+	})
+
 	if !skipRestart {
 		tlsCfg, err := topo.TLSConfig(m.specManager.Path(name, spec.TLSCertKeyDir))
 		if err != nil {

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -39,28 +39,28 @@ import (
 
 // GrafanaSpec represents the Grafana topology specification in topology.yaml
 type GrafanaSpec struct {
-	Host                  string               `yaml:"host"`
-	ManageHost            string               `yaml:"manage_host,omitempty" validate:"manage_host:editable"`
-	SSHPort               int                  `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
-	Imported              bool                 `yaml:"imported,omitempty"`
-	Patched               bool                 `yaml:"patched,omitempty"`
-	IgnoreExporter        bool                 `yaml:"ignore_exporter,omitempty"`
-	Port                  int                  `yaml:"port" default:"3000"`
-	DeployDir             string               `yaml:"deploy_dir,omitempty"`
-	Config                map[string]string    `yaml:"config,omitempty" validate:"config:ignore"`
-	ResourceControl       meta.ResourceControl `yaml:"resource_control,omitempty" validate:"resource_control:editable"`
-	Arch                  string               `yaml:"arch,omitempty"`
-	OS                    string               `yaml:"os,omitempty"`
-	DashboardDir          string               `yaml:"dashboard_dir,omitempty" validate:"dashboard_dir:editable"`
-	Username              string               `yaml:"username,omitempty" default:"admin" validate:"username:editable"`
-	Password              string               `yaml:"password,omitempty" default:"admin" validate:"password:editable"`
-	AnonymousEnable       bool                 `yaml:"anonymous_enable" default:"false" validate:"anonymous_enable:editable"`
-	RootURL               string               `yaml:"root_url" validate:"root_url:editable"`
-	Domain                string               `yaml:"domain" validate:"domain:editable"`
-	DefaultTheme          string               `yaml:"default_theme,omitempty" validate:"default_theme:editable"`
-	OrgName               string               `yaml:"org_name,omitempty" validate:"org_name:editable"`
-	OrgRole               string               `yaml:"org_role,omitempty" validate:"org_role:editable"`
-	IsVMDefaultDatasource bool                 `yaml:"is_vm_default_datasource,omitempty" validate:"is_vm_default_datasource:editable"`
+	Host                     string               `yaml:"host"`
+	ManageHost               string               `yaml:"manage_host,omitempty" validate:"manage_host:editable"`
+	SSHPort                  int                  `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
+	Imported                 bool                 `yaml:"imported,omitempty"`
+	Patched                  bool                 `yaml:"patched,omitempty"`
+	IgnoreExporter           bool                 `yaml:"ignore_exporter,omitempty"`
+	Port                     int                  `yaml:"port" default:"3000"`
+	DeployDir                string               `yaml:"deploy_dir,omitempty"`
+	Config                   map[string]string    `yaml:"config,omitempty" validate:"config:ignore"`
+	ResourceControl          meta.ResourceControl `yaml:"resource_control,omitempty" validate:"resource_control:editable"`
+	Arch                     string               `yaml:"arch,omitempty"`
+	OS                       string               `yaml:"os,omitempty"`
+	DashboardDir             string               `yaml:"dashboard_dir,omitempty" validate:"dashboard_dir:editable"`
+	Username                 string               `yaml:"username,omitempty" default:"admin" validate:"username:editable"`
+	Password                 string               `yaml:"password,omitempty" default:"admin" validate:"password:editable"`
+	AnonymousEnable          bool                 `yaml:"anonymous_enable" default:"false" validate:"anonymous_enable:editable"`
+	RootURL                  string               `yaml:"root_url" validate:"root_url:editable"`
+	Domain                   string               `yaml:"domain" validate:"domain:editable"`
+	DefaultTheme             string               `yaml:"default_theme,omitempty" validate:"default_theme:editable"`
+	OrgName                  string               `yaml:"org_name,omitempty" validate:"org_name:editable"`
+	OrgRole                  string               `yaml:"org_role,omitempty" validate:"org_role:editable"`
+	UseVMAsDefaultDatasource bool                 `yaml:"use_vm_as_default_datasource,omitempty" validate:"use_vm_as_default_datasource:editable"`
 }
 
 // Role returns the component role of the instance
@@ -288,7 +288,7 @@ func (i *GrafanaInstance) InitConfig(
 	datasources := make([]*config.DatasourceConfig, 0)
 
 	// Determine which datasource is default based on Grafana spec
-	vmIsDefault := spec.IsVMDefaultDatasource && monitors[0].EnableVMRemoteWrite
+	vmIsDefault := spec.UseVMAsDefaultDatasource && monitors[0].EnableVMRemoteWrite
 	promIsDefault := !vmIsDefault
 
 	// Add Prometheus datasource
@@ -377,7 +377,7 @@ func (i *GrafanaInstance) initDashboards(ctx context.Context, e ctxt.Executor, s
 	// Determine which datasource to use in dashboards
 	datasourceName := clusterName
 	monitors := val.Interface().([]*PrometheusSpec)
-	if len(monitors) > 0 && monitors[0].EnableVMRemoteWrite && monitors[0].NgPort > 0 && (spec.IsVMDefaultDatasource) {
+	if len(monitors) > 0 && monitors[0].EnableVMRemoteWrite && monitors[0].NgPort > 0 && (spec.UseVMAsDefaultDatasource) {
 		datasourceName = fmt.Sprintf("%s-vm", clusterName)
 	}
 

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -288,7 +288,7 @@ func (i *GrafanaInstance) InitConfig(
 	datasources := make([]*config.DatasourceConfig, 0)
 
 	// Determine which datasource is default based on Grafana spec
-	vmIsDefault := spec.IsVMDefaultDatasource
+	vmIsDefault := spec.IsVMDefaultDatasource && monitors[0].EnableVMRemoteWrite
 	promIsDefault := !vmIsDefault
 
 	// Add Prometheus datasource

--- a/pkg/cluster/spec/grafana.go
+++ b/pkg/cluster/spec/grafana.go
@@ -39,27 +39,28 @@ import (
 
 // GrafanaSpec represents the Grafana topology specification in topology.yaml
 type GrafanaSpec struct {
-	Host            string               `yaml:"host"`
-	ManageHost      string               `yaml:"manage_host,omitempty" validate:"manage_host:editable"`
-	SSHPort         int                  `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
-	Imported        bool                 `yaml:"imported,omitempty"`
-	Patched         bool                 `yaml:"patched,omitempty"`
-	IgnoreExporter  bool                 `yaml:"ignore_exporter,omitempty"`
-	Port            int                  `yaml:"port" default:"3000"`
-	DeployDir       string               `yaml:"deploy_dir,omitempty"`
-	Config          map[string]string    `yaml:"config,omitempty" validate:"config:ignore"`
-	ResourceControl meta.ResourceControl `yaml:"resource_control,omitempty" validate:"resource_control:editable"`
-	Arch            string               `yaml:"arch,omitempty"`
-	OS              string               `yaml:"os,omitempty"`
-	DashboardDir    string               `yaml:"dashboard_dir,omitempty" validate:"dashboard_dir:editable"`
-	Username        string               `yaml:"username,omitempty" default:"admin" validate:"username:editable"`
-	Password        string               `yaml:"password,omitempty" default:"admin" validate:"password:editable"`
-	AnonymousEnable bool                 `yaml:"anonymous_enable" default:"false" validate:"anonymous_enable:editable"`
-	RootURL         string               `yaml:"root_url" validate:"root_url:editable"`
-	Domain          string               `yaml:"domain" validate:"domain:editable"`
-	DefaultTheme    string               `yaml:"default_theme,omitempty" validate:"default_theme:editable"`
-	OrgName         string               `yaml:"org_name,omitempty" validate:"org_name:editable"`
-	OrgRole         string               `yaml:"org_role,omitempty" validate:"org_role:editable"`
+	Host                  string               `yaml:"host"`
+	ManageHost            string               `yaml:"manage_host,omitempty" validate:"manage_host:editable"`
+	SSHPort               int                  `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
+	Imported              bool                 `yaml:"imported,omitempty"`
+	Patched               bool                 `yaml:"patched,omitempty"`
+	IgnoreExporter        bool                 `yaml:"ignore_exporter,omitempty"`
+	Port                  int                  `yaml:"port" default:"3000"`
+	DeployDir             string               `yaml:"deploy_dir,omitempty"`
+	Config                map[string]string    `yaml:"config,omitempty" validate:"config:ignore"`
+	ResourceControl       meta.ResourceControl `yaml:"resource_control,omitempty" validate:"resource_control:editable"`
+	Arch                  string               `yaml:"arch,omitempty"`
+	OS                    string               `yaml:"os,omitempty"`
+	DashboardDir          string               `yaml:"dashboard_dir,omitempty" validate:"dashboard_dir:editable"`
+	Username              string               `yaml:"username,omitempty" default:"admin" validate:"username:editable"`
+	Password              string               `yaml:"password,omitempty" default:"admin" validate:"password:editable"`
+	AnonymousEnable       bool                 `yaml:"anonymous_enable" default:"false" validate:"anonymous_enable:editable"`
+	RootURL               string               `yaml:"root_url" validate:"root_url:editable"`
+	Domain                string               `yaml:"domain" validate:"domain:editable"`
+	DefaultTheme          string               `yaml:"default_theme,omitempty" validate:"default_theme:editable"`
+	OrgName               string               `yaml:"org_name,omitempty" validate:"org_name:editable"`
+	OrgRole               string               `yaml:"org_role,omitempty" validate:"org_role:editable"`
+	IsVMDefaultDatasource bool                 `yaml:"is_vm_default_datasource,omitempty" validate:"is_vm_default_datasource:editable"`
 }
 
 // Role returns the component role of the instance
@@ -265,6 +266,10 @@ func (i *GrafanaInstance) InitConfig(
 		return err
 	}
 
+	// Get the grafana spec
+	spec = i.InstanceSpec.(*GrafanaSpec)
+
+	// Get monitors
 	topo := reflect.ValueOf(i.topo)
 	if topo.Kind() == reflect.Ptr {
 		topo = topo.Elem()
@@ -282,8 +287,8 @@ func (i *GrafanaInstance) InitConfig(
 	// Create datasources configuration
 	datasources := make([]*config.DatasourceConfig, 0)
 
-	// Create both Prometheus and VM datasources, setting defaults based on configuration
-	vmIsDefault := monitors[0].VMConfig.Enable && monitors[0].VMConfig.IsDefaultDatasource
+	// Determine which datasource is default based on Grafana spec
+	vmIsDefault := spec.IsVMDefaultDatasource
 	promIsDefault := !vmIsDefault
 
 	// Add Prometheus datasource
@@ -295,7 +300,7 @@ func (i *GrafanaInstance) InitConfig(
 	datasources = append(datasources, promDatasource)
 
 	// Add VM datasource if enabled
-	if monitors[0].VMConfig.Enable {
+	if monitors[0].EnableVMRemoteWrite && monitors[0].NgPort > 0 {
 		vmDatasource := config.NewDatasourceConfig(
 			fmt.Sprintf("%s-vm", clusterName),
 			// not support tls
@@ -372,7 +377,7 @@ func (i *GrafanaInstance) initDashboards(ctx context.Context, e ctxt.Executor, s
 	// Determine which datasource to use in dashboards
 	datasourceName := clusterName
 	monitors := val.Interface().([]*PrometheusSpec)
-	if len(monitors) > 0 && monitors[0].VMConfig.Enable && monitors[0].VMConfig.IsDefaultDatasource {
+	if len(monitors) > 0 && monitors[0].EnableVMRemoteWrite && monitors[0].NgPort > 0 && (spec.IsVMDefaultDatasource) {
 		datasourceName = fmt.Sprintf("%s-vm", clusterName)
 	}
 

--- a/pkg/cluster/spec/grafana_test.go
+++ b/pkg/cluster/spec/grafana_test.go
@@ -389,9 +389,9 @@ func TestVictoriaMetricsDefaultDatasource(t *testing.T) {
 	}
 	topo.Grafanas = []*GrafanaSpec{
 		{
-			Host:                  "127.0.0.1",
-			Port:                  3000,
-			IsVMDefaultDatasource: true,
+			Host:                     "127.0.0.1",
+			Port:                     3000,
+			UseVMAsDefaultDatasource: true,
 		},
 	}
 

--- a/pkg/cluster/spec/grafana_test.go
+++ b/pkg/cluster/spec/grafana_test.go
@@ -20,6 +20,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/pingcap/tiup/pkg/meta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestLocalDashboards(t *testing.T) {
@@ -160,9 +162,14 @@ level = warning
 	assert.Equal(t, expected, string(result))
 }
 
-type mockExecutor struct{}
+type mockExecutor struct {
+	executeFunc func(ctx context.Context, cmd string, sudo bool, timeouts ...time.Duration) ([]byte, []byte, error)
+}
 
 func (e *mockExecutor) Execute(ctx context.Context, cmd string, sudo bool, timeouts ...time.Duration) (stdout []byte, stderr []byte, err error) {
+	if e.executeFunc != nil {
+		return e.executeFunc(ctx, cmd, sudo, timeouts...)
+	}
 	return nil, nil, nil
 }
 
@@ -197,9 +204,12 @@ func TestGrafanaDatasourceConfig(t *testing.T) {
 	topo := new(Specification)
 	topo.Monitors = []*PrometheusSpec{
 		{
-			Host:                "127.0.0.1",
-			Port:                9090,
-			EnableVMRemoteWrite: true,
+			Host:   "127.0.0.1",
+			Port:   9090,
+			NgPort: 12020,
+			VMConfig: VMConfig{
+				Enable: true,
+			},
 		},
 	}
 	topo.Grafanas = []*GrafanaSpec{
@@ -231,8 +241,15 @@ func TestGrafanaDatasourceConfig(t *testing.T) {
 	assert.Contains(t, string(dsContent), "type: prometheus")
 	assert.Contains(t, string(dsContent), "url: http://127.0.0.1:9090")
 
+	// Verify Prometheus is the default datasource
+	assert.Contains(t, string(dsContent), fmt.Sprintf(`name: %s`, clusterName))
+	assert.Contains(t, string(dsContent), `isDefault: true`)
+	assert.Contains(t, string(dsContent), `url: http://127.0.0.1:9090`)
+	assert.Contains(t, string(dsContent), fmt.Sprintf(`name: %s-vm`, clusterName))
+	assert.Contains(t, string(dsContent), `url: http://127.0.0.1:12020`)
+
 	// Test without VM remote write enabled
-	topo.Monitors[0].EnableVMRemoteWrite = false
+	topo.Monitors[0].VMConfig.Enable = false
 	err = grafanaInstance.InitConfig(ctxt.New(ctx, 0, logprinter.NewLogger("")), mockExec, clusterName, "v5.4.0", "tidb", paths)
 	require.NoError(t, err)
 
@@ -245,4 +262,202 @@ func TestGrafanaDatasourceConfig(t *testing.T) {
 	assert.NotContains(t, string(dsContent), fmt.Sprintf("name: %s-vm", clusterName))
 	assert.Contains(t, string(dsContent), "type: prometheus")
 	assert.Contains(t, string(dsContent), "url: http://127.0.0.1:9090")
+}
+
+// TestVictoriaMetricsDefaultDatasource tests that when Victoria Metrics is set as the default datasource,
+// the dashboards correctly use it instead of Prometheus
+func TestVictoriaMetricsDefaultDatasource(t *testing.T) {
+	ctx := context.Background()
+	deployDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	// Create paths structure with folders needed for dashboards
+	paths := meta.DirPaths{
+		Deploy: deployDir,
+		Cache:  cacheDir,
+	}
+
+	// Create the necessary directory structure
+	dashboardsDir := filepath.Join(deployDir, "dashboards")
+	binDir := filepath.Join(deployDir, "bin")
+	err := os.MkdirAll(dashboardsDir, 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(binDir, 0755)
+	require.NoError(t, err)
+
+	// Create a mock for the execute function to handle the dashboard copy command
+	origExecutor := &mockExecutor{
+		executeFunc: func(ctx context.Context, cmd string, sudo bool, timeouts ...time.Duration) ([]byte, []byte, error) {
+			// Manually perform what the command would do
+			if strings.Contains(cmd, "find") && strings.Contains(cmd, "cp") {
+				// Create the dashboard file by copying it from bin to dashboards dir
+				content, err := os.ReadFile(filepath.Join(binDir, "sample.json"))
+				if err != nil {
+					return nil, nil, err
+				}
+				err = os.WriteFile(filepath.Join(dashboardsDir, "sample.json"), content, 0644)
+				if err != nil {
+					return nil, nil, err
+				}
+			} else if strings.Contains(cmd, "sed") {
+				// Handle the sed command to replace datasource references
+				files, err := os.ReadDir(dashboardsDir)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				for _, file := range files {
+					if strings.HasSuffix(file.Name(), ".json") {
+						content, err := os.ReadFile(filepath.Join(dashboardsDir, file.Name()))
+						if err != nil {
+							return nil, nil, err
+						}
+
+						// Replace datasource references - simulating what sed would do
+						modifiedContent := strings.ReplaceAll(string(content),
+							`"DS_TEST-CLUSTER"`,
+							fmt.Sprintf(`"DS_%s-VM"`, strings.ToUpper("test-cluster")))
+						modifiedContent = strings.ReplaceAll(modifiedContent,
+							`"text": "test-cluster"`,
+							fmt.Sprintf(`"text": "%s-vm"`, "test-cluster"))
+						modifiedContent = strings.ReplaceAll(modifiedContent,
+							`"value": "test-cluster"`,
+							fmt.Sprintf(`"value": "%s-vm"`, "test-cluster"))
+
+						err = os.WriteFile(filepath.Join(dashboardsDir, file.Name()), []byte(modifiedContent), 0644)
+						if err != nil {
+							return nil, nil, err
+						}
+					}
+				}
+			}
+			return nil, nil, nil
+		},
+	}
+
+	// Create a sample dashboard file with datasource references
+	dashboardContent := `{
+		"annotations": {
+			"list": []
+		},
+		"editable": true,
+		"fiscalYearStartMonth": 0,
+		"graphTooltip": 0,
+		"links": [],
+		"liveNow": false,
+		"panels": [],
+		"refresh": "",
+		"schemaVersion": 38,
+		"style": "dark",
+		"tags": [],
+		"templating": {
+			"list": [
+				{
+					"current": {
+						"selected": false,
+						"text": "test-cluster",
+						"value": "test-cluster"
+					},
+					"hide": 0,
+					"includeAll": false,
+					"label": "Datasource",
+					"multi": false,
+					"name": "DS_TEST-CLUSTER",
+					"options": [],
+					"query": "prometheus",
+					"refresh": 1,
+					"regex": "",
+					"skipUrlSync": false,
+					"type": "datasource"
+				}
+			]
+		},
+		"title": "Test Dashboard",
+		"uid": "test",
+		"version": 1,
+		"weekStart": ""
+	}`
+	err = os.WriteFile(filepath.Join(binDir, "sample.json"), []byte(dashboardContent), 0644)
+	require.NoError(t, err)
+
+	// Create test topology with VM as default datasource
+	topo := new(Specification)
+	topo.Monitors = []*PrometheusSpec{
+		{
+			Host:   "127.0.0.1",
+			Port:   9090,
+			NgPort: 12020,
+			VMConfig: VMConfig{
+				Enable:              true,
+				IsDefaultDatasource: true,
+			},
+		},
+	}
+	topo.Grafanas = []*GrafanaSpec{
+		{
+			Host: "127.0.0.1",
+			Port: 3000,
+		},
+	}
+
+	// Create Grafana component
+	comp := GrafanaComponent{topo}
+	grafanaInstance := comp.Instances()[0].(*GrafanaInstance)
+
+	// Test configuration
+	clusterName := "test-cluster"
+	err = grafanaInstance.InitConfig(ctxt.New(ctx, 0, logprinter.NewLogger("")), origExecutor, clusterName, "v5.4.0", "tidb", paths)
+	require.NoError(t, err)
+
+	// Verify the datasource configuration file
+	dsContent, err := os.ReadFile(filepath.Join(deployDir, "provisioning", "datasources", "datasource.yml"))
+	require.NoError(t, err)
+
+	// Check if Victoria Metrics is set as the default datasource
+	assert.Contains(t, string(dsContent), fmt.Sprintf(`name: %s`, clusterName))
+	assert.Contains(t, string(dsContent), `isDefault: false`)
+	assert.Contains(t, string(dsContent), `url: http://127.0.0.1:9090`)
+	assert.Contains(t, string(dsContent), fmt.Sprintf(`name: %s-vm`, clusterName))
+	assert.Contains(t, string(dsContent), `url: http://127.0.0.1:12020`)
+	assert.Contains(t, string(dsContent), `isDefault: true`)
+
+	// Check if dashboard was copied and datasource was properly replaced
+	dashboardFile := filepath.Join(dashboardsDir, "sample.json")
+	assert.FileExists(t, dashboardFile)
+
+	dashContent, err := os.ReadFile(dashboardFile)
+	require.NoError(t, err)
+
+	// Check if the dashboard is using the VM datasource instead of Prometheus
+	assert.Contains(t, string(dashContent), fmt.Sprintf(`"text": "%s-vm"`, clusterName))
+	assert.Contains(t, string(dashContent), fmt.Sprintf(`"value": "%s-vm"`, clusterName))
+	assert.NotContains(t, string(dashContent), `"DS_TEST-CLUSTER"`) // Should be replaced
+}
+
+// TestVMConfigSerialization tests that VMConfig properly serializes to/from YAML
+func TestVMConfigSerialization(t *testing.T) {
+	// Test serialization
+	config := VMConfig{
+		Enable:              true,
+		IsDefaultDatasource: true,
+	}
+
+	// Test serialization
+	yamlData, err := yaml.Marshal(config)
+	require.NoError(t, err)
+
+	// Check YAML output format
+	expectedYAML := `enable: true
+is_default_datasource: true
+`
+	assert.Equal(t, expectedYAML, string(yamlData))
+
+	// Test deserialization
+	var deserializedConfig VMConfig
+	err = yaml.Unmarshal(yamlData, &deserializedConfig)
+	require.NoError(t, err)
+
+	// Check values
+	assert.Equal(t, config.Enable, deserializedConfig.Enable)
+	assert.Equal(t, config.IsDefaultDatasource, deserializedConfig.IsDefaultDatasource)
 }

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -37,19 +37,20 @@ import (
 
 // PrometheusSpec represents the Prometheus Server topology specification in topology.yaml
 type PrometheusSpec struct {
-	Host                  string                 `yaml:"host"`
-	ManageHost            string                 `yaml:"manage_host,omitempty" validate:"manage_host:editable"`
-	SSHPort               int                    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
-	Imported              bool                   `yaml:"imported,omitempty"`
-	Patched               bool                   `yaml:"patched,omitempty"`
-	IgnoreExporter        bool                   `yaml:"ignore_exporter,omitempty"`
-	Port                  int                    `yaml:"port" default:"9090"`
-	NgPort                int                    `yaml:"ng_port,omitempty" validate:"ng_port:editable"`     // ng_port is usable since v5.3.0 and default as 12020 since v5.4.0, so the default value is set in spec.go/AdjustByVersion
-	VMConfig              VMConfig               `yaml:"vm_config,omitempty" validate:"vm_config:editable"` // Victoria Metrics configuration
+	Host           string `yaml:"host"`
+	ManageHost     string `yaml:"manage_host,omitempty" validate:"manage_host:editable"`
+	SSHPort        int    `yaml:"ssh_port,omitempty" validate:"ssh_port:editable"`
+	Imported       bool   `yaml:"imported,omitempty"`
+	Patched        bool   `yaml:"patched,omitempty"`
+	IgnoreExporter bool   `yaml:"ignore_exporter,omitempty"`
+	Port           int    `yaml:"port" default:"9090"`
+	NgPort         int    `yaml:"ng_port,omitempty" validate:"ng_port:editable"` // ng_port is usable since v5.3.0 and default as 12020 since v5.4.0, so the default value is set in spec.go/AdjustByVersion
+
 	DeployDir             string                 `yaml:"deploy_dir,omitempty"`
 	DataDir               string                 `yaml:"data_dir,omitempty"`
 	LogDir                string                 `yaml:"log_dir,omitempty"`
 	NumaNode              string                 `yaml:"numa_node,omitempty" validate:"numa_node:editable"`
+	EnableVMRemoteWrite   bool                   `yaml:"enable_vm_remote_write,omitempty" validate:"enable_vm_remote_write:editable"` // Enable remote write to ng-monitoring
 	RemoteConfig          Remote                 `yaml:"remote_config,omitempty" validate:"remote_config:ignore"`
 	ExternalAlertmanagers []ExternalAlertmanager `yaml:"external_alertmanagers" validate:"external_alertmanagers:ignore"`
 	PushgatewayAddrs      []string               `yaml:"pushgateway_addrs,omitempty" validate:"pushgateway_addrs:ignore"`
@@ -63,12 +64,6 @@ type PrometheusSpec struct {
 	ScrapeTimeout         string                 `yaml:"scrape_timeout,omitempty" validate:"scrape_timeout:editable"`
 
 	AdditionalArgs []string `yaml:"additional_args,omitempty" validate:"additional_args:ignore"`
-}
-
-// VMConfig represents Victoria Metrics configuration
-type VMConfig struct {
-	Enable              bool `yaml:"enable,omitempty" validate:"enable:editable"`                               // Enable remote write to ng-monitoring
-	IsDefaultDatasource bool `yaml:"is_default_datasource,omitempty" validate:"is_default_datasource:editable"` // Use Victoria Metrics as default datasource for Grafana
 }
 
 // Remote prometheus remote config
@@ -202,7 +197,7 @@ type MonitorInstance struct {
 
 // handleRemoteWrite handles remote write configuration for NG monitoring
 func (i *MonitorInstance) handleRemoteWrite(spec *PrometheusSpec, monitoring *PrometheusSpec) {
-	if !spec.VMConfig.Enable || monitoring.NgPort <= 0 {
+	if !spec.EnableVMRemoteWrite || monitoring.NgPort <= 0 {
 		return
 	}
 

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -44,8 +44,8 @@ type PrometheusSpec struct {
 	Patched               bool                   `yaml:"patched,omitempty"`
 	IgnoreExporter        bool                   `yaml:"ignore_exporter,omitempty"`
 	Port                  int                    `yaml:"port" default:"9090"`
-	NgPort                int                    `yaml:"ng_port,omitempty" validate:"ng_port:editable"`                               // ng_port is usable since v5.3.0 and default as 12020 since v5.4.0, so the default value is set in spec.go/AdjustByVersion
-	EnableVMRemoteWrite   bool                   `yaml:"enable_vm_remote_write,omitempty" validate:"enable_vm_remote_write:editable"` // Enable remote write to ng-monitoring
+	NgPort                int                    `yaml:"ng_port,omitempty" validate:"ng_port:editable"`     // ng_port is usable since v5.3.0 and default as 12020 since v5.4.0, so the default value is set in spec.go/AdjustByVersion
+	VMConfig              VMConfig               `yaml:"vm_config,omitempty" validate:"vm_config:editable"` // Victoria Metrics configuration
 	DeployDir             string                 `yaml:"deploy_dir,omitempty"`
 	DataDir               string                 `yaml:"data_dir,omitempty"`
 	LogDir                string                 `yaml:"log_dir,omitempty"`
@@ -63,6 +63,12 @@ type PrometheusSpec struct {
 	ScrapeTimeout         string                 `yaml:"scrape_timeout,omitempty" validate:"scrape_timeout:editable"`
 
 	AdditionalArgs []string `yaml:"additional_args,omitempty" validate:"additional_args:ignore"`
+}
+
+// VMConfig represents Victoria Metrics configuration
+type VMConfig struct {
+	Enable              bool `yaml:"enable,omitempty" validate:"enable:editable"`                               // Enable remote write to ng-monitoring
+	IsDefaultDatasource bool `yaml:"is_default_datasource,omitempty" validate:"is_default_datasource:editable"` // Use Victoria Metrics as default datasource for Grafana
 }
 
 // Remote prometheus remote config
@@ -196,7 +202,7 @@ type MonitorInstance struct {
 
 // handleRemoteWrite handles remote write configuration for NG monitoring
 func (i *MonitorInstance) handleRemoteWrite(spec *PrometheusSpec, monitoring *PrometheusSpec) {
-	if !spec.EnableVMRemoteWrite || monitoring.NgPort <= 0 {
+	if !spec.VMConfig.Enable || monitoring.NgPort <= 0 {
 		return
 	}
 

--- a/pkg/cluster/spec/monitoring_test.go
+++ b/pkg/cluster/spec/monitoring_test.go
@@ -253,3 +253,165 @@ func TestGetRetention(t *testing.T) {
 	val = getRetention("999d")
 	assert.EqualValues(t, "999d", val)
 }
+
+func TestHandleRemoteWrite(t *testing.T) {
+	topo := new(Specification)
+
+	// Create monitoring instance
+	monitorInstance := &MonitorInstance{
+		BaseInstance: BaseInstance{
+			InstanceSpec: &PrometheusSpec{},
+		},
+		topo: topo,
+	}
+
+	// Test case 1: VM is disabled
+	spec := &PrometheusSpec{
+		VMConfig: VMConfig{
+			Enable: false,
+		},
+		RemoteConfig: Remote{},
+	}
+
+	monitoring := &PrometheusSpec{
+		Host:   "127.0.0.1",
+		NgPort: 12020,
+	}
+
+	// Call the function
+	monitorInstance.handleRemoteWrite(spec, monitoring)
+
+	// Check that no remote write config was added when VM is disabled
+	assert.Nil(t, spec.RemoteConfig.RemoteWrite)
+
+	// Test case 2: VM is enabled but NgPort is 0
+	spec = &PrometheusSpec{
+		VMConfig: VMConfig{
+			Enable: true,
+		},
+		RemoteConfig: Remote{},
+	}
+
+	monitoring = &PrometheusSpec{
+		Host:   "127.0.0.1",
+		NgPort: 0,
+	}
+
+	// Call the function
+	monitorInstance.handleRemoteWrite(spec, monitoring)
+
+	// Check that no remote write config was added when NgPort is 0
+	assert.Nil(t, spec.RemoteConfig.RemoteWrite)
+
+	// Test case 3: VM is enabled and NgPort is set
+	spec = &PrometheusSpec{
+		VMConfig: VMConfig{
+			Enable: true,
+		},
+		RemoteConfig: Remote{},
+	}
+
+	monitoring = &PrometheusSpec{
+		Host:   "127.0.0.1",
+		NgPort: 12020,
+	}
+
+	// Call the function
+	monitorInstance.handleRemoteWrite(spec, monitoring)
+
+	// Check that remote write config was added
+	assert.NotNil(t, spec.RemoteConfig.RemoteWrite)
+	assert.Len(t, spec.RemoteConfig.RemoteWrite, 1)
+	assert.Equal(t, "http://127.0.0.1:12020/api/v1/write", spec.RemoteConfig.RemoteWrite[0]["url"])
+
+	// Test case 4: URL already exists in remote write configs
+	expectedURL := fmt.Sprintf("http://%s/api/v1/write", "127.0.0.1:12020")
+	existingRemoteWrite := []map[string]any{
+		{
+			"url": expectedURL,
+		},
+	}
+
+	spec = &PrometheusSpec{
+		VMConfig: VMConfig{
+			Enable: true,
+		},
+		RemoteConfig: Remote{
+			RemoteWrite: existingRemoteWrite,
+		},
+	}
+
+	monitoring = &PrometheusSpec{
+		Host:   "127.0.0.1",
+		NgPort: 12020,
+	}
+
+	// Call the function
+	monitorInstance.handleRemoteWrite(spec, monitoring)
+
+	// Check that no duplicate remote write config was added
+	assert.Len(t, spec.RemoteConfig.RemoteWrite, 1)
+	assert.Equal(t, expectedURL, spec.RemoteConfig.RemoteWrite[0]["url"])
+}
+
+// TestVMConfigField tests that the VMConfig field is properly defined in PrometheusSpec
+func TestVMConfigField(t *testing.T) {
+	// Create a PrometheusSpec with VMConfig
+	spec := PrometheusSpec{
+		Host: "127.0.0.1",
+		Port: 9090,
+		VMConfig: VMConfig{
+			Enable:              true,
+			IsDefaultDatasource: true,
+		},
+	}
+
+	// Validate VMConfig field exists and is accessible
+	assert.True(t, spec.VMConfig.Enable)
+	assert.True(t, spec.VMConfig.IsDefaultDatasource)
+
+	// Test setting fields
+	spec.VMConfig.Enable = false
+	spec.VMConfig.IsDefaultDatasource = false
+
+	assert.False(t, spec.VMConfig.Enable)
+	assert.False(t, spec.VMConfig.IsDefaultDatasource)
+}
+
+// TestVMConfigYAMLBackwardsCompatibility tests loading YAML with and without VMConfig field
+func TestVMConfigYAMLBackwardsCompatibility(t *testing.T) {
+	// Old YAML without VMConfig
+	oldYAML := `
+host: 127.0.0.1
+port: 9090
+ng_port: 12020
+`
+
+	// New YAML with VMConfig
+	newYAML := `
+host: 127.0.0.1
+port: 9090
+ng_port: 12020
+vm_config:
+  enable: true
+  is_default_datasource: true
+`
+
+	// Test unmarshaling old YAML
+	var oldSpec PrometheusSpec
+	err := yaml.Unmarshal([]byte(oldYAML), &oldSpec)
+	assert.NoError(t, err)
+
+	// Default values should be false
+	assert.False(t, oldSpec.VMConfig.Enable)
+	assert.False(t, oldSpec.VMConfig.IsDefaultDatasource)
+
+	// Test unmarshaling new YAML
+	var newSpec PrometheusSpec
+	err = yaml.Unmarshal([]byte(newYAML), &newSpec)
+	assert.NoError(t, err)
+
+	// New values should match what's in the YAML
+	assert.True(t, newSpec.VMConfig.Enable)
+	assert.True(t, newSpec.VMConfig.IsDefaultDatasource)
+}

--- a/pkg/cluster/task/init_config_test.go
+++ b/pkg/cluster/task/init_config_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
 	"github.com/pingcap/tiup/pkg/meta"
+	"github.com/pingcap/tiup/pkg/utils/mock"
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tiup/pkg/utils/mock"
 )
 
 type initConfigSuite struct {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
ref https://github.com/pingcap/tiup/issues/2531

Support changing the data source when multiple data sources exist

### What is changed and how it works?

Introduce the VMConfig
- `enableVMRemoteWrite` moved to VMConfig's `enable`
- added the config item `IsVMDefaultDatasource` to switch vm datasource 

Once you configure the isDefaultDatasource, run:

```
tiup cluster reload <cluster-name> -N grafana_node:3000 
```
it will re-generate the dashboards template with the new datasource.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
