### PR TITLE
WIP: Make TiUP compatible with usql v0.19.19

### DIFF
--- a/components/client/main.go
+++ b/components/client/main.go
@@ -23,6 +23,7 @@ import (
 	"os/user"
 	"path"
 
+	"github.com/go-git/go-billy/v5/osfs"
 	ui "github.com/gizak/termui/v3"
 	"github.com/gizak/termui/v3/widgets"
 	"github.com/pingcap/tiup/pkg/environment"
@@ -98,11 +99,12 @@ func connect(target string) error {
 	if err != nil {
 		return fmt.Errorf("can't get current user: %s", err.Error())
 	}
-	l, err := rline.New(false, "", env.HistoryFile(u))
+	l, err := rline.New(false, false, false, "", env.HistoryFile(u))
 	if err != nil {
 		return fmt.Errorf("can't open history file: %s", err.Error())
 	}
-	h := handler.New(l, u, os.Getenv(localdata.EnvNameInstanceDataDir), true)
+	dataDir := os.Getenv(localdata.EnvNameInstanceDataDir)
+	h := handler.New(l, u, dataDir, osfs.New(dataDir), true)
 	if err = h.Open(context.TODO(), ep.dsn); err != nil {
 		return fmt.Errorf("can't open connection to %s: %s", ep.dsn, err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
 	github.com/vishvananda/netlink v0.0.0-20210530105856-14e832ae1e8f
-	github.com/xo/usql v0.14.0
+	github.com/xo/usql v0.19.19
 	go.etcd.io/etcd/client/pkg/v3 v3.5.7
 	go.etcd.io/etcd/client/v3 v3.5.7
 	go.uber.org/atomic v1.11.0


### PR DESCRIPTION
**This is a draft as I am evaluating updating directly to latest usql v0.20.8 as an alternative.**

---

As the  golang-github-xo-usql-dev package v0.19.19 in Debian is newer than the v0.9.5 in go.mod of TiUP, the Debian build failed on:

    src/github.com/pingcap/tiup/components/client/main.go:98:33: not enough arguments in call to rline.New
    	have (bool, string, string)
    	want (bool, bool, bool, string, string)
    src/github.com/pingcap/tiup/components/client/main.go:102:70: not enough arguments in call to handler.New
    	have (rline.IO, *user.User, string, bool)
    	want (rline.IO, *user.User, string, billy.Filesystem, bool)

Apply these changes on TiUP to make it compatible:

- `rline.New` now requires two additional boolean arguments. These are set to `false` as safe defaults.

- `handler.New` now requires a `billy.Filesystem` argument. This is provided by importing `osfs` and creating a new `osfs.New` instance using the instance data directory.

### What problem does this PR solve? <!--add issue link with summary if exists-->

Closes: #2588.

Origin: https://salsa.debian.org/go-team/packages/tiup/-/blob/b12259882f8fdca0d9b4dec3ebc9c5ba99dffc03/debian/patches/0002-Make-TiUP-compatible-with-usql-v0.19.19.patch

### What is changed and how it works?

See commit message and details.

### Check List

Tests

- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

Side effects

- [x] Breaking backward compatibility (won't work with old usql anymore)

Related changes
-

Release notes:

```release-note
NONE
```
