### PR TITLE
cluster: clear leader_priority for pd leader if exist

### DIFF
--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -134,6 +134,7 @@ var (
 	pdLeaderURI          = "pd/api/v1/leader"
 	pdLeaderTransferURI  = "pd/api/v1/leader/transfer"
 	pdMembersURI         = "pd/api/v1/members"
+	pdMemberPriorityURI  = "pd/api/v1/members/name/%s"
 	pdSchedulersURI      = "pd/api/v1/schedulers"
 	pdStoreURI           = "pd/api/v1/store"
 	pdStoresURI          = "pd/api/v1/stores"
@@ -1033,6 +1034,17 @@ func (pc *PDClient) GetServicePrimary(service string) (string, error) {
 		return body, json.Unmarshal(body, &primary)
 	})
 	return primary, err
+}
+
+// SetLeaderPriority sets priority config value of PD member.
+func (pc *PDClient) SetLeaderPriority(name string, value int32) error {
+	data := map[string]any{"leader-priority": value}
+	body, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	pc.l().Debugf("setting leader_priority for %s: %d", name, value)
+	return pc.updateConfig(fmt.Sprintf(pdMemberPriorityURI, name), bytes.NewBuffer(body))
 }
 
 const (

--- a/pkg/cluster/spec/pd.go
+++ b/pkg/cluster/spec/pd.go
@@ -451,7 +451,7 @@ func (i *PDInstance) PreRestart(ctx context.Context, topo Topology, apiTimeoutSe
 			return err
 		}
 
-		var oldPriority int32 = 0
+		var oldPriority int32
 		if m := slices.IndexFunc(members.Members, func(j *pdpb.Member) bool {
 			return i.Name == j.Name
 		}); m != -1 && members.Members[m].LeaderPriority != 0 {

--- a/pkg/cluster/spec/pd.go
+++ b/pkg/cluster/spec/pd.go
@@ -19,10 +19,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/tiup/pkg/cluster/api"
 	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/template/scripts"
@@ -444,8 +446,29 @@ func (i *PDInstance) PreRestart(ctx context.Context, topo Topology, apiTimeoutSe
 		return err
 	}
 	if len(tidbTopo.PDServers) > 1 && isLeader {
+		members, err := pdClient.GetMembers()
+		if err != nil {
+			return err
+		}
+
+		var oldPriority int32 = 0
+		if m := slices.IndexFunc(members.Members, func(j *pdpb.Member) bool {
+			return i.Name == j.Name
+		}); m != -1 && members.Members[m].LeaderPriority != 0 {
+			oldPriority = members.Members[m].LeaderPriority
+		}
+
+		if oldPriority != 0 {
+			if err := pdClient.SetLeaderPriority(i.Name, 0); err != nil {
+				return errors.Annotatef(err, "failed to clear PD leader priority[%d] %s", oldPriority, i.GetHost())
+			}
+		}
 		if err := pdClient.EvictPDLeader(timeoutOpt); err != nil {
 			return errors.Annotatef(err, "failed to evict PD leader %s", i.GetHost())
+		}
+
+		if err := pdClient.SetLeaderPriority(i.Name, oldPriority); err != nil {
+			return errors.Annotatef(err, "failed to recover PD leader priority[%d] %s", oldPriority, i.GetHost())
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #2223

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
This can only be tested by a cluster with more than 2 pd server, using pd-ctl set a high leader_priority before testing.
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
