### PR TITLE
tici: Update the default config filename & default port of tici

### DIFF
--- a/components/playground/instance/tici.go
+++ b/components/playground/instance/tici.go
@@ -123,9 +123,9 @@ func (t *TiCIInstance) startMetaServer(ctx context.Context) error {
 	args := []string{}
 
 	// Use default or provided config path
-	metaConfigPath := filepath.Join(t.ticiDir, "ci", "test-meta-config.toml")
+	metaConfigPath := filepath.Join(t.ticiDir, "ci", "test-meta.toml")
 	if t.configDir != "" {
-		metaConfigPath = filepath.Join(t.configDir, "test-meta-config.toml")
+		metaConfigPath = filepath.Join(t.configDir, "test-meta.toml")
 	}
 	args = append(args, fmt.Sprintf("--config=%s", metaConfigPath))
 
@@ -144,9 +144,9 @@ func (t *TiCIInstance) startWorkerNode(ctx context.Context) error {
 	args := []string{}
 
 	// Use default or provided config path
-	workerConfigPath := filepath.Join(t.ticiDir, "ci", "test-writer.toml")
+	workerConfigPath := filepath.Join(t.ticiDir, "ci", "test-worker.toml")
 	if t.configDir != "" {
-		workerConfigPath = filepath.Join(t.configDir, "test-writer.toml")
+		workerConfigPath = filepath.Join(t.configDir, "test-worker.toml")
 	}
 	args = append(args, fmt.Sprintf("--config=%s", workerConfigPath))
 

--- a/components/playground/instance/tici.go
+++ b/components/playground/instance/tici.go
@@ -65,15 +65,19 @@ func NewTiCIWorkerInstance(shOpt SharedOptions, baseDir, host string, id int, pd
 func NewTiCIInstanceWithRole(shOpt SharedOptions, baseDir, host string, id int, pds []*PDInstance,
 	ticiDir, configDir string, role TiCIRole) *TiCIInstance {
 	var componentSuffix string
-	var defaultPort int
+	var defaultPort, defaultStatusPort int
 
 	switch role {
 	case TiCIRoleMeta:
+		// MetaServer default port
 		componentSuffix = "meta"
-		defaultPort = 8500 // MetaServer default port
+		defaultPort = 8500
+		defaultStatusPort = 8501
 	case TiCIRoleWorker:
+		// WorkerNode default port
 		componentSuffix = "worker"
-		defaultPort = 8501 // WorkerNode default port
+		defaultPort = 8510
+		defaultStatusPort = 8511
 	default:
 		panic("invalid TiCI role")
 	}
@@ -87,7 +91,7 @@ func NewTiCIInstanceWithRole(shOpt SharedOptions, baseDir, host string, id int, 
 			Dir:        dir,
 			Host:       host,
 			Port:       utils.MustGetFreePort(host, defaultPort, shOpt.PortOffset),
-			StatusPort: utils.MustGetFreePort(host, defaultPort+1, shOpt.PortOffset),
+			StatusPort: utils.MustGetFreePort(host, defaultStatusPort, shOpt.PortOffset),
 			ConfigPath: configDir,
 		},
 		pds:       pds,


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #xxx

### What is changed and how it works?

Update the default config filename of tici according to https://github.com/pingcap-inc/tici/pull/221
Update the default port of tici according to https://github.com/pingcap-inc/tici/pull/232

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
