### PR TITLE
support TiFlash startup when no TiDB server exists

### DIFF
--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1387,8 +1387,9 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 
 	colorCmd := color.New(color.FgHiCyan, color.Bold)
 
-	if len(tidbSucc) > 0 {
-		// start TiFlash after at least one TiDB is up.
+	// In FTS mode, TiFlash can start without TiDB. In other modes, TiFlash needs at least one TiDB to be up.
+	if len(tidbSucc) > 0 || (p.bootOptions.ShOpt.Mode == instance.ModeFTS && len(p.tiflashs) > 0) {
+		// start TiFlash after at least one TiDB is up (or in FTS mode even without TiDB).
 		var started []*instance.TiFlashInstance
 		for _, flash := range p.tiflashs {
 			if err := p.startInstance(ctx, flash); err != nil {
@@ -1399,7 +1400,9 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		}
 		p.tiflashs = started
 		p.waitAllTiFlashUp()
+	}
 
+	if len(tidbSucc) > 0 {
 		fmt.Println()
 		successMsg := "🎉 TiDB Playground Cluster is started"
 		if len(p.ticiMetas) > 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when start TiCI without TiDB server
```bash
tiup playground:v1.16.2-feature.fts --mode tidb-fts --s3.bucket bucket-jane --tiflash 1 --db 0 
```
TiFlash server can not be started.
This pr support to start TiFlash server without TiDB server

close #xxx

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
