### PR TITLE
fix: disable ANSI escape sequences when stdout is not a TTY

### DIFF
--- a/pkg/repository/progress.go
+++ b/pkg/repository/progress.go
@@ -15,8 +15,10 @@ package repository
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cheggaaa/pb/v3"
+	"golang.org/x/term"
 )
 
 // DisableProgress implement the DownloadProgress interface and disable download progress
@@ -42,7 +44,17 @@ func (p *ProgressBar) Start(url string, size int64) {
 	p.size = size
 	p.bar = pb.Start64(size)
 	p.bar.Set(pb.Bytes, true)
-	p.bar.SetTemplateString(fmt.Sprintf(`download %s {{counters . }} {{percent . }} {{speed . "%%s/s" "? MiB/s"}}`, url))
+
+	// Check if stdout is a TTY
+	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
+
+	// Use a simple template without ANSI escape sequences when stdout is not a TTY
+	if isTTY {
+		p.bar.SetTemplateString(fmt.Sprintf(`download %s {{counters . }} {{percent . }} {{speed . "%%s/s" "? MiB/s"}}`, url))
+	} else {
+		// Simple template for non-TTY output (no progress bar, just text)
+		p.bar.SetTemplateString(fmt.Sprintf(`download %s {{counters . }}`, url))
+	}
 }
 
 // SetCurrent implement the DownloadProgress interface

--- a/pkg/tui/progress/multi_bar.go
+++ b/pkg/tui/progress/multi_bar.go
@@ -76,13 +76,26 @@ func (b *MultiBar) StopRenderLoop() {
 }
 
 func (b *MultiBar) preRender() {
-	// Preserve space for the bar
-	fmt.Print(strings.Repeat("\n", len(b.bars)+1))
+	// Preserve space for the bar only if TTY
+	if isTTY.Load() {
+		fmt.Print(strings.Repeat("\n", len(b.bars)+1))
+	}
 }
 
 func (b *MultiBar) render() {
 	f := bufio.NewWriter(os.Stdout)
 
+	// Non-TTY mode: simple line-by-line output
+	if !isTTY.Load() {
+		for _, bar := range b.bars {
+			bar.core.renderTo(f)
+			_, _ = fmt.Fprintln(f)
+		}
+		_ = f.Flush()
+		return
+	}
+
+	// TTY mode: use cursor movements for dynamic updates
 	y := int(termSizeHeight.Load()) - 1
 	movedY := 0
 	for i := len(b.bars) - 1; i >= 0; i-- {

--- a/pkg/tui/progress/single_bar.go
+++ b/pkg/tui/progress/single_bar.go
@@ -54,7 +54,13 @@ func (b *singleBarCore) renderDoneOrError(w io.Writer, dp *DisplayProps) {
 	if len(dp.Detail) > 0 {
 		detail = ": " + dp.Detail
 	}
-	_, _ = fmt.Fprintf(w, "%s ... %s%s", displayPrefix, tailColor.Sprint(tail), detail)
+
+	// Disable color if not a TTY
+	if isTTY.Load() {
+		_, _ = fmt.Fprintf(w, "%s ... %s%s", displayPrefix, tailColor.Sprint(tail), detail)
+	} else {
+		_, _ = fmt.Fprintf(w, "%s ... %s%s", displayPrefix, tail, detail)
+	}
 }
 
 func (b *singleBarCore) renderSpinner(w io.Writer, dp *DisplayProps) {
@@ -76,12 +82,17 @@ func (b *singleBarCore) renderSpinner(w io.Writer, dp *DisplayProps) {
 		displayPrefix = runewidth.Truncate(dp.Prefix, width-midWidth, "")
 		displaySuffix = ""
 	}
-	_, _ = fmt.Fprintf(w, "%s ... %s %s",
-		displayPrefix,
-		colorSpinner.Sprintf("%c", spinnerText[b.spinnerFrame]),
-		displaySuffix)
 
-	b.spinnerFrame = (b.spinnerFrame + 1) % len(spinnerText)
+	// Disable color and spinner animation if not a TTY
+	if isTTY.Load() {
+		_, _ = fmt.Fprintf(w, "%s ... %s %s",
+			displayPrefix,
+			colorSpinner.Sprintf("%c", spinnerText[b.spinnerFrame]),
+			displaySuffix)
+		b.spinnerFrame = (b.spinnerFrame + 1) % len(spinnerText)
+	} else {
+		_, _ = fmt.Fprintf(w, "%s ... %s", displayPrefix, displaySuffix)
+	}
 }
 
 func (b *singleBarCore) renderTo(w io.Writer) {
@@ -141,8 +152,10 @@ func (b *SingleBar) StopRenderLoop() {
 }
 
 func (b *SingleBar) preRender() {
-	// Preserve space for the bar
-	fmt.Println("")
+	// Preserve space for the bar only if TTY
+	if isTTY.Load() {
+		fmt.Println("")
+	}
 }
 
 func (b *SingleBar) render() {

--- a/pkg/tui/progress/terminal.go
+++ b/pkg/tui/progress/terminal.go
@@ -22,11 +22,13 @@ import (
 
 	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 )
 
 var (
 	termSizeWidth  = atomic.Int32{}
 	termSizeHeight = atomic.Int32{}
+	isTTY          = atomic.Bool{}
 )
 
 func updateTerminalSize() error {
@@ -40,22 +42,38 @@ func updateTerminalSize() error {
 }
 
 func moveCursorUp(w io.Writer, n int) {
+	if !isTTY.Load() {
+		return
+	}
 	_, _ = fmt.Fprintf(w, "\033[%dA", n)
 }
 
 func moveCursorDown(w io.Writer, n int) {
+	if !isTTY.Load() {
+		return
+	}
 	_, _ = fmt.Fprintf(w, "\033[%dB", n)
 }
 
 func moveCursorToLineStart(w io.Writer) {
+	if !isTTY.Load() {
+		_, _ = fmt.Fprintf(w, "\n")
+		return
+	}
 	_, _ = fmt.Fprintf(w, "\r")
 }
 
 func clearLine(w io.Writer) {
+	if !isTTY.Load() {
+		return
+	}
 	_, _ = fmt.Fprintf(w, "\033[2K")
 }
 
 func init() {
+	// Check if stdout is a TTY
+	isTTY.Store(term.IsTerminal(int(os.Stdout.Fd())))
+
 	_ = updateTerminalSize()
 
 	sigCh := make(chan os.Signal, 1)


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #2657 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation


Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
disable ANSI escape sequences when stdout is not a TTY
```
