### PR TITLE
playground: fix tiflash metric

### DIFF
--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -92,10 +92,10 @@ func (inst *TiFlashInstance) Addr() string {
 	return utils.JoinHostPort(AdvertiseHost(inst.Host), inst.servicePort)
 }
 
-// StatusAddrs implements Instance interface.
-func (inst *TiFlashInstance) StatusAddrs() (addrs []string) {
-	addrs = append(addrs, utils.JoinHostPort(inst.Host, inst.StatusPort))
-	addrs = append(addrs, utils.JoinHostPort(inst.Host, inst.proxyStatusPort))
+// MetricAddr implements Instance interface.
+func (inst *TiFlashInstance) MetricAddr() (r MetricAddr) {
+	r.Targets = append(r.Targets, utils.JoinHostPort(inst.Host, inst.StatusPort))
+	r.Targets = append(r.Targets, utils.JoinHostPort(inst.Host, inst.proxyStatusPort))
 	return
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #xxx

### What is changed and how it works?

Introduce by https://github.com/pingcap/tiup/pull/2299, `StatusAddrs` rename to `MetricAddr`.

But `TiFlashInstance` implements its own `StatusAddrs`, and this PR does not rewrite the method of `TiFlashInstance`.

Therefore, monitor does not have TiFlash proxy status address, then all metrics in the TiFlash proxy are missing.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
