### PR TITLE
cluster: fix tici s3 config

### DIFF
--- a/pkg/cluster/spec/tici_meta.go
+++ b/pkg/cluster/spec/tici_meta.go
@@ -262,6 +262,12 @@ func (i *TiCIMetaInstance) PrepareStart(ctx context.Context, tlsCfg *tls.Config)
 	if v, ok := spec.Config["s3.secret_key"].(string); ok {
 		secretKey = v
 	}
+	if v, ok := spec.Config["s3.region"].(string); ok {
+		endpoint = fmt.Sprintf("%s&region=%s", endpoint, v)
+	}
+	if v, ok := spec.Config["s3.use_path_style"].(bool); ok {
+		endpoint = fmt.Sprintf("%s&force-path-style=%t", endpoint, v)
+	}
 	cdcAddr := utils.JoinHostPort(topo.CDCServers[0].Host, topo.CDCServers[0].Port)
 	cdcClient := api.NewCDCOpenAPIClient(ctx, []string{cdcAddr}, 10*time.Second, nil)
 	return cdcClient.CreateChangefeed(bucket, prefix, endpoint, accessKey, secretKey, flushInterval)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #xxx

### What is changed and how it works?

```
tici_meta_servers:
  - host: tici-meta-peer
    config:
      s3.endpoint: "https://a.b.com"
      s3.region: Beijing
      s3.access_key: "xxx"
      s3.secret_key: "xxx"
      s3.bucket: fts
      s3.use_path_style: false
```
tiup cluster:v1.16.2-feature.fts start
```
Error: failed to start tici-meta: bad request when creating changefeed: {
    "error_msg": "[CDC:ErrSinkURIInvalid]sink uri invalid 's3://fts/tici_default_prefix/cdc?protocol=canal-json\u0026enable-tidb-extension=true\u0026output-row-key=true\u0026access-key=xx\u0026secret-access-key=xx\u0026endpoint=https://ks3-cn-beijing-internal.ksyuncs.com\u0026flush-interval=5s': [CDC:ErrFailToCreateExternalStorage]failed to create external storage%!(EXTRA string=creating ExternalStorage for s3): failed to get region of bucket fts: Forbidden: Forbidden\n\tstatus code: 403, request id: fanoi020kcmobjfsq1ib1mv4llld6gjd, host id: ",
    "error_code": "CDC:ErrSinkURIInvalid"
}
```
The tiup cluster can't use `s3.use_path_style` and `s3.region` config when create changefeed. The fix pr uses the 2 configs.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
