### PR TITLE
playground: Change date-separator value to 'none' for fts

### DIFF
--- a/pkg/cluster/api/cdcapi.go
+++ b/pkg/cluster/api/cdcapi.go
@@ -366,6 +366,7 @@ func (c *CDCOpenAPIClient) CreateChangefeed(bucket, prefix, endpoint, accessKey,
 	}
 
 	sinkConfig := map[string]any{
+         // Avoid encountering the issue of date in the CDC output path. https://github.com/pingcap/ticdc/issues/4073
 		"date-separator": "none",
 	}
 


### PR DESCRIPTION
What problem does this PR solve?
Solving the problem of time rewind caused by 'date path' at Object Storage for tici.

Related to ticdc issue  [#4073](https://github.com/pingcap/ticdc/issues/4073).

What is changed and how it works?
Add config 'sink_config' when create changefeed, set the `date-separator` value `"none"` for fts.

### Check List
Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes
- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects
- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes
- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

Release notes:
```
NONE
```
