### PR TITLE
playground: make the tici changefeed endpoint configurable

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1341,7 +1341,8 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		}
 		bucket := ticiMetaConfig["s3"].(map[string]any)["bucket"].(string)
 		prefix := ticiMetaConfig["s3"].(map[string]any)["prefix"].(string)
-		if err := p.createChangefeed(bucket, prefix); err != nil {
+		endpoint := ticiMetaConfig["s3"].(map[string]any)["endpoint"].(string)
+		if err := p.createChangefeed(bucket, prefix, endpoint); err != nil {
 			fmt.Println(color.RedString("Failed to create changefeed: %s", err))
 		} else {
 			fmt.Println("Changefeed created successfully.")
@@ -1911,7 +1912,7 @@ func parseMysqlVersion(versionOutput string) (vMaj int, vMin int, vPatch int, er
 }
 
 // createChangefeed creates a changefeed using tiup cdc cli
-func (p *Playground) createChangefeed(bucket, prefix string) error {
+func (p *Playground) createChangefeed(bucket, prefix, endpoint string) error {
 	if len(p.ticdcs) == 0 {
 		return fmt.Errorf("no TiCDC instances available")
 	}
@@ -1920,7 +1921,7 @@ func (p *Playground) createChangefeed(bucket, prefix string) error {
 	cdcAddr := fmt.Sprintf("http://%s", p.ticdcs[0].Addr())
 
 	// Prepare changefeed creation command
-	sinkURI := fmt.Sprintf("s3://%s/%s/cdc?protocol=canal-json&access-key=minioadmin&secret-access-key=minioadmin&endpoint=http://127.0.0.1:9000&enable-tidb-extension=true&output-row-key=true", bucket, prefix)
+	sinkURI := fmt.Sprintf("s3://%s/%s/cdc?protocol=canal-json&access-key=minioadmin&secret-access-key=minioadmin&endpoint=%s&enable-tidb-extension=true&output-row-key=true", bucket, prefix, endpoint)
 
 	cmd := exec.Command("tiup", "cdc", "cli", "changefeed", "create",
 		fmt.Sprintf("--server=%s", cdcAddr),

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1342,7 +1342,9 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		bucket := ticiMetaConfig["s3"].(map[string]any)["bucket"].(string)
 		prefix := ticiMetaConfig["s3"].(map[string]any)["prefix"].(string)
 		endpoint := ticiMetaConfig["s3"].(map[string]any)["endpoint"].(string)
-		if err := p.createChangefeed(bucket, prefix, endpoint); err != nil {
+		accessKey := ticiMetaConfig["s3"].(map[string]any)["access_key"].(string)
+		secretKey := ticiMetaConfig["s3"].(map[string]any)["secret_key"].(string)
+		if err := p.createChangefeed(bucket, prefix, endpoint, accessKey, secretKey); err != nil {
 			fmt.Println(color.RedString("Failed to create changefeed: %s", err))
 		} else {
 			fmt.Println("Changefeed created successfully.")
@@ -1912,7 +1914,7 @@ func parseMysqlVersion(versionOutput string) (vMaj int, vMin int, vPatch int, er
 }
 
 // createChangefeed creates a changefeed using tiup cdc cli
-func (p *Playground) createChangefeed(bucket, prefix, endpoint string) error {
+func (p *Playground) createChangefeed(bucket, prefix, endpoint, accessKey, secretKey string) error {
 	if len(p.ticdcs) == 0 {
 		return fmt.Errorf("no TiCDC instances available")
 	}
@@ -1921,7 +1923,7 @@ func (p *Playground) createChangefeed(bucket, prefix, endpoint string) error {
 	cdcAddr := fmt.Sprintf("http://%s", p.ticdcs[0].Addr())
 
 	// Prepare changefeed creation command
-	sinkURI := fmt.Sprintf("s3://%s/%s/cdc?protocol=canal-json&access-key=minioadmin&secret-access-key=minioadmin&endpoint=%s&enable-tidb-extension=true&output-row-key=true", bucket, prefix, endpoint)
+	sinkURI := fmt.Sprintf("s3://%s/%s/cdc?protocol=canal-json&access-key=%s&secret-access-key=%s&endpoint=%s&enable-tidb-extension=true&output-row-key=true", bucket, prefix, accessKey, secretKey, endpoint)
 
 	cmd := exec.Command("tiup", "cdc", "cli", "changefeed", "create",
 		fmt.Sprintf("--server=%s", cdcAddr),


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #xxx

### What is changed and how it works?

Make the url configurable by the passed config.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
