### PR TITLE
*: add option to force redownload binaries

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -102,6 +102,7 @@ the latest stable version will be downloaded from the repository.`,
 				return cmd.Help()
 			}
 			env := environment.GlobalEnv()
+			forcePull := false
 
 			// TBD: change this flag to subcommand
 
@@ -138,6 +139,8 @@ the latest stable version will be downloaded from the repository.`,
 				}
 				binPath = args[1]
 				args = args[2:]
+			case "--force-pull":
+				forcePull = true
 			case "--tag", "-T":
 				if len(args) < 2 {
 					return fmt.Errorf("flag %s needs an argument", args[0])
@@ -163,7 +166,7 @@ the latest stable version will be downloaded from the repository.`,
 				args = args[1:]
 			}
 
-			return tiupexec.RunComponent(env, tag, componentSpec, binPath, args)
+			return tiupexec.RunComponent(env, tag, componentSpec, binPath, forcePull, args)
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			return environment.GlobalEnv().Close()

--- a/components/playground/grafana.go
+++ b/components/playground/grafana.go
@@ -31,20 +31,22 @@ import (
 )
 
 type grafana struct {
-	host    string
-	port    int
-	version string
+	host      string
+	port      int
+	version   string
+	forcePull bool
 
 	waitErr  error
 	waitOnce sync.Once
 	cmd      *exec.Cmd
 }
 
-func newGrafana(version string, host string, port int) *grafana {
+func newGrafana(version string, host string, port int, forcePull bool) *grafana {
 	return &grafana{
-		host:    host,
-		version: version,
-		port:    port,
+		host:      host,
+		version:   version,
+		port:      port,
+		forcePull: forcePull,
 	}
 }
 
@@ -195,7 +197,7 @@ http_port = %d
 	}
 
 	var binPath string
-	if binPath, err = tiupexec.PrepareBinary("grafana", utils.Version(g.version), binPath); err != nil {
+	if binPath, err = tiupexec.PrepareBinary("grafana", utils.Version(g.version), binPath, g.forcePull); err != nil {
 		return err
 	}
 	cmd := instance.PrepareCommand(ctx, binPath, args, nil, dir)

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -66,6 +66,7 @@ type SharedOptions struct {
 	Mode               string     `yaml:"mode"`
 	PortOffset         int        `yaml:"port_offset"`
 	EnableTiKVColumnar bool       `yaml:"enable_tikv_columnar"` // Only available when mode == ModeCSE
+	ForcePull          bool       `yaml:"force_pull"`
 }
 
 // CSEOptions contains configs to run TiDB cluster in CSE mode.
@@ -118,7 +119,7 @@ type Instance interface {
 	// Proc return the underlying process.
 	Process() Process
 	// PrepareBinary use given binpath or download from tiup mirrors.
-	PrepareBinary(binaryName string, componentName string, version string) error
+	PrepareBinary(binaryName string, componentName string, version string, force bool) error
 	// PrepareProcess construct the process used later.
 	PrepareProcess(ctx context.Context, binPath string, args, envs []string, workDir string) error
 }
@@ -155,7 +156,7 @@ func (inst *instance) MetricAddr() (r MetricAddr) {
 	return
 }
 
-func (inst *instance) PrepareBinary(binaryName string, componentName string, boundVersion string) error {
+func (inst *instance) PrepareBinary(binaryName string, componentName string, boundVersion string, force bool) error {
 	var version utils.Version
 	var err error
 	if inst.BinPath == "" {
@@ -163,7 +164,7 @@ func (inst *instance) PrepareBinary(binaryName string, componentName string, bou
 			return err
 		}
 	}
-	instanceBinPath, err := tiupexec.PrepareBinary(binaryName, version, inst.BinPath)
+	instanceBinPath, err := tiupexec.PrepareBinary(binaryName, version, inst.BinPath, force)
 	if err != nil {
 		return err
 	}

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -257,6 +257,7 @@ Note: Version constraint is [green][bold]%s[reset]. If you'd like to use other v
 	rootCmd.Flags().BoolVar(&options.ShOpt.HighPerf, "perf", false, "Tune default config for better performance instead of debug troubleshooting")
 	rootCmd.Flags().BoolVar(&options.ShOpt.EnableTiKVColumnar, "tikv.columnar", false,
 		fmt.Sprintf("Enable TiKV columnar storage engine, only available when --mode=%s", instance.ModeCSE))
+	rootCmd.Flags().BoolVar(&options.ShOpt.ForcePull, "force-pull", false, "Force redownload the component. It is useful to manually refresh nightly or broken binaries")
 
 	rootCmd.PersistentFlags().StringVarP(&tag, "tag", "T", "", "Specify a tag for playground, data dir of this tag will not be removed after exit")
 	rootCmd.Flags().Bool("without-monitor", false, "Don't start prometheus and grafana component")

--- a/components/playground/monitor.go
+++ b/components/playground/monitor.go
@@ -79,7 +79,7 @@ func (m *monitor) wait() error {
 }
 
 // the cmd is not started after return
-func newMonitor(ctx context.Context, shOpt instance.SharedOptions, version string, host, dir string) (*monitor, error) {
+func newMonitor(ctx context.Context, shOpt instance.SharedOptions, version string, host, dir string, forcePull bool) (*monitor, error) {
 	if err := utils.MkdirAll(dir, 0755); err != nil {
 		return nil, errors.AddStack(err)
 	}
@@ -138,7 +138,7 @@ scrape_configs:
 	}
 
 	var binPath string
-	if binPath, err = tiupexec.PrepareBinary("prometheus", sversion, binPath); err != nil {
+	if binPath, err = tiupexec.PrepareBinary("prometheus", sversion, binPath, forcePull); err != nil {
 		return nil, err
 	}
 	cmd := instance.PrepareCommand(ctx, binPath, args, nil, dir)

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -512,7 +512,7 @@ func (p *Playground) startInstance(ctx context.Context, inst instance.Instance) 
 
 	boundVersion := p.bindVersion(inst.Component(), p.bootOptions.Version)
 
-	if err := inst.PrepareBinary(component, inst.Role(), boundVersion); err != nil {
+	if err := inst.PrepareBinary(component, inst.Role(), boundVersion, p.bootOptions.ShOpt.ForcePull); err != nil {
 		return err
 	}
 
@@ -1574,7 +1574,7 @@ func (p *Playground) bootMonitor(ctx context.Context, env *environment.Environme
 	dataDir := p.dataDir
 	promDir := filepath.Join(dataDir, "prometheus")
 
-	monitor, err := newMonitor(ctx, options.ShOpt, options.Version, options.Host, promDir)
+	monitor, err := newMonitor(ctx, options.ShOpt, options.Version, options.Host, promDir, p.bootOptions.ShOpt.ForcePull)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1703,7 +1703,7 @@ func (p *Playground) bootGrafana(ctx context.Context, env *environment.Environme
 		return nil, err
 	}
 
-	grafana := newGrafana(string(sversion), options.Host, options.GrafanaPort)
+	grafana := newGrafana(string(sversion), options.Host, options.GrafanaPort, p.bootOptions.ShOpt.ForcePull)
 	// fmt.Println("Start Grafana instance...")
 	err = grafana.start(ctx, grafanaDir, options.ShOpt.PortOffset, "http://"+utils.JoinHostPort(monitorInfo.IP, monitorInfo.Port))
 	if err != nil {

--- a/pkg/environment/env.go
+++ b/pkg/environment/env.go
@@ -271,44 +271,6 @@ func (env *Environment) SelectInstalledVersion(component string, ver utils.Versi
 	return ver, errInstallFirst
 }
 
-// DownloadComponentIfMissing downloads the specific version of a component if it is missing
-func (env *Environment) DownloadComponentIfMissing(component string, ver utils.Version) (utils.Version, error) {
-	var err error
-	if ver.String() == utils.NightlyVersionAlias {
-		if ver, _, err = env.v1Repo.LatestNightlyVersion(component); err != nil {
-			return "", err
-		}
-	}
-
-	// Use the latest version if user doesn't specify a specific version and
-	// download the latest version if the specific component doesn't be installed
-
-	// Check whether the specific version exist in local
-	ver, err = env.SelectInstalledVersion(component, ver)
-	needDownload := errors.Cause(err) == ErrInstallFirst
-	if err != nil && !needDownload {
-		return "", err
-	}
-
-	if needDownload {
-		fmt.Fprintf(os.Stderr, "The component `%s` version %s is not installed; downloading from repository.\n", component, ver.String())
-		spec := repository.ComponentSpec{
-			ID:      component,
-			Version: string(ver),
-			Force:   false,
-		}
-		if err := env.v1Repo.UpdateComponents([]repository.ComponentSpec{spec}); err != nil {
-			return "", err
-		}
-	}
-
-	if ver.IsEmpty() {
-		return env.SelectInstalledVersion(component, ver)
-	}
-
-	return ver, nil
-}
-
 // BinaryPath return the installed binary path.
 func (env *Environment) BinaryPath(component string, ver utils.Version) (string, error) {
 	installPath, err := env.profile.ComponentInstalledPath(component, ver)

--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/environment"
 	"github.com/pingcap/tiup/pkg/localdata"
+	"github.com/pingcap/tiup/pkg/repository"
 	"github.com/pingcap/tiup/pkg/tui/colorstr"
 	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/pingcap/tiup/pkg/version"
@@ -40,14 +41,14 @@ var skipStartingMessages = map[string]bool{
 }
 
 // RunComponent start a component and wait it
-func RunComponent(env *environment.Environment, tag, spec, binPath string, args []string) error {
+func RunComponent(env *environment.Environment, tag, spec, binPath string, forcePull bool, args []string) error {
 	component, version := environment.ParseCompVersion(spec)
 
 	if version == "" {
 		cmdCheckUpdate(component, version)
 	}
 
-	binPath, err := PrepareBinary(component, version, binPath)
+	binPath, err := PrepareBinary(component, version, binPath, forcePull)
 	if err != nil {
 		return err
 	}
@@ -229,7 +230,7 @@ func cmdCheckUpdate(component string, version utils.Version) {
 }
 
 // PrepareBinary use given binpath or download from tiup mirror
-func PrepareBinary(component string, version utils.Version, binPath string) (string, error) {
+func PrepareBinary(component string, version utils.Version, binPath string, force bool) (string, error) {
 	if binPath != "" {
 		tmp, err := filepath.Abs(binPath)
 		if err != nil {
@@ -237,12 +238,48 @@ func PrepareBinary(component string, version utils.Version, binPath string) (str
 		}
 		binPath = tmp
 	} else {
-		selectVer, err := environment.GlobalEnv().DownloadComponentIfMissing(component, version)
-		if err != nil {
-			return "", err
+		env := environment.GlobalEnv()
+		var ver utils.Version
+		var err error
+
+		if ver.String() == utils.NightlyVersionAlias {
+			if ver, _, err = env.V1Repository().LatestNightlyVersion(component); err != nil {
+				return "", err
+			}
 		}
 
-		binPath, err = environment.GlobalEnv().BinaryPath(component, selectVer)
+		needDownload := false
+		if !force {
+			// Use the latest version if user doesn't specify a specific version and
+			// download the latest version if the specific component doesn't be installed
+			// Check whether the specific version exist in local
+			ver, err = env.SelectInstalledVersion(component, ver)
+			needDownload = errors.Cause(err) == environment.ErrInstallFirst
+			if err != nil && !needDownload {
+				return "", err
+			}
+		}
+
+		if needDownload || force {
+			fmt.Fprintf(os.Stderr, "The component `%s` version %s is not installed; downloading from repository.\n", component, ver.String())
+			spec := repository.ComponentSpec{
+				ID:      component,
+				Version: string(ver),
+				Force:   force,
+			}
+			if err := env.V1Repository().UpdateComponents([]repository.ComponentSpec{spec}); err != nil {
+				return "", err
+			}
+		}
+
+		if ver.IsEmpty() {
+			ver, err = env.SelectInstalledVersion(component, ver)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		binPath, err = environment.GlobalEnv().BinaryPath(component, ver)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

ref #2439 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
[xhe@tb14p tiup]$ ./bin/tiup-playground v8.5.3 --force-pull 
The component `pd` version  is not installed; downloading from repository.
download https://tiup-mirrors.pingcap.com/pd-v8.5.3-linux-amd64.tar.gz 45.67 MiB / 54.84 MiB 83.29% 25.18 MiB/s     
```
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
