### PR TITLE
cluster: refresh TLS certs after rename

### DIFF
--- a/pkg/cluster/manager/check.go
+++ b/pkg/cluster/manager/check.go
@@ -674,7 +674,7 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder, sy
 		t.Limit(host, fields[0], fields[1], fields[2], fields[3], sudo)
 		msg = fmt.Sprintf("will try to set '%s'", color.HiBlueString(res.Msg))
 	case operator.CheckNameSELinuxConf, operator.CheckNameSELinuxStatus:
-		t.Shell(host,
+		t.ShellIgnoreNonZero(host,
 			fmt.Sprintf(
 				"sed -i 's/^[[:blank:]]*SELINUX=enforcing/SELINUX=disabled/g' %s && %s",
 				"/etc/selinux/config",
@@ -684,7 +684,7 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder, sy
 			sudo)
 		msg = fmt.Sprintf("will try to %s, reboot might be needed", color.HiBlueString("disable SELinux"))
 	case operator.CheckNameTHP:
-		t.Shell(host,
+		t.ShellIgnoreNonZero(host,
 			fmt.Sprintf(
 				`if [ -d %[1]s ]; then echo never > %[1]s/enabled; fi && %s`,
 				"/sys/kernel/mm/transparent_hugepage",
@@ -697,7 +697,7 @@ func fixFailedChecks(host string, res *operator.CheckResult, t *task.Builder, sy
 		// not applying swappiness setting here, it should be fixed
 		// in the sysctl check
 		// t.Sysctl(host, "vm.swappiness", "0")
-		t.Shell(host,
+		t.ShellIgnoreNonZero(host,
 			"swapoff -a || exit 0", // ignore failure
 			"", sudo,
 		)

--- a/pkg/cluster/manager/manager_test.go
+++ b/pkg/cluster/manager/manager_test.go
@@ -16,7 +16,9 @@ package manager
 import (
 	"testing"
 
+	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
+	"github.com/pingcap/tiup/pkg/cluster/task"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -115,4 +117,39 @@ func TestDeduplicateCheckResult(t *testing.T) {
 	if len(checkResults) != 1 {
 		t.Errorf("Deduplicate Check Result Failed")
 	}
+}
+
+func TestFixFailedChecksSELinuxCommandIsBestEffort(t *testing.T) {
+	b := task.NewBuilder(nil)
+	msg, err := fixFailedChecks("n1", &operator.CheckResult{Name: operator.CheckNameSELinuxStatus}, b, string(spec.SystemMode))
+	require.NoError(t, err)
+	require.NotEmpty(t, msg)
+
+	cmd := b.Build().String()
+	require.Contains(t, cmd, "sed -i")
+	require.Contains(t, cmd, "setenforce 0")
+	require.Contains(t, cmd, ") || true")
+}
+
+func TestFixFailedChecksTHPCommandIsBestEffort(t *testing.T) {
+	b := task.NewBuilder(nil)
+	msg, err := fixFailedChecks("n1", &operator.CheckResult{Name: operator.CheckNameTHP}, b, string(spec.SystemMode))
+	require.NoError(t, err)
+	require.NotEmpty(t, msg)
+
+	cmd := b.Build().String()
+	require.Contains(t, cmd, "transparent_hugepage")
+	require.Contains(t, cmd, "grubby --update-kernel=ALL")
+	require.Contains(t, cmd, ") || true")
+}
+
+func TestFixFailedChecksSwapCommandIsBestEffort(t *testing.T) {
+	b := task.NewBuilder(nil)
+	msg, err := fixFailedChecks("n1", &operator.CheckResult{Name: operator.CheckNameSwap}, b, string(spec.SystemMode))
+	require.NoError(t, err)
+	require.NotEmpty(t, msg)
+
+	cmd := b.Build().String()
+	require.Contains(t, cmd, "swapoff -a")
+	require.Contains(t, cmd, ") || true")
 }

--- a/pkg/cluster/manager/rename.go
+++ b/pkg/cluster/manager/rename.go
@@ -14,11 +14,14 @@
 package manager
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/pingcap/tiup/pkg/cluster/clusterutil"
+	"github.com/pingcap/tiup/pkg/cluster/ctxt"
+	"github.com/pingcap/tiup/pkg/cluster/executor"
 	operator "github.com/pingcap/tiup/pkg/cluster/operation"
 	"github.com/pingcap/tiup/pkg/cluster/spec"
 	"github.com/pingcap/tiup/pkg/tui"
@@ -53,7 +56,7 @@ func (m *Manager) Rename(name string, opt operator.Options, newName string, skip
 		}
 	}
 
-	_, err := m.meta(name)
+	metadata, err := m.meta(name)
 	if err != nil { // refuse renaming if current cluster topology is not valid
 		return err
 	}
@@ -64,6 +67,30 @@ func (m *Manager) Rename(name string, opt operator.Options, newName string, skip
 
 	m.logger.Infof("Rename cluster `%s` -> `%s` successfully", name, newName)
 
+	if metadata.GetTopology().BaseTopo().GlobalOptions.TLSEnabled {
+		if err := m.refreshTLSAfterRename(newName, opt, metadata); err != nil {
+			return err
+		}
+	}
+
 	opt.Roles = []string{spec.ComponentGrafana, spec.ComponentPrometheus}
 	return m.Reload(newName, opt, false, skipConfirm)
+}
+
+func (m *Manager) refreshTLSAfterRename(name string, opt operator.Options, metadata spec.Metadata) error {
+	sshProxyProps := &tui.SSHConnectionProps{}
+	if opt.SSHType != executor.SSHTypeNone && len(opt.SSHProxyHost) != 0 {
+		var err error
+		sshProxyProps, err = tui.ReadIdentityFileOrPassword(opt.SSHProxyIdentity, opt.SSHProxyUsePassword)
+		if err != nil {
+			return err
+		}
+	}
+
+	t, err := buildTLSTask(m, name, metadata, opt, false, sshProxyProps, nil)
+	if err != nil {
+		return err
+	}
+	ctx := ctxt.New(context.Background(), opt.Concurrency, m.logger)
+	return t.Execute(ctx)
 }

--- a/pkg/cluster/task/builder.go
+++ b/pkg/cluster/task/builder.go
@@ -396,6 +396,18 @@ func (b *Builder) Shell(host, command, cmdID string, sudo bool) *Builder {
 	return b
 }
 
+// ShellIgnoreNonZero runs a shell command on cluster host and ignores the command exit status.
+func (b *Builder) ShellIgnoreNonZero(host, command, cmdID string, sudo bool) *Builder {
+	b.tasks = append(b.tasks, &Shell{
+		host:          host,
+		command:       command,
+		sudo:          sudo,
+		cmdID:         cmdID,
+		ignoreNonZero: true,
+	})
+	return b
+}
+
 // SystemCtl run systemctl on host
 func (b *Builder) SystemCtl(host, unit, action string, daemonReload, checkActive bool, scope string) *Builder {
 	b.tasks = append(b.tasks, &SystemCtl{

--- a/pkg/cluster/task/shell.go
+++ b/pkg/cluster/task/shell.go
@@ -22,12 +22,20 @@ import (
 	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
 )
 
-// Shell is used to create directory on the target host
+// Shell is used to run a shell command on the target host.
 type Shell struct {
-	host    string
-	command string
-	sudo    bool
-	cmdID   string
+	host          string
+	command       string
+	sudo          bool
+	cmdID         string
+	ignoreNonZero bool
+}
+
+func (m *Shell) commandToRun() string {
+	if m.ignoreNonZero {
+		return fmt.Sprintf("(%s) || true", m.command)
+	}
+	return m.command
 }
 
 // Execute implements the Task interface
@@ -37,10 +45,11 @@ func (m *Shell) Execute(ctx context.Context) error {
 		return ErrNoExecutor
 	}
 
+	command := m.commandToRun()
 	ctx.Value(logprinter.ContextKeyLogger).(*logprinter.Logger).
-		Infof("Run command on %s(sudo:%v): %s", m.host, m.sudo, m.command)
+		Infof("Run command on %s(sudo:%v): %s", m.host, m.sudo, command)
 
-	stdout, stderr, err := exec.Execute(ctx, m.command, m.sudo)
+	stdout, stderr, err := exec.Execute(ctx, command, m.sudo)
 	outputID := m.host
 	if m.cmdID != "" {
 		outputID = m.cmdID
@@ -60,5 +69,5 @@ func (m *Shell) Rollback(ctx context.Context) error {
 
 // String implements the fmt.Stringer interface
 func (m *Shell) String() string {
-	return fmt.Sprintf("Shell: host=%s, sudo=%v, command=`%s`", m.host, m.sudo, m.command)
+	return fmt.Sprintf("Shell: host=%s, sudo=%v, command=`%s`", m.host, m.sudo, m.commandToRun())
 }

--- a/pkg/cluster/task/shell_test.go
+++ b/pkg/cluster/task/shell_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiup/pkg/cluster/ctxt"
+	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeShellExecutor struct {
+	command string
+}
+
+func (e *fakeShellExecutor) Execute(_ context.Context, cmd string, _ bool, _ ...time.Duration) ([]byte, []byte, error) {
+	e.command = cmd
+	if strings.HasSuffix(cmd, "|| true") {
+		return nil, nil, nil
+	}
+	return nil, nil, errors.New("command failed")
+}
+
+func (e *fakeShellExecutor) Transfer(_ context.Context, _, _ string, _ bool, _ int, _ bool) error {
+	return nil
+}
+
+func TestShellIgnoreNonZeroWrapsCommand(t *testing.T) {
+	exec := &fakeShellExecutor{}
+	ctx := ctxt.New(context.Background(), 0, logprinter.NewLogger(""))
+	ctxt.GetInner(ctx).SetExecutor("n1", exec)
+
+	err := NewBuilder(nil).ShellIgnoreNonZero("n1", "missing-command", "", true).Build().Execute(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "(missing-command) || true", exec.command)
+}
+
+func TestShellPropagatesCommandFailureByDefault(t *testing.T) {
+	exec := &fakeShellExecutor{}
+	ctx := ctxt.New(context.Background(), 0, logprinter.NewLogger(""))
+	ctxt.GetInner(ctx).SetExecutor("n1", exec)
+
+	err := NewBuilder(nil).Shell("n1", "missing-command", "", true).Build().Execute(ctx)
+	require.Error(t, err)
+	require.Equal(t, "missing-command", exec.command)
+}

--- a/tests/tiup-cluster/script/cmd_subtest.sh
+++ b/tests/tiup-cluster/script/cmd_subtest.sh
@@ -164,6 +164,12 @@ function cmd_subtest() {
     # Test rename
     tiup-cluster $client --yes rename $name "tmp-cluster-name"
     tiup-cluster $client display "tmp-cluster-name"
+    if [ $test_tls = true ]; then
+        local_ca="$HOME/.tiup/storage/cluster/clusters/tmp-cluster-name/tls/ca.crt"
+        local_ca_sum=`sha256sum "$local_ca" | awk '{print $1}'`
+        remote_ca_sum=`ssh -o "StrictHostKeyChecking=no" -o "PasswordAuthentication=no" n1 "sha256sum /home/tidb/deploy/tidb-4000/tls/ca.crt" | awk '{print $1}'`
+        test "$local_ca_sum" = "$remote_ca_sum"
+    fi
     tiup-cluster $client --yes rename "tmp-cluster-name" $name
 
     # Test enable & disable


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

close https://github.com/pingcap/tiup/issues/2702

After renaming a TLS-enabled cluster, TiUP refreshed the topology and reloaded Grafana/Prometheus, but it did not refresh and re-distribute TLS certificates. The remote TiDB nodes could still use certificates generated for the old cluster name, causing certificate mismatch during later operations.

This PR also fixes `tiup cluster check --apply` compatibility issues exposed by the integration tests. Some apply-fix commands are best-effort actions and should not fail the whole check when optional host tools or files are absent, such as `/etc/selinux/config`, `setenforce`, or `grubby` in Debian/container environments.

### What is changed and how it works?

- Refresh TLS certificates after `tiup cluster rename` when the cluster has TLS enabled.
- Reuse the existing local CA and certificate material to regenerate and distribute node certificates and configs for the renamed cluster.
- Extend the integration command script to verify that the local TiUP CA and the remote TiDB node CA remain consistent after rename.
- Add `ShellIgnoreNonZero` for shell tasks whose command exit status is best-effort.
- Use `ShellIgnoreNonZero` for SELinux, THP, and swap apply-fix commands while keeping normal `Shell` failure behavior unchanged.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Ran locally:

- `go test ./pkg/cluster/task ./pkg/cluster/manager`
- `bash -n tests/tiup-cluster/script/cmd_subtest.sh`
- `git diff --check`

CI:

- `integrate-cluster-cmd` passed with the best-effort shell task fix before the cleanup force-push; re-running after the cleaned-up commit stack.

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

Release notes:

```release-note
Refresh TLS certificates after renaming a TLS-enabled cluster to avoid certificate mismatch.
```