### PR TITLE
fix the reader addr in tiflash conf

### DIFF
--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -541,7 +541,12 @@ func (i *TiFlashInstance) initTiFlashConfig(ctx context.Context, version string,
 	}
 	var ticiConfig string
 	if version == utils.FTSVersionAlias {
-		ticiConfig = fmt.Sprintf(`tici.reader_node.addr: "%s"`, utils.JoinHostPort(spec.Host, spec.TiCIReaderNodePort))
+		ticiConfig = fmt.Sprintf(
+			`tici.reader_node.addr: "%s"
+    tici.reader_node.advertise_addr: "%s"`,
+			utils.JoinHostPort("0.0.0.0", spec.TiCIReaderNodePort),
+			utils.JoinHostPort(spec.Host, spec.TiCIReaderNodePort),
+		)
 	}
 
 	err = yaml.Unmarshal(fmt.Appendf(nil, `


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #xxx

### What is changed and how it works?
change the tici reader config in  tiflash.toml from 
```toml
[tici.reader_node]
addr = "tiflash-1-peer:8520"
```
to
```toml
[tici.reader_node]
addr = "0.0.0.0:8520"
advertise_addr = "tiflash-1-peer:8520"
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
