### PR TITLE
cluster: abort force scale-in when PD delete fails

### DIFF
--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -800,16 +800,6 @@ func (pc *PDClient) IsUp(host string) (bool, error) {
 // DelStore deletes stores from a (TiKV) host
 // The host parameter should be in format of IP:Port, that matches store's address
 func (pc *PDClient) DelStore(host string, retryOpt *utils.RetryOption) error {
-	return pc.deleteStore(host, retryOpt, false)
-}
-
-// DelStorePhysicallyDestroyed deletes a store and tells PD that the store has
-// been physically destroyed, so PD can bypass replica-count checks.
-func (pc *PDClient) DelStorePhysicallyDestroyed(host string, retryOpt *utils.RetryOption) error {
-	return pc.deleteStore(host, retryOpt, true)
-}
-
-func (pc *PDClient) deleteStore(host string, retryOpt *utils.RetryOption, physicallyDestroyed bool) error {
 	// get info of current stores
 	storeInfo, err := pc.GetCurrentStore(host)
 	if err != nil {
@@ -823,9 +813,6 @@ func (pc *PDClient) deleteStore(host string, retryOpt *utils.RetryOption, physic
 	storeID := storeInfo.Store.Id
 
 	cmd := fmt.Sprintf("%s/%d", pdStoreURI, storeID)
-	if physicallyDestroyed {
-		cmd += "?force=true"
-	}
 	endpoints := pc.getEndpoints(cmd)
 
 	logger := pc.l()

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -800,6 +800,16 @@ func (pc *PDClient) IsUp(host string) (bool, error) {
 // DelStore deletes stores from a (TiKV) host
 // The host parameter should be in format of IP:Port, that matches store's address
 func (pc *PDClient) DelStore(host string, retryOpt *utils.RetryOption) error {
+	return pc.delStore(host, retryOpt, false)
+}
+
+// DelStorePhysicallyDestroyed deletes a store and tells PD that the store has
+// been physically destroyed, so PD can bypass replica-count checks.
+func (pc *PDClient) DelStorePhysicallyDestroyed(host string, retryOpt *utils.RetryOption) error {
+	return pc.delStore(host, retryOpt, true)
+}
+
+func (pc *PDClient) delStore(host string, retryOpt *utils.RetryOption, physicallyDestroyed bool) error {
 	// get info of current stores
 	storeInfo, err := pc.GetCurrentStore(host)
 	if err != nil {
@@ -813,6 +823,9 @@ func (pc *PDClient) DelStore(host string, retryOpt *utils.RetryOption) error {
 	storeID := storeInfo.Store.Id
 
 	cmd := fmt.Sprintf("%s/%d", pdStoreURI, storeID)
+	if physicallyDestroyed {
+		cmd += "?force=true"
+	}
 	endpoints := pc.getEndpoints(cmd)
 
 	logger := pc.l()

--- a/pkg/cluster/api/pdapi.go
+++ b/pkg/cluster/api/pdapi.go
@@ -800,16 +800,16 @@ func (pc *PDClient) IsUp(host string) (bool, error) {
 // DelStore deletes stores from a (TiKV) host
 // The host parameter should be in format of IP:Port, that matches store's address
 func (pc *PDClient) DelStore(host string, retryOpt *utils.RetryOption) error {
-	return pc.delStore(host, retryOpt, false)
+	return pc.deleteStore(host, retryOpt, false)
 }
 
 // DelStorePhysicallyDestroyed deletes a store and tells PD that the store has
 // been physically destroyed, so PD can bypass replica-count checks.
 func (pc *PDClient) DelStorePhysicallyDestroyed(host string, retryOpt *utils.RetryOption) error {
-	return pc.delStore(host, retryOpt, true)
+	return pc.deleteStore(host, retryOpt, true)
 }
 
-func (pc *PDClient) delStore(host string, retryOpt *utils.RetryOption, physicallyDestroyed bool) error {
+func (pc *PDClient) deleteStore(host string, retryOpt *utils.RetryOption, physicallyDestroyed bool) error {
 	// get info of current stores
 	storeInfo, err := pc.GetCurrentStore(host)
 	if err != nil {

--- a/pkg/cluster/api/pdapi_test.go
+++ b/pkg/cluster/api/pdapi_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
+	"github.com/pingcap/tiup/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelStorePhysicallyDestroyedQuery(t *testing.T) {
+	tests := []struct {
+		name                   string
+		delStore               func(*PDClient, string, *utils.RetryOption) error
+		expectedDeleteRawQuery string
+	}{
+		{
+			name:                   "regular delete",
+			delStore:               (*PDClient).DelStore,
+			expectedDeleteRawQuery: "",
+		},
+		{
+			name:                   "physically destroyed delete",
+			delStore:               (*PDClient).DelStorePhysicallyDestroyed,
+			expectedDeleteRawQuery: "force=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var deleted atomic.Bool
+			var deleteRawQuery string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/pd/api/v1/stores":
+					state := metapb.StoreState_Up
+					if deleted.Load() {
+						state = metapb.StoreState_Offline
+					}
+					fmt.Fprintf(w, `{"count":1,"stores":[{"store":{"id":42,"address":"store-1:20160","state":%d}}]}`, state)
+				case r.Method == http.MethodDelete && r.URL.Path == "/pd/api/v1/store/42":
+					deleteRawQuery = r.URL.RawQuery
+					deleted.Store(true)
+					fmt.Fprint(w, `"The store is set as Offline."`)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			logger := logprinter.NewLogger("")
+			logger.SetStdout(io.Discard)
+			logger.SetStderr(io.Discard)
+			ctx := context.WithValue(context.Background(), logprinter.ContextKeyLogger, logger)
+			client := NewPDClient(ctx, []string{strings.TrimPrefix(server.URL, "http://")}, time.Second, nil)
+
+			err := tt.delStore(client, "store-1:20160", &utils.RetryOption{
+				Delay:   time.Millisecond,
+				Timeout: time.Second,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedDeleteRawQuery, deleteRawQuery)
+		})
+	}
+}

--- a/pkg/cluster/api/pdapi_test.go
+++ b/pkg/cluster/api/pdapi_test.go
@@ -30,60 +30,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDelStorePhysicallyDestroyedQuery(t *testing.T) {
-	tests := []struct {
-		name                   string
-		delStore               func(*PDClient, string, *utils.RetryOption) error
-		expectedDeleteRawQuery string
-	}{
-		{
-			name:                   "regular delete",
-			delStore:               (*PDClient).DelStore,
-			expectedDeleteRawQuery: "",
-		},
-		{
-			name:                   "physically destroyed delete",
-			delStore:               (*PDClient).DelStorePhysicallyDestroyed,
-			expectedDeleteRawQuery: "force=true",
-		},
-	}
+func TestDelStoreDoesNotUseForceQuery(t *testing.T) {
+	var deleted atomic.Bool
+	var deleteRawQuery string
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var deleted atomic.Bool
-			var deleteRawQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/pd/api/v1/stores":
+			state := metapb.StoreState_Up
+			if deleted.Load() {
+				state = metapb.StoreState_Offline
+			}
+			fmt.Fprintf(w, `{"count":1,"stores":[{"store":{"id":42,"address":"store-1:20160","state":%d}}]}`, state)
+		case r.Method == http.MethodDelete && r.URL.Path == "/pd/api/v1/store/42":
+			deleteRawQuery = r.URL.RawQuery
+			deleted.Store(true)
+			fmt.Fprint(w, `"The store is set as Offline."`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
 
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch {
-				case r.Method == http.MethodGet && r.URL.Path == "/pd/api/v1/stores":
-					state := metapb.StoreState_Up
-					if deleted.Load() {
-						state = metapb.StoreState_Offline
-					}
-					fmt.Fprintf(w, `{"count":1,"stores":[{"store":{"id":42,"address":"store-1:20160","state":%d}}]}`, state)
-				case r.Method == http.MethodDelete && r.URL.Path == "/pd/api/v1/store/42":
-					deleteRawQuery = r.URL.RawQuery
-					deleted.Store(true)
-					fmt.Fprint(w, `"The store is set as Offline."`)
-				default:
-					http.NotFound(w, r)
-				}
-			}))
-			defer server.Close()
+	logger := logprinter.NewLogger("")
+	logger.SetStdout(io.Discard)
+	logger.SetStderr(io.Discard)
+	ctx := context.WithValue(context.Background(), logprinter.ContextKeyLogger, logger)
+	client := NewPDClient(ctx, []string{strings.TrimPrefix(server.URL, "http://")}, time.Second, nil)
 
-			logger := logprinter.NewLogger("")
-			logger.SetStdout(io.Discard)
-			logger.SetStderr(io.Discard)
-			ctx := context.WithValue(context.Background(), logprinter.ContextKeyLogger, logger)
-			client := NewPDClient(ctx, []string{strings.TrimPrefix(server.URL, "http://")}, time.Second, nil)
+	err := client.DelStore("store-1:20160", &utils.RetryOption{
+		Delay:   time.Millisecond,
+		Timeout: time.Second,
+	})
 
-			err := tt.delStore(client, "store-1:20160", &utils.RetryOption{
-				Delay:   time.Millisecond,
-				Timeout: time.Second,
-			})
-
-			require.NoError(t, err)
-			require.Equal(t, tt.expectedDeleteRawQuery, deleteRawQuery)
-		})
-	}
+	require.NoError(t, err)
+	require.Empty(t, deleteRawQuery)
 }

--- a/pkg/cluster/operation/scale_in.go
+++ b/pkg/cluster/operation/scale_in.go
@@ -192,8 +192,8 @@ func ScaleInCluster(
 				compName := component.Name()
 
 				if compName != spec.ComponentPump && compName != spec.ComponentDrainer {
-					if err := deletePhysicallyDestroyedMember(ctx, component, instance, pdClient, binlogClient, options.APITimeout); err != nil {
-						logger.Warnf("failed to delete %s: %v", compName, err)
+					if err := deleteMember(ctx, component, instance, pdClient, binlogClient, options.APITimeout); err != nil {
+						return errors.Trace(err)
 					}
 				}
 
@@ -388,29 +388,6 @@ func deleteMember(
 	binlogClient *api.BinlogClient,
 	timeoutSecond uint64,
 ) error {
-	return deleteMemberWithStoreDelete(ctx, component, instance, pdClient, pdClient.DelStore, binlogClient, timeoutSecond)
-}
-
-func deletePhysicallyDestroyedMember(
-	ctx context.Context,
-	component spec.Component,
-	instance spec.Instance,
-	pdClient *api.PDClient,
-	binlogClient *api.BinlogClient,
-	timeoutSecond uint64,
-) error {
-	return deleteMemberWithStoreDelete(ctx, component, instance, pdClient, pdClient.DelStorePhysicallyDestroyed, binlogClient, timeoutSecond)
-}
-
-func deleteMemberWithStoreDelete(
-	ctx context.Context,
-	component spec.Component,
-	instance spec.Instance,
-	pdClient *api.PDClient,
-	delStore func(string, *utils.RetryOption) error,
-	binlogClient *api.BinlogClient,
-	timeoutSecond uint64,
-) error {
 	timeoutOpt := &utils.RetryOption{
 		Timeout: time.Second * time.Duration(timeoutSecond),
 		Delay:   time.Second * 5,
@@ -418,12 +395,12 @@ func deleteMemberWithStoreDelete(
 
 	switch component.Name() {
 	case spec.ComponentTiKV:
-		if err := delStore(instance.ID(), timeoutOpt); err != nil {
+		if err := pdClient.DelStore(instance.ID(), timeoutOpt); err != nil {
 			return err
 		}
 	case spec.ComponentTiFlash:
 		addr := utils.JoinHostPort(instance.GetHost(), instance.(*spec.TiFlashInstance).GetServicePort())
-		if err := delStore(addr, timeoutOpt); err != nil {
+		if err := pdClient.DelStore(addr, timeoutOpt); err != nil {
 			return err
 		}
 	case spec.ComponentPD:

--- a/pkg/cluster/operation/scale_in.go
+++ b/pkg/cluster/operation/scale_in.go
@@ -192,7 +192,7 @@ func ScaleInCluster(
 				compName := component.Name()
 
 				if compName != spec.ComponentPump && compName != spec.ComponentDrainer {
-					if err := deleteMember(ctx, component, instance, pdClient, binlogClient, options.APITimeout); err != nil {
+					if err := deletePhysicallyDestroyedMember(ctx, component, instance, pdClient, binlogClient, options.APITimeout); err != nil {
 						logger.Warnf("failed to delete %s: %v", compName, err)
 					}
 				}
@@ -388,6 +388,29 @@ func deleteMember(
 	binlogClient *api.BinlogClient,
 	timeoutSecond uint64,
 ) error {
+	return deleteMemberWithStoreDelete(ctx, component, instance, pdClient, pdClient.DelStore, binlogClient, timeoutSecond)
+}
+
+func deletePhysicallyDestroyedMember(
+	ctx context.Context,
+	component spec.Component,
+	instance spec.Instance,
+	pdClient *api.PDClient,
+	binlogClient *api.BinlogClient,
+	timeoutSecond uint64,
+) error {
+	return deleteMemberWithStoreDelete(ctx, component, instance, pdClient, pdClient.DelStorePhysicallyDestroyed, binlogClient, timeoutSecond)
+}
+
+func deleteMemberWithStoreDelete(
+	ctx context.Context,
+	component spec.Component,
+	instance spec.Instance,
+	pdClient *api.PDClient,
+	delStore func(string, *utils.RetryOption) error,
+	binlogClient *api.BinlogClient,
+	timeoutSecond uint64,
+) error {
 	timeoutOpt := &utils.RetryOption{
 		Timeout: time.Second * time.Duration(timeoutSecond),
 		Delay:   time.Second * 5,
@@ -395,12 +418,12 @@ func deleteMember(
 
 	switch component.Name() {
 	case spec.ComponentTiKV:
-		if err := pdClient.DelStore(instance.ID(), timeoutOpt); err != nil {
+		if err := delStore(instance.ID(), timeoutOpt); err != nil {
 			return err
 		}
 	case spec.ComponentTiFlash:
 		addr := utils.JoinHostPort(instance.GetHost(), instance.(*spec.TiFlashInstance).GetServicePort())
-		if err := pdClient.DelStore(addr, timeoutOpt); err != nil {
+		if err := delStore(addr, timeoutOpt); err != nil {
 			return err
 		}
 	case spec.ComponentPD:


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Close https://github.com/pingcap/tiup/issues/2705

When `tiup cluster scale-in --force` scales in a TiKV instance, TiUP currently ignores errors from deleting the store/member in PD, then continues to stop/destroy the instance and remove it from the topology.

If PD rejects the delete-store request, for example because removing the TiKV would make the number of remaining up stores less than `max-replicas`, the store remains `Up` / `Serving` in PD while TiUP no longer shows the instance in `tiup cluster display`.

### What is changed and how it works?

- Keep using the normal PD delete-store API for TiKV/TiFlash scale-in. This PR does not mark the store as physically destroyed and does not pass PD's `force` query.
- In the `scale-in --force` path, return the PD delete error immediately instead of warning and continuing.
- This prevents TiUP from stopping/destroying the instance and updating topology when PD has not accepted the store/member deletion.
- Add a unit test to ensure `PDClient.DelStore` does not send the `force` query parameter.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

Release notes:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tiup/blob/master/doc/dev/release-note-guide.md) before writing the release note.
-->
```release-note
Fix an issue that `tiup cluster scale-in --force` could remove a TiKV instance from topology even when PD rejected deleting its store.
```
