### PR TITLE
tiflash: Add more example of setting the tiflash-proxy configs

### DIFF
--- a/embed/examples/cluster/minimal.yaml
+++ b/embed/examples/cluster/minimal.yaml
@@ -206,7 +206,12 @@ tiflash_servers:
     # data_dir: /tidb-data/tiflash-9000
     # # TiFlash Server log file storage directory.
     # log_dir: /tidb-deploy/tiflash-9000/log
-  # # The ip address of the TiKV Server.
+    # # The following configs are used to overwrite the `server_configs.tiflash` values.
+    # config:
+    #   logger.level: info
+    # # The following configs are used to overwrite the `server_configs.tiflash-learner` values.
+    # learner_config:
+    #   log.level: info
   - host: 10.0.1.21
     # ssh_port: 22
     # tcp_port: 9000

--- a/embed/examples/cluster/multi-dc.yaml
+++ b/embed/examples/cluster/multi-dc.yaml
@@ -259,6 +259,16 @@ tiflash_servers:
     # data_dir: /tidb-data/tiflash-9000
     # # TiFlash Server log file storage directory.
     # log_dir: /tidb-deploy/tiflash-9000/log
+    # # The following configs are used to overwrite the `server_configs.tiflash` values.
+    # config:
+    #   logger.level: info
+    # # The following configs are used to overwrite the `server_configs.tiflash-learner` values.
+    learner_config:
+      server.labels:
+        zone: bj
+        dc: bja
+        rack: rack1
+        host: tiflash-host1
   - host: 10.0.1.25
     # ssh_port: 22
     # tcp_port: 9000
@@ -269,6 +279,16 @@ tiflash_servers:
     # deploy_dir: /tidb-deploy/tiflash-9000
     # data_dir: /tidb-data/tiflash-9000
     # log_dir: /tidb-deploy/tiflash-9000/log
+    # # The following configs are used to overwrite the `server_configs.tiflash` values.
+    # config:
+    #   logger.level: info
+    # # The following configs are used to overwrite the `server_configs.tiflash-learner` values.
+    learner_config:
+      server.labels:
+        zone: bj
+        dc: bjb
+        rack: rack1
+        host: tiflash-host2
 
 # # Server configs are used to specify the configuration of Prometheus Server.  
 monitoring_servers:


### PR DESCRIPTION

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/pingcap/tiup/pull/2444 added an example of tiflash-proxy config in `topology.example.yaml`. But not all people know that. The tiflash-proxy config is not shown in the `minimal.yaml` and `multi-dc.yaml`

### What is changed and how it works?

Add example of setting the tiflash-proxy configs in the `minimal.yaml` and `multi-dc.yaml`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - [] Unit test
 - [] Integration test
 - [] Manual test (add detailed scripts or steps below)
 - [] No code

Code changes

 - [] Has exported function/method change
 - [] Has exported variable/fields change
 - [] Has interface methods change
 - [] Has persistent data change

Side effects

 - [] Possible performance regression
 - [] Increased code complexity
 - [] Breaking backward compatibility

Related changes

 - [] Need to cherry-pick to the release branch
 - [] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
