### PR TITLE
cluster: support retention by size for prometheus

### DIFF
--- a/embed/templates/scripts/run_prometheus.sh.tpl
+++ b/embed/templates/scripts/run_prometheus.sh.tpl
@@ -55,5 +55,10 @@ exec bin/prometheus/prometheus \
 {{- end}}
 {{- end}}
 {{- if not .EnablePromAgentMode}}
-    --storage.tsdb.retention="{{.Retention}}"
+{{- if .RetentionSize}}
+    --storage.tsdb.retention.size="{{.RetentionSize}}"
+{{- end}}
+{{- if .RetentionTime}}
+    --storage.tsdb.retention.time="{{.RetentionTime}}"
+{{- end}}
 {{- end}}

--- a/pkg/cluster/spec/monitoring_test.go
+++ b/pkg/cluster/spec/monitoring_test.go
@@ -229,32 +229,68 @@ scrape_configs:
 
 func TestGetRetention(t *testing.T) {
 	var val string
-	val = getRetention("-1d")
+	val = getRetentionTime("-1d")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetention("0d")
+	val = getRetentionTime("0d")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetention("01d")
+	val = getRetentionTime("01d")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetention("1dd")
+	val = getRetentionTime("1dd")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetention("*1d")
+	val = getRetentionTime("*1d")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetention("1d ")
+	val = getRetentionTime("1d ")
+	assert.EqualValues(t, "1d", val)
+
+	val = getRetentionTime(" 1d")
+	assert.EqualValues(t, "1d", val)
+
+	val = getRetentionTime("ddd")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetention("ddd")
-	assert.EqualValues(t, "30d", val)
-
-	val = getRetention("60d")
+	val = getRetentionTime("60d")
 	assert.EqualValues(t, "60d", val)
 
-	val = getRetention("999d")
+	val = getRetentionTime("999d")
 	assert.EqualValues(t, "999d", val)
+
+	val = getRetentionSize("-1MB")
+	assert.EqualValues(t, "", val)
+
+	val = getRetentionSize("30d")
+	assert.EqualValues(t, "", val)
+
+	val = getRetentionSize("1k")
+	assert.EqualValues(t, "", val)
+
+	val = getRetentionSize("01G")
+	assert.EqualValues(t, "", val)
+
+	val = getRetentionSize("233mb")
+	assert.EqualValues(t, "233MB", val)
+
+	val = getRetentionSize("*1GB")
+	assert.EqualValues(t, "", val)
+
+	val = getRetentionSize("20GB ")
+	assert.EqualValues(t, "20GB", val)
+
+	val = getRetentionSize(" 20GB")
+	assert.EqualValues(t, "20GB", val)
+
+	val = getRetentionSize("3TB")
+	assert.EqualValues(t, "3TB", val)
+
+	val = getRetentionSize("30GB")
+	assert.EqualValues(t, "30GB", val)
+
+	val = getRetentionSize("1EB")
+	assert.EqualValues(t, "1EB", val)
 }
 
 // TestHandleRemoteWrite verifies that remote write configurations are properly handled

--- a/pkg/cluster/spec/monitoring_test.go
+++ b/pkg/cluster/spec/monitoring_test.go
@@ -229,67 +229,67 @@ scrape_configs:
 
 func TestGetRetention(t *testing.T) {
 	var val string
-	val = getRetentionTime("-1d")
+	val = getRetentionTime(nil, "-1d")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetentionTime("0d")
+	val = getRetentionTime(nil, "0d")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetentionTime("01d")
+	val = getRetentionTime(nil, "01d")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetentionTime("1dd")
+	val = getRetentionTime(nil, "1dd")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetentionTime("*1d")
+	val = getRetentionTime(nil, "*1d")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetentionTime("1d ")
+	val = getRetentionTime(nil, "1d ")
 	assert.EqualValues(t, "1d", val)
 
-	val = getRetentionTime(" 1d")
+	val = getRetentionTime(nil, " 1d")
 	assert.EqualValues(t, "1d", val)
 
-	val = getRetentionTime("ddd")
+	val = getRetentionTime(nil, "ddd")
 	assert.EqualValues(t, "30d", val)
 
-	val = getRetentionTime("60d")
+	val = getRetentionTime(nil, "60d")
 	assert.EqualValues(t, "60d", val)
 
-	val = getRetentionTime("999d")
+	val = getRetentionTime(nil, "999d")
 	assert.EqualValues(t, "999d", val)
 
-	val = getRetentionSize("-1MB")
+	val = getRetentionSize(nil, "-1MB")
 	assert.EqualValues(t, "", val)
 
-	val = getRetentionSize("30d")
+	val = getRetentionSize(nil, "30d")
 	assert.EqualValues(t, "", val)
 
-	val = getRetentionSize("1k")
+	val = getRetentionSize(nil, "1k")
 	assert.EqualValues(t, "", val)
 
-	val = getRetentionSize("01G")
+	val = getRetentionSize(nil, "01G")
 	assert.EqualValues(t, "", val)
 
-	val = getRetentionSize("233mb")
+	val = getRetentionSize(nil, "233mb")
 	assert.EqualValues(t, "233MB", val)
 
-	val = getRetentionSize("*1GB")
+	val = getRetentionSize(nil, "*1GB")
 	assert.EqualValues(t, "", val)
 
-	val = getRetentionSize("20GB ")
+	val = getRetentionSize(nil, "20GB ")
 	assert.EqualValues(t, "20GB", val)
 
-	val = getRetentionSize(" 20GB")
+	val = getRetentionSize(nil, " 20GB")
 	assert.EqualValues(t, "20GB", val)
 
-	val = getRetentionSize("3TB")
+	val = getRetentionSize(nil, "3TB")
 	assert.EqualValues(t, "3TB", val)
 
-	val = getRetentionSize("30GB")
+	val = getRetentionSize(nil, "30GB")
 	assert.EqualValues(t, "30GB", val)
 
-	val = getRetentionSize("1EB")
+	val = getRetentionSize(nil, "1EB")
 	assert.EqualValues(t, "1EB", val)
 }
 

--- a/pkg/cluster/template/scripts/monitoring.go
+++ b/pkg/cluster/template/scripts/monitoring.go
@@ -26,7 +26,8 @@ import (
 type PrometheusScript struct {
 	Port                int
 	WebExternalURL      string
-	Retention           string
+	RetentionSize       string
+	RetentionTime       string
 	EnableNG            bool
 	EnablePromAgentMode bool
 

--- a/pkg/cluster/template/scripts/monitoring_test.go
+++ b/pkg/cluster/template/scripts/monitoring_test.go
@@ -32,7 +32,8 @@ func TestPrometheusScriptWithAgentMode(t *testing.T) {
 	script := &PrometheusScript{
 		Port:                9090,
 		WebExternalURL:      "http://localhost:9090",
-		Retention:           "30d",
+		RetentionTime:       "30d",
+		RetentionSize:       "100GB",
 		EnableNG:            false,
 		EnablePromAgentMode: true,
 		DeployDir:           "/deploy",


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add support of retention by size for Prometheus. Default value is empty to keep former behavior unchanged. The `storage.tsdb.retention.size` and `storage.tsdb.retention.time` can be set together.

> If both time and size retention policies are specified, whichever triggers first will be used.

See [Prometheus doc](https://prometheus.io/docs/prometheus/latest/storage/) for details.

Also close #2058

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Tested with TiDB v8.5.2, which uses Prometheus v2.49.1
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [x] Has exported variable/fields change
- [ ] Has interface methods change
- [x] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [x] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
