### PR TITLE
cluster: unify default tiflash logger size/count with doc

### DIFF
--- a/pkg/cluster/spec/tiflash.go
+++ b/pkg/cluster/spec/tiflash.go
@@ -556,8 +556,6 @@ server_configs:
     status.metrics_port: %[8]d
     logger.errorlog: "%[2]s/tiflash_error.log"
     logger.log: "%[2]s/tiflash.log"
-    logger.count: 10
-    logger.size: "100M"
     %[13]s
     raft.pd_addr: "%[9]s"
     %[12]s


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In the doc https://docs.pingcap.com/tidb/stable/tiflash-configuration/#logger, the `logger.size` and `logger.count` should be `100M` and `10`, this is not consistent with the default value in the tiup cluster.

close #2684

### What is changed and how it works?
Unify the logger size and count with doc

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Remove hardcoded TiFlash logger.size/logger.count from TiUP Cluster’s generated config so TiFlash uses its built-in default log rotation settings.
```
