### PR TITLE
playground: Support tikv-worker and --tikv.columnar in tidb-cse mode

### DIFF
--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -43,11 +43,12 @@ type Config struct {
 // Unlike Config, these options are shared for all instances of all components.
 type SharedOptions struct {
 	/// Whether or not to tune the cluster in order to run faster (instead of easier to debug).
-	HighPerf   bool       `yaml:"high_perf"`
-	CSE        CSEOptions `yaml:"cse"` // Only available when mode == tidb-cse or tiflash-disagg
-	PDMode     string     `yaml:"pd_mode"`
-	Mode       string     `yaml:"mode"`
-	PortOffset int        `yaml:"port_offset"`
+	HighPerf           bool       `yaml:"high_perf"`
+	CSE                CSEOptions `yaml:"cse"` // Only available when mode == tidb-cse or tiflash-disagg
+	PDMode             string     `yaml:"pd_mode"`
+	Mode               string     `yaml:"mode"`
+	PortOffset         int        `yaml:"port_offset"`
+	EnableTiKVColumnar bool       `yaml:"enable_tikv_columnar"` // Only available when mode == tidb-cse
 }
 
 // CSEOptions contains configs to run TiDB cluster in CSE mode.

--- a/components/playground/instance/tiflash_config.go
+++ b/components/playground/instance/tiflash_config.go
@@ -34,6 +34,15 @@ func (inst *TiFlashInstance) getProxyConfig() map[string]any {
 			config["dfs.s3-region"] = "local"
 		}
 	}
+	// If TiKVColumnar is enabled, TiFlash Proxy need to know how to access S3 as well.
+	if inst.Role == TiFlashRoleDisaggCompute && inst.shOpt.Mode == "tidb-cse" && inst.shOpt.EnableTiKVColumnar {
+		config["dfs.prefix"] = "tikv"
+		config["dfs.s3-endpoint"] = inst.shOpt.CSE.S3Endpoint
+		config["dfs.s3-key-id"] = inst.shOpt.CSE.AccessKey
+		config["dfs.s3-secret-key"] = inst.shOpt.CSE.SecretKey
+		config["dfs.s3-bucket"] = inst.shOpt.CSE.Bucket
+		config["dfs.s3-region"] = "local"
+	}
 
 	return config
 }
@@ -68,6 +77,9 @@ func (inst *TiFlashInstance) getConfig() map[string]any {
 		config["flash.disaggregated_mode"] = "tiflash_compute"
 		if inst.shOpt.Mode == "tidb-cse" {
 			config["enable_safe_point_v2"] = true
+			if inst.shOpt.EnableTiKVColumnar {
+				config["flash.use_columnar"] = true
+			}
 		}
 	}
 

--- a/components/playground/instance/tikv_config.go
+++ b/components/playground/instance/tikv_config.go
@@ -29,6 +29,7 @@ func (inst *TiKVInstance) getConfig() map[string]any {
 		config["dfs.s3-secret-key"] = inst.shOpt.CSE.SecretKey
 		config["dfs.s3-bucket"] = inst.shOpt.CSE.Bucket
 		config["dfs.s3-region"] = "local"
+		config["kvengine.build-columnar"] = true
 	}
 
 	return config

--- a/components/playground/instance/tikv_worker.go
+++ b/components/playground/instance/tikv_worker.go
@@ -101,6 +101,7 @@ func (inst *TiKVWorkerInstance) Component() string {
 	return "tikv_worker"
 }
 
+// LogFile return the log file name.
 func (inst *TiKVWorkerInstance) LogFile() string {
 	return filepath.Join(inst.Dir, "tikv_worker.log")
 }

--- a/components/playground/instance/tikv_worker.go
+++ b/components/playground/instance/tikv_worker.go
@@ -1,0 +1,123 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tiup/pkg/utils"
+)
+
+// resolveTiKVWorkerBinPath resolves the tikv-worker binary path when tikv-server path is provided.
+func resolveTiKVWorkerBinPath(binPath string) string {
+	if !strings.HasSuffix(binPath, "tikv-server") {
+		return binPath
+	}
+	dir := filepath.Dir(binPath)
+	return filepath.Join(dir, "tikv-worker")
+}
+
+// TiKVWorkerInstance represent a running TiKVWorker instance.
+type TiKVWorkerInstance struct {
+	instance
+	shOpt SharedOptions
+	pds   []*PDInstance
+	Process
+}
+
+// NewTiKVWorkerInstance creates a new TiKVWorker instance.
+func NewTiKVWorkerInstance(shOpt SharedOptions, binPath string, dir, host, configPath string, id int, port int, pds []*PDInstance) *TiKVWorkerInstance {
+	if port <= 0 {
+		port = 19000
+	}
+	return &TiKVWorkerInstance{
+		shOpt: shOpt,
+		instance: instance{
+			BinPath:    resolveTiKVWorkerBinPath(binPath),
+			ID:         id,
+			Dir:        dir,
+			Host:       host,
+			Port:       utils.MustGetFreePort(host, port, shOpt.PortOffset),
+			ConfigPath: configPath,
+		},
+		pds: pds,
+	}
+}
+
+// Addr return the address of TiKVWorker.
+func (inst *TiKVWorkerInstance) Addr() string {
+	return utils.JoinHostPort(inst.Host, inst.Port)
+}
+
+// Start calls set inst.cmd and Start
+func (inst *TiKVWorkerInstance) Start(ctx context.Context) error {
+	if inst.shOpt.PDMode == "ms" {
+		return errors.New("tikv_worker does not support ms pd mode")
+	}
+	if inst.shOpt.Mode != "tidb-cse" {
+		return errors.New("tikv_worker only supports tidb-cse mode")
+	}
+
+	configPath := filepath.Join(inst.Dir, "tikv_worker.toml")
+	if err := prepareConfig(
+		configPath,
+		inst.ConfigPath,
+		inst.getConfig(),
+	); err != nil {
+		return err
+	}
+
+	endpoints := pdEndpoints(inst.pds, true)
+	args := []string{
+		fmt.Sprintf("--addr=%s", utils.JoinHostPort(inst.Host, inst.Port)),
+		fmt.Sprintf("--log-file=%s", inst.LogFile()),
+		fmt.Sprintf("--pd-endpoints=%s", strings.Join(endpoints, ",")),
+		fmt.Sprintf("--config=%s", configPath),
+	}
+
+	inst.Process = &process{cmd: PrepareCommand(ctx, inst.BinPath, args, nil, inst.Dir)}
+
+	logIfErr(inst.Process.SetOutputFile(inst.LogFile()))
+	return inst.Process.Start()
+}
+
+// Component return the component name.
+func (inst *TiKVWorkerInstance) Component() string {
+	return "tikv_worker"
+}
+
+func (inst *TiKVWorkerInstance) LogFile() string {
+	return filepath.Join(inst.Dir, "tikv_worker.log")
+}
+
+func (inst *TiKVWorkerInstance) getConfig() map[string]any {
+	config := make(map[string]any)
+	config["dfs.prefix"] = "tikv"
+	config["dfs.s3-endpoint"] = inst.shOpt.CSE.S3Endpoint
+	config["dfs.s3-key-id"] = inst.shOpt.CSE.AccessKey
+	config["dfs.s3-secret-key"] = inst.shOpt.CSE.SecretKey
+	config["dfs.s3-bucket"] = inst.shOpt.CSE.Bucket
+	config["dfs.s3-region"] = "local"
+	config["raft-engine.enabled"] = false
+	config["schema-manager.dir"] = filepath.Join(inst.Dir, "schemas")
+	config["schema-manager.schema-refresh-threshold"] = 1
+	config["schema-manager.enabled"] = true
+	config["schema-manager.keyspace-refresh-interval"] = "10s"
+
+	return config
+}

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -39,6 +39,7 @@ import (
 const (
 	ComponentTiDB             = "tidb"
 	ComponentTiKV             = "tikv"
+	ComponentTiKVWorker       = "tikv-worker"
 	ComponentPD               = "pd"
 	ComponentTSO              = "tso"
 	ComponentScheduling       = "scheduling"


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

When `--mode=tidb-cse`, a fully functional tikv-worker process will be started as well (with remote compactor, remote cop and schema manager running).

Additionally, when `--tikv.columnar` is specified in this mode, TiKVColumnar query will be enabled (this brings all TiFlash Compute Node to read via TiKVColumnar).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

```
/Users/breezewish/Work/tiup/bin/tiup-playground v7.3.0 --mode=tidb-cse --tag serverless \
  --db.binpath ../tidb-cse/bin/tidb-server \
  --kv.binpath ../tikv-cse/target/release/tikv-server \
  --pd.binpath ../pd-cse/bin/pd-server \
  --tiflash.binpath ../tiflash-cse/cmake-build-Release/dbms/src/Server/tiflash \
  --tiflash.compute 1 --tikv.columnar
```

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
playground: Support tikv-worker and --tikv.columnar in tidb-cse mode
```
