### PR TITLE
ci: add staging mirror option to release workflow

### DIFF
--- a/.github/workflows/release-tiup.yaml
+++ b/.github/workflows/release-tiup.yaml
@@ -22,6 +22,10 @@ on:
       git-ref:
         description: git ref
         required: true
+      staging-mirror:
+        description: Publish to staging mirror
+        required: false
+        type: boolean
 
 jobs:
   release:
@@ -59,7 +63,12 @@ jobs:
         working-directory: ${{ env.working-directory }}
         if: github.event_name != 'release'
         run: |
-          STAGING_VER=`git describe --tags | sed 's/-[^-]*$//' | sed -r 's/(-[^-]*$)/-nightly\1/'`
+          if [ "$BRANCH_NAME" != "master" ]; then
+            BRANCH_NAME=$(echo $GITHUB_REF | sed 's|refs/heads/||; s|/|_|g')
+            STAGING_VER=$(git describe --tags | sed 's/-[0-9]*-[^-]*$//')-$BRANCH_NAME
+          else
+            STAGING_VER=$(git describe --tags | sed 's/-[^-]*$//' | sed -r 's/(-[^-]*$)/-nightly\1/')
+          fi
           echo ::set-output name=STAGING::$STAGING_VER
 
       - name: Get git ref and commit
@@ -148,7 +157,7 @@ jobs:
       - name: Publish packages
         working-directory: ${{ env.working-directory }}
         env:
-          TIUP_MIRRORS: ${{ secrets.TIUP_SERVER_PROD }}
+          TIUP_MIRRORS: ${{ github.event.inputs.staging-mirror == 'true' && secrets.TIUP_SERVER_STAGING || secrets.TIUP_SERVER_PROD }}
           TIUP_HOME: ${{ steps.packaging.outputs.TIUP_HOME }}
           TIUP_BIN: ${{ steps.packaging.outputs.TIUP_BIN }}
           REL_VER: ${{ steps.build_tiup.outputs.REL_VER }}
@@ -211,7 +220,7 @@ jobs:
           sed -i 's/version.*/version "${{ needs.release.outputs.REL_VER }}"/g'  Formula/tiup.rb
           sed -i 's/tag:.*/tag:      "${{ needs.release.outputs.REL_VER }}"/g'  Formula/tiup.rb
           cat Formula/tiup.rb
-          
+
       - name: Push new homebrew
         uses: actions-js/push@master
         continue-on-error: true


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #xxx

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
