### PR TITLE
playground: wait PD ready before starting TiDB to avoid cluster ID mismatch

### DIFF
--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -15,9 +15,12 @@ package instance
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiup/pkg/tidbver"
@@ -235,4 +238,41 @@ func (inst *PDInstance) LogFile() string {
 // Addr return the listen address of PD
 func (inst *PDInstance) Addr() string {
 	return utils.JoinHostPort(AdvertiseHost(inst.Host), inst.StatusPort)
+}
+
+// Ready returns nil when PD is ready to serve.
+func (inst *PDInstance) Ready(ctx context.Context) error {
+	url := fmt.Sprintf("http://%s/pd/api/v1/members", inst.Addr())
+
+	var r struct {
+		Header struct {
+			ClusterID uint64 `json:"cluster_id"`
+		} `json:"header"`
+	}
+
+	ready := func() bool {
+		resp, err := http.Get(url)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == 200 {
+			err = json.NewDecoder(resp.Body).Decode(&r)
+			return err == nil && r.Header.ClusterID != 0
+		}
+		return false
+	}
+
+	for {
+		if ready() {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+			// retry
+		}
+	}
 }

--- a/components/playground/playground.go
+++ b/components/playground/playground.go
@@ -1285,6 +1285,7 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 
 	anyPumpReady := false
 	allDMMasterReady := false
+	allPDReady := false
 	// Start all instance except tiflash.
 	err := p.WalkInstances(func(cid string, ins instance.Instance) error {
 		if cid == spec.ComponentTiFlash {
@@ -1294,6 +1295,19 @@ func (p *Playground) bootCluster(ctx context.Context, env *environment.Environme
 		if cid == spec.ComponentDMWorker && !allDMMasterReady {
 			p.waitAllDMMasterUp()
 			allDMMasterReady = true
+		}
+
+		// wait all PD ready before starting TiDB to avoid cluster ID mismatch
+		if cid == spec.ComponentTiDB && !allPDReady {
+			for _, pd := range p.pds {
+				pdCtx, cancel := context.WithTimeout(ctx, time.Second*120)
+				err := pd.Ready(pdCtx)
+				cancel()
+				if err != nil {
+					return errors.Annotatef(err, "failed to wait PD %s to be ready", pd.Addr())
+				}
+			}
+			allPDReady = true
 		}
 
 		err := p.startInstance(ctx, ins)


### PR DESCRIPTION

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #2678

### What is changed and how it works?

Test PD `pd/api/v1/members` API returns non-zero clusterID in response before starting TiDB server to avoid TiDB server gets incorrect cluster-id 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Test multiple times with `tiup playground v6.1.7 --db 1 --pd 1 --kv 3 --tiflash 0`

- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
NONE
```
