### PR TITLE
playground: Add config 'use-table-id-as-path=true' while creating changefeed for TiCI

### DIFF
--- a/pkg/cluster/api/cdcapi.go
+++ b/pkg/cluster/api/cdcapi.go
@@ -348,6 +348,7 @@ func (c *CDCOpenAPIClient) CreateChangefeed(bucket, prefix, endpoint, accessKey,
 	options = append(options, "protocol=canal-json")
 	options = append(options, "enable-tidb-extension=true")
 	options = append(options, "output-row-key=true")
+	// Use table id as path instead of table name in the cdc output file path. https://github.com/pingcap/ticdc/issues/4357
 	options = append(options, "use-table-id-as-path=true")
 	if accessKey != "" && secretKey != "" {
 		options = append(options, fmt.Sprintf("access-key=%s", accessKey))


### PR DESCRIPTION
Add config 'use-table-id-as-path=true' while creating changefeed for TiCI.

### What is changed and how it works?

To enable tici to support rebuilding tables with the same name, ticdc supports configuring the path to use the table_id [(#4356)](https://github.com/pingcap/ticdc/pull/4356). 

To ensure that changefeed creation uses the table_id as the path when using tici, playground need the `use-table-id-as-path=true` configuration enabled by default.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
```release-note
NONE
```
