### PR TITLE
cluster: add stop/start timeout for systemd service

### DIFF
--- a/embed/templates/systemd/system.service.tpl
+++ b/embed/templates/systemd/system.service.tpl
@@ -41,6 +41,12 @@ RestartSec=15s
 {{- if .DisableSendSigkill}}
 SendSIGKILL=no
 {{- end}}
+{{- if .TimeoutStartSec}}
+TimeoutStartSec={{.TimeoutStartSec}}
+{{- end}}
+{{- if .TimeoutStopSec}}
+TimeoutStopSec={{.TimeoutStopSec}}
+{{- end}}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -197,6 +197,8 @@ func (i *BaseInstance) InitConfig(ctx context.Context, e ctxt.Executor, opt Glob
 		WithMemoryLimit(resource.MemoryLimit).
 		WithCPUQuota(resource.CPUQuota).
 		WithLimitCORE(resource.LimitCORE).
+		WithTimeoutStartSec(resource.TimeoutStartSec).
+		WithTimeoutStopSec(resource.TimeoutStopSec).
 		WithIOReadBandwidthMax(resource.IOReadBandwidthMax).
 		WithIOWriteBandwidthMax(resource.IOWriteBandwidthMax).
 		WithSystemdMode(string(systemdMode))

--- a/pkg/cluster/task/monitored_config.go
+++ b/pkg/cluster/task/monitored_config.go
@@ -106,6 +106,9 @@ func (m *MonitoredConfig) syncMonitoredSystemConfig(ctx context.Context, exec ct
 	systemCfg := system.NewConfig(comp, m.deployUser, m.paths.Deploy).
 		WithMemoryLimit(resource.MemoryLimit).
 		WithCPUQuota(resource.CPUQuota).
+		WithLimitCORE(resource.LimitCORE).
+		WithTimeoutStartSec(resource.TimeoutStartSec).
+		WithTimeoutStopSec(resource.TimeoutStopSec).
 		WithIOReadBandwidthMax(resource.IOReadBandwidthMax).
 		WithIOWriteBandwidthMax(resource.IOWriteBandwidthMax).
 		WithSystemdMode(string(systemdMode))

--- a/pkg/cluster/template/systemd/system.go
+++ b/pkg/cluster/template/systemd/system.go
@@ -33,6 +33,8 @@ type Config struct {
 	LimitCORE           string
 	DeployDir           string
 	DisableSendSigkill  bool
+	TimeoutStopSec      string
+	TimeoutStartSec     string
 	GrantCapNetRaw      bool
 	// Takes one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always.
 	// The Template set as always if this is not set.
@@ -82,6 +84,18 @@ func (c *Config) WithLimitCORE(core string) *Config {
 // WithSystemdMode set the SystemdMode field of Config
 func (c *Config) WithSystemdMode(mode string) *Config {
 	c.SystemdMode = mode
+	return c
+}
+
+// WithTimeoutStopSec set the TimeoutStopSec field of Config
+func (c *Config) WithTimeoutStopSec(sec string) *Config {
+	c.TimeoutStopSec = sec
+	return c
+}
+
+// WithTimeoutStartSec set the TimeoutStartSec field of Config
+func (c *Config) WithTimeoutStartSec(sec string) *Config {
+	c.TimeoutStartSec = sec
 	return c
 }
 

--- a/pkg/meta/resource_ctrl.go
+++ b/pkg/meta/resource_ctrl.go
@@ -21,4 +21,6 @@ type ResourceControl struct {
 	IOReadBandwidthMax  string `yaml:"io_read_bandwidth_max,omitempty" validate:"io_read_bandwidth_max:editable"`
 	IOWriteBandwidthMax string `yaml:"io_write_bandwidth_max,omitempty" validate:"io_write_bandwidth_max:editable"`
 	LimitCORE           string `yaml:"limit_core,omitempty" validate:"limit_core:editable"`
+	TimeoutStopSec      string `yaml:"timeout_stop_sec,omitempty" validate:"timeout_stop_sec:editable"`
+	TimeoutStartSec     string `yaml:"timeout_start_sec,omitempty" validate:"timeout_start_sec:editable"`
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #xxx

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
tiup cluster deploy

see if service file have those fields
```
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
cluster: add stop/start timeout for systemd service
```
