### PR TITLE
cluster: make SELinux and THP check auto-fixes work on non-RHEL hosts

### DIFF
--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -686,7 +686,10 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder, sy
 	case operator.CheckNameTHP:
 		t.Shell(host,
 			fmt.Sprintf(
-				`if [ -d %[1]s ]; then echo never > %[1]s/enabled; fi && %s`,
+				// grubby only exists on RHEL-family distros; skip the persistent
+				// kernel argument when it's not available (e.g. Debian/Ubuntu)
+				// instead of failing the whole apply.
+				`if [ -d %[1]s ]; then echo never > %[1]s/enabled; fi && if command -v grubby >/dev/null 2>&1; then %s; fi`,
 				"/sys/kernel/mm/transparent_hugepage",
 				`grubby --update-kernel=ALL --args="transparent_hugepage=never"`,
 			),

--- a/pkg/cluster/operation/check.go
+++ b/pkg/cluster/operation/check.go
@@ -608,9 +608,15 @@ func CheckSELinuxStatus(ctx context.Context, e ctxt.Executor, sudo bool) *CheckR
 		Command: "getenforce",
 		Sudo:    sudo,
 	})
-	stdout, stderr, err := m.Execute(ctx, e)
+	stdout, _, err := m.Execute(ctx, e)
 	if err != nil {
-		result.Err = fmt.Errorf("%w %s", err, stderr)
+		// getenforce is unavailable (e.g. SELinux userspace tools are not
+		// installed, as on most Debian/Ubuntu hosts), which means SELinux is
+		// not enforcing on this host. Treat it as disabled rather than a
+		// failure, so we don't trigger a fix that edits a non-existent
+		// /etc/selinux/config. The configuration is still checked separately
+		// by CheckSELinuxConf.
+		result.Msg = "getenforce not available, assuming SELinux is disabled"
 		return result
 	}
 	out := strings.Trim(string(stdout), "\n")


### PR DESCRIPTION
### What problem does this PR solve?

Two recently-merged checks added auto-fix commands that assume a RHEL-family host. They break `tiup cluster check --apply` (and the `cluster`/`dm` integration tests) on Debian/Ubuntu, where the assumed tools/files don't exist. Both currently fail on `master`.

1. **SELinux status check (#2496).** `CheckSELinuxStatus` runs `getenforce`. On hosts without the SELinux userspace tools (most Debian/Ubuntu, including the CI containers) the command is missing, so the check is reported as **Fail**. With `--apply` that triggers the SELinux fix:
   ```bash
   sed -i 's/.../' /etc/selinux/config && setenforce 0
   ```
   but `/etc/selinux/config` doesn't exist there → `sed: can't read /etc/selinux/config: No such file or directory` → the run aborts.

2. **THP check (#2498).** The THP auto-fix was extended with:
   ```bash
   grubby --update-kernel=ALL --args="transparent_hugepage=never"
   ```
   `grubby` is a RHEL-family tool and is absent on Debian/Ubuntu → `grubby: command not found` (exit 127) → the run aborts.

### What is changed and how it works?

- **`CheckSELinuxStatus`**: treat a `getenforce` execution error (binary absent → SELinux not installed/enforcing) as **disabled** rather than a failure, restoring the lenient pre-#2496 behavior. `Enforcing` still fails and `Permissive` still warns. The configuration is still validated independently by `CheckSELinuxConf`.
- **THP auto-fix**: guard the `grubby` call with `command -v grubby` so the persistent kernel argument is set where `grubby` exists, but skipped on hosts without it. The runtime setting (`echo never > .../enabled`) still applies everywhere.

Together these make the SELinux and THP checks Debian/non-RHEL safe and unblock the cluster/dm integration tests.

### Check List

- [x] Unit test (`go test ./pkg/cluster/operation/... ./pkg/cluster/manager/...`)
- [x] Integration test (cluster/dm CI on this PR)

### Side effects

- None on RHEL-family hosts; behavior there is unchanged.

### Related changes

- Follow-up to #2496 and #2498.
