### PR TITLE
playground: Add --perf for starting cluster for higher performance

### DIFF
--- a/components/playground/instance/dm_master.go
+++ b/components/playground/instance/dm_master.go
@@ -19,7 +19,7 @@ type DMMaster struct {
 var _ Instance = &DMMaster{}
 
 // NewDMMaster create a new DMMaster instance.
-func NewDMMaster(binPath string, dir, host, configPath string, portOffset int, id int, port int) *DMMaster {
+func NewDMMaster(shOpt SharedOptions, binPath string, dir, host, configPath string, id int, port int) *DMMaster {
 	if port <= 0 {
 		port = 8261
 	}
@@ -29,9 +29,9 @@ func NewDMMaster(binPath string, dir, host, configPath string, portOffset int, i
 			ID:      id,
 			Dir:     dir,
 			Host:    host,
-			Port:    utils.MustGetFreePort(host, 8291, portOffset),
+			Port:    utils.MustGetFreePort(host, 8291, shOpt.PortOffset),
 			// Similar like PD's client port, here use StatusPort for Master Port.
-			StatusPort: utils.MustGetFreePort(host, port, portOffset),
+			StatusPort: utils.MustGetFreePort(host, port, shOpt.PortOffset),
 			ConfigPath: configPath,
 		},
 	}

--- a/components/playground/instance/dm_worker.go
+++ b/components/playground/instance/dm_worker.go
@@ -20,7 +20,7 @@ type DMWorker struct {
 var _ Instance = &DMWorker{}
 
 // NewDMWorker create a DMWorker instance.
-func NewDMWorker(binPath string, dir, host, configPath string, portOffset int, id int, port int, masters []*DMMaster) *DMWorker {
+func NewDMWorker(shOpt SharedOptions, binPath string, dir, host, configPath string, id int, port int, masters []*DMMaster) *DMWorker {
 	if port <= 0 {
 		port = 8262
 	}
@@ -30,7 +30,7 @@ func NewDMWorker(binPath string, dir, host, configPath string, portOffset int, i
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, port, portOffset),
+			Port:       utils.MustGetFreePort(host, port, shOpt.PortOffset),
 			ConfigPath: configPath,
 		},
 		masters: masters,

--- a/components/playground/instance/drainer.go
+++ b/components/playground/instance/drainer.go
@@ -32,14 +32,14 @@ type Drainer struct {
 var _ Instance = &Drainer{}
 
 // NewDrainer create a Drainer instance.
-func NewDrainer(binPath string, dir, host, configPath string, portOffset int, id int, pds []*PDInstance) *Drainer {
+func NewDrainer(shOpt SharedOptions, binPath string, dir, host, configPath string, id int, pds []*PDInstance) *Drainer {
 	d := &Drainer{
 		instance: instance{
 			BinPath:    binPath,
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, 8250, portOffset),
+			Port:       utils.MustGetFreePort(host, 8250, shOpt.PortOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -39,6 +39,17 @@ type Config struct {
 	Version    string `yaml:"version"`
 }
 
+// SharedOptions contains some commonly used, tunable options for most components.
+// Unlike Config, these options are shared for all instances of all components.
+type SharedOptions struct {
+	/// Whether or not to tune the cluster in order to run faster (instead of easier to debug).
+	HighPerf   bool       `yaml:"high_perf"`
+	CSE        CSEOptions `yaml:"cse"` // Only available when mode == tidb-cse or tiflash-disagg
+	PDMode     string     `yaml:"pd_mode"`
+	Mode       string     `yaml:"mode"`
+	PortOffset int        `yaml:"port_offset"`
+}
+
 // CSEOptions contains configs to run TiDB cluster in CSE mode.
 type CSEOptions struct {
 	S3Endpoint string `yaml:"s3_endpoint"`
@@ -144,7 +155,7 @@ func logIfErr(err error) {
 func pdEndpoints(pds []*PDInstance, isHTTP bool) []string {
 	var endpoints []string
 	for _, pd := range pds {
-		if pd.Role == PDRoleTSO || pd.Role == PDRoleScheduling {
+		if pd.role == PDRoleTSO || pd.role == PDRoleScheduling {
 			continue
 		}
 		if isHTTP {

--- a/components/playground/instance/pd_config.go
+++ b/components/playground/instance/pd_config.go
@@ -22,7 +22,7 @@ func (inst *PDInstance) getConfig() map[string]any {
 		config["replication.max-replica"] = 1
 	}
 
-	if inst.mode == "tidb-cse" {
+	if inst.shOpt.Mode == "tidb-cse" {
 		config["keyspace.pre-alloc"] = []string{"mykeyspace"}
 		config["replication.enable-placement-rules"] = true
 		config["schedule.merge-schedule-limit"] = 0

--- a/components/playground/instance/pump.go
+++ b/components/playground/instance/pump.go
@@ -34,14 +34,14 @@ type Pump struct {
 var _ Instance = &Pump{}
 
 // NewPump create a Pump instance.
-func NewPump(binPath string, dir, host, configPath string, portOffset int, id int, pds []*PDInstance) *Pump {
+func NewPump(shOpt SharedOptions, binPath string, dir, host, configPath string, id int, pds []*PDInstance) *Pump {
 	pump := &Pump{
 		instance: instance{
 			BinPath:    binPath,
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, 8249, portOffset),
+			Port:       utils.MustGetFreePort(host, 8249, shOpt.PortOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/instance/ticdc.go
+++ b/components/playground/instance/ticdc.go
@@ -33,7 +33,7 @@ type TiCDC struct {
 var _ Instance = &TiCDC{}
 
 // NewTiCDC create a TiCDC instance.
-func NewTiCDC(binPath string, dir, host, configPath string, portOffset int, id int, port int, pds []*PDInstance) *TiCDC {
+func NewTiCDC(shOpt SharedOptions, binPath string, dir, host, configPath string, id int, port int, pds []*PDInstance) *TiCDC {
 	if port <= 0 {
 		port = 8300
 	}
@@ -43,7 +43,7 @@ func NewTiCDC(binPath string, dir, host, configPath string, portOffset int, id i
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, port, portOffset),
+			Port:       utils.MustGetFreePort(host, port, shOpt.PortOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -26,32 +26,32 @@ import (
 // TiDBInstance represent a running tidb-server
 type TiDBInstance struct {
 	instance
-	pds []*PDInstance
+	shOpt SharedOptions
+	pds   []*PDInstance
 	Process
 	tiproxyCertDir string
 	enableBinlog   bool
-	mode           string
 }
 
 // NewTiDBInstance return a TiDBInstance
-func NewTiDBInstance(binPath string, dir, host, configPath string, portOffset int, id, port int, pds []*PDInstance, tiproxyCertDir string, enableBinlog bool, mode string) *TiDBInstance {
+func NewTiDBInstance(shOpt SharedOptions, binPath string, dir, host, configPath string, id, port int, pds []*PDInstance, tiproxyCertDir string, enableBinlog bool) *TiDBInstance {
 	if port <= 0 {
 		port = 4000
 	}
 	return &TiDBInstance{
+		shOpt: shOpt,
 		instance: instance{
 			BinPath:    binPath,
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, port, portOffset),
-			StatusPort: utils.MustGetFreePort("0.0.0.0", 10080, portOffset),
+			Port:       utils.MustGetFreePort(host, port, shOpt.PortOffset),
+			StatusPort: utils.MustGetFreePort("0.0.0.0", 10080, shOpt.PortOffset),
 			ConfigPath: configPath,
 		},
 		tiproxyCertDir: tiproxyCertDir,
 		pds:            pds,
 		enableBinlog:   enableBinlog,
-		mode:           mode,
 	}
 }
 

--- a/components/playground/instance/tidb_config.go
+++ b/components/playground/instance/tidb_config.go
@@ -22,7 +22,7 @@ func (inst *TiDBInstance) getConfig() map[string]any {
 	config := make(map[string]any)
 	config["security.auto-tls"] = true
 
-	if inst.mode == "tidb-cse" {
+	if inst.shOpt.Mode == "tidb-cse" {
 		config["keyspace-name"] = "mykeyspace"
 		config["enable-safe-point-v2"] = true
 		config["force-enable-vector-type"] = true
@@ -52,7 +52,7 @@ func (inst *TiDBInstance) getConfig() map[string]any {
 		config["tiflash-replicas.group-id"] = "enable_s3_wn_region"
 		config["tiflash-replicas.extra-s3-rule"] = false
 		config["tiflash-replicas.min-count"] = 1
-	} else if inst.mode == "tiflash-disagg" {
+	} else if inst.shOpt.Mode == "tiflash-disagg" {
 		config["use-autoscaler"] = false
 		config["disaggregated-tiflash"] = true
 	}

--- a/components/playground/instance/tiflash_config.go
+++ b/components/playground/instance/tiflash_config.go
@@ -23,14 +23,14 @@ func (inst *TiFlashInstance) getProxyConfig() map[string]any {
 	config["storage.reserve-raft-space"] = 0
 
 	if inst.Role == TiFlashRoleDisaggWrite {
-		if inst.mode == "tidb-cse" {
+		if inst.shOpt.Mode == "tidb-cse" {
 			config["storage.api-version"] = 2
 			config["storage.enable-ttl"] = true
 			config["dfs.prefix"] = "tikv"
-			config["dfs.s3-endpoint"] = inst.cseOpts.S3Endpoint
-			config["dfs.s3-key-id"] = inst.cseOpts.AccessKey
-			config["dfs.s3-secret-key"] = inst.cseOpts.SecretKey
-			config["dfs.s3-bucket"] = inst.cseOpts.Bucket
+			config["dfs.s3-endpoint"] = inst.shOpt.CSE.S3Endpoint
+			config["dfs.s3-key-id"] = inst.shOpt.CSE.AccessKey
+			config["dfs.s3-secret-key"] = inst.shOpt.CSE.SecretKey
+			config["dfs.s3-bucket"] = inst.shOpt.CSE.Bucket
 			config["dfs.s3-region"] = "local"
 		}
 	}
@@ -45,29 +45,39 @@ func (inst *TiFlashInstance) getConfig() map[string]any {
 	config["logger.level"] = "debug"
 
 	if inst.Role == TiFlashRoleDisaggWrite {
-		config["storage.s3.endpoint"] = inst.cseOpts.S3Endpoint
-		config["storage.s3.bucket"] = inst.cseOpts.Bucket
+		config["storage.s3.endpoint"] = inst.shOpt.CSE.S3Endpoint
+		config["storage.s3.bucket"] = inst.shOpt.CSE.Bucket
 		config["storage.s3.root"] = "/tiflash-cse/"
-		config["storage.s3.access_key_id"] = inst.cseOpts.AccessKey
-		config["storage.s3.secret_access_key"] = inst.cseOpts.SecretKey
+		config["storage.s3.access_key_id"] = inst.shOpt.CSE.AccessKey
+		config["storage.s3.secret_access_key"] = inst.shOpt.CSE.SecretKey
 		config["storage.main.dir"] = []string{filepath.Join(inst.Dir, "main_data")}
 		config["flash.disaggregated_mode"] = "tiflash_write"
-		if inst.mode == "tidb-cse" {
+		if inst.shOpt.Mode == "tidb-cse" {
 			config["enable_safe_point_v2"] = true
 			config["storage.api_version"] = 2
 		}
 	} else if inst.Role == TiFlashRoleDisaggCompute {
-		config["storage.s3.endpoint"] = inst.cseOpts.S3Endpoint
-		config["storage.s3.bucket"] = inst.cseOpts.Bucket
+		config["storage.s3.endpoint"] = inst.shOpt.CSE.S3Endpoint
+		config["storage.s3.bucket"] = inst.shOpt.CSE.Bucket
 		config["storage.s3.root"] = "/tiflash-cse/"
-		config["storage.s3.access_key_id"] = inst.cseOpts.AccessKey
-		config["storage.s3.secret_access_key"] = inst.cseOpts.SecretKey
+		config["storage.s3.access_key_id"] = inst.shOpt.CSE.AccessKey
+		config["storage.s3.secret_access_key"] = inst.shOpt.CSE.SecretKey
 		config["storage.remote.cache.dir"] = filepath.Join(inst.Dir, "remote_cache")
 		config["storage.remote.cache.capacity"] = uint64(50000000000) // 50GB
 		config["storage.main.dir"] = []string{filepath.Join(inst.Dir, "main_data")}
 		config["flash.disaggregated_mode"] = "tiflash_compute"
-		if inst.mode == "tidb-cse" {
+		if inst.shOpt.Mode == "tidb-cse" {
 			config["enable_safe_point_v2"] = true
+		}
+	}
+
+	if inst.shOpt.HighPerf {
+		config["logger.level"] = "info"
+		if inst.Role == TiFlashRoleDisaggWrite {
+			config["profiles.default.cpu_thread_count_scale"] = 5.0
+		} else if inst.Role == TiFlashRoleDisaggCompute {
+			config["profiles.default.task_scheduler_thread_soft_limit"] = 0
+			config["profiles.default.task_scheduler_thread_hard_limit"] = 0
 		}
 	}
 

--- a/components/playground/instance/tiflash_pre7.go
+++ b/components/playground/instance/tiflash_pre7.go
@@ -141,12 +141,12 @@ func (inst *TiFlashInstance) checkConfigOld(deployDir, clusterManagerPath string
 	}()
 
 	// Write default config to buffer
-	if err := writeTiFlashConfigOld(flashBuf, version, inst.TCPPort, inst.Port, inst.ServicePort, inst.StatusPort,
+	if err := writeTiFlashConfigOld(flashBuf, version, inst.tcpPort, inst.Port, inst.servicePort, inst.StatusPort,
 		inst.Host, deployDir, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {
 		return errors.Trace(err)
 	}
 	if err := writeTiFlashProxyConfigOld(proxyBuf, version, inst.Host, deployDir,
-		inst.ServicePort, inst.ProxyPort, inst.ProxyStatusPort); err != nil {
+		inst.servicePort, inst.proxyPort, inst.proxyStatusPort); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/components/playground/instance/tikv_cdc.go
+++ b/components/playground/instance/tikv_cdc.go
@@ -32,14 +32,14 @@ type TiKVCDC struct {
 var _ Instance = &TiKVCDC{}
 
 // NewTiKVCDC create a TiKVCDC instance.
-func NewTiKVCDC(binPath string, dir, host, configPath string, portOffset int, id int, pds []*PDInstance) *TiKVCDC {
+func NewTiKVCDC(shOpt SharedOptions, binPath string, dir, host, configPath string, id int, pds []*PDInstance) *TiKVCDC {
 	tikvCdc := &TiKVCDC{
 		instance: instance{
 			BinPath:    binPath,
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, 8600, portOffset),
+			Port:       utils.MustGetFreePort(host, 8600, shOpt.PortOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/instance/tikv_config.go
+++ b/components/playground/instance/tikv_config.go
@@ -20,14 +20,14 @@ func (inst *TiKVInstance) getConfig() map[string]any {
 	config["storage.reserve-space"] = 0
 	config["storage.reserve-raft-space"] = 0
 
-	if inst.mode == "tidb-cse" {
+	if inst.shOpt.Mode == "tidb-cse" {
 		config["storage.api-version"] = 2
 		config["storage.enable-ttl"] = true
 		config["dfs.prefix"] = "tikv"
-		config["dfs.s3-endpoint"] = inst.cseOpts.S3Endpoint
-		config["dfs.s3-key-id"] = inst.cseOpts.AccessKey
-		config["dfs.s3-secret-key"] = inst.cseOpts.SecretKey
-		config["dfs.s3-bucket"] = inst.cseOpts.Bucket
+		config["dfs.s3-endpoint"] = inst.shOpt.CSE.S3Endpoint
+		config["dfs.s3-key-id"] = inst.shOpt.CSE.AccessKey
+		config["dfs.s3-secret-key"] = inst.shOpt.CSE.SecretKey
+		config["dfs.s3-bucket"] = inst.shOpt.CSE.Bucket
 		config["dfs.s3-region"] = "local"
 	}
 

--- a/components/playground/instance/tiproxy.go
+++ b/components/playground/instance/tiproxy.go
@@ -68,7 +68,7 @@ func GenTiProxySessionCerts(dir string) error {
 }
 
 // NewTiProxy create a TiProxy instance.
-func NewTiProxy(binPath string, dir, host, configPath string, portOffset int, id int, port int, pds []*PDInstance) *TiProxy {
+func NewTiProxy(shOpt SharedOptions, binPath string, dir, host, configPath string, id int, port int, pds []*PDInstance) *TiProxy {
 	if port <= 0 {
 		port = 6000
 	}
@@ -78,8 +78,8 @@ func NewTiProxy(binPath string, dir, host, configPath string, portOffset int, id
 			ID:         id,
 			Dir:        dir,
 			Host:       host,
-			Port:       utils.MustGetFreePort(host, port, portOffset),
-			StatusPort: utils.MustGetFreePort(host, 3080, portOffset),
+			Port:       utils.MustGetFreePort(host, port, shOpt.PortOffset),
+			StatusPort: utils.MustGetFreePort(host, 3080, shOpt.PortOffset),
 			ConfigPath: configPath,
 		},
 		pds: pds,

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -78,12 +78,12 @@ func (m *monitor) wait() error {
 }
 
 // the cmd is not started after return
-func newMonitor(ctx context.Context, version string, host, dir string, portOffset int) (*monitor, error) {
+func newMonitor(ctx context.Context, shOpt instance.SharedOptions, version string, host, dir string) (*monitor, error) {
 	if err := utils.MkdirAll(dir, 0755); err != nil {
 		return nil, errors.AddStack(err)
 	}
 
-	port := utils.MustGetFreePort(host, 9090, portOffset)
+	port := utils.MustGetFreePort(host, 9090, shOpt.PortOffset)
 	addr := utils.JoinHostPort(host, port)
 
 	tmpl := `

--- a/components/playground/ngmonitoring.go
+++ b/components/playground/ngmonitoring.go
@@ -45,12 +45,12 @@ func (m *ngMonitoring) wait() error {
 }
 
 // the cmd is not started after return
-func newNGMonitoring(ctx context.Context, version string, host, dir string, portOffset int, pds []*instance.PDInstance) (*ngMonitoring, error) {
+func newNGMonitoring(ctx context.Context, shOpt instance.SharedOptions, version string, host, dir string, pds []*instance.PDInstance) (*ngMonitoring, error) {
 	if err := utils.MkdirAll(dir, 0755); err != nil {
 		return nil, errors.AddStack(err)
 	}
 
-	port := utils.MustGetFreePort(host, 12020, portOffset)
+	port := utils.MustGetFreePort(host, 12020, shOpt.PortOffset)
 	m := new(ngMonitoring)
 	var endpoints []string
 	for _, pd := range pds {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently playground cluster is boot for debug-friendly by default.

### What is changed and how it works?

- Add `--perf` to allow the cluster boot for higher performance instead of debug friendly.
  Currently only TiFlash config is polished (and is sufficient for testing the TiDB cluster using VectorDBBench). Other config can be also added if someone need it.

- Now there are more and more global options. It makes code hard to read. So I reorganized these options and grouped them into a single structure. In this way it is more clear and will be easy to add global options later.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Tested with --perf, --mode=tidb-cse and all works as expected.


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
playground: Add --perf for starting cluster for higher performance
```
