### PR TITLE
cmd: stop forwarding root tag flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,10 +43,7 @@ var (
 )
 
 // arguments
-var (
-	binPath string
-	tag     string
-)
+var binPath string
 
 func init() {
 	cobra.EnableCommandSorting = false
@@ -113,11 +110,8 @@ the latest stable version will be downloaded from the repository.`,
 			// TBD: change this flag to subcommand
 
 			// We assume the first unknown parameter is the component name and following
-			// parameters will be transparent passed because registered flags and subcommands
-			// will be parsed correctly.
-			// e.g: tiup --tag mytag --rm playground --db 3 --pd 3 --kv 4
-			//   => run "playground" with parameters "--db 3 --pd 3 --kv 4"
-			// tiup --tag mytag --binpath /xxx/tikv-server tikv
+			// parameters will be transparently passed because registered flags and
+			// subcommands will be parsed correctly.
 			switch args[0] {
 			case "--help", "-h":
 				return cmd.Help()
@@ -147,32 +141,15 @@ the latest stable version will be downloaded from the repository.`,
 				args = args[2:]
 			case "--force-pull":
 				forcePull = true
-			case "--tag", "-T":
-				if len(args) < 2 {
-					return fmt.Errorf("flag %s needs an argument", args[0])
-				}
-				tag = args[1]
-				args = args[2:]
-			}
-
-			// component may use tag from environment variable. as workaround, make tiup set the same tag
-			for i := 0; i < len(args)-1; i++ {
-				if args[i] == "--tag" || args[i] == "-T" {
-					tag = args[i+1]
-				}
 			}
 
 			if len(args) < 1 {
 				return cmd.Help()
 			}
 
-			componentSpec := args[0]
-			args = args[1:]
-			if len(args) > 0 && args[0] == "--" {
-				args = args[1:]
-			}
+			runArgs := parseRootComponentArgs(args, binPath, forcePull)
 
-			return tiupexec.RunComponent(env, tag, componentSpec, binPath, forcePull, args)
+			return tiupexec.RunComponent(env, "", runArgs.componentSpec, runArgs.binPath, runArgs.forcePull, runArgs.componentArgs)
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			return environment.GlobalEnv().Close()
@@ -213,7 +190,6 @@ the latest stable version will be downloaded from the repository.`,
 	// useless, exist to generate help information
 	rootCmd.Flags().String("binary", "", "Print binary path of a specific version of a component `<component>[:version]`\n"+
 		"and the latest version installed will be selected if no version specified")
-	rootCmd.Flags().StringP("tag", "T", "", "[Deprecated] Specify a tag for component instance")
 	rootCmd.Flags().String("binpath", "", "Specify the binary path of component instance")
 	rootCmd.Flags().BoolP("version", "v", false, "Print the version of tiup")
 
@@ -230,6 +206,32 @@ the latest stable version will be downloaded from the repository.`,
 		newLinkCmd(),
 		newUnlinkCmd(),
 	)
+}
+
+type rootComponentArgs struct {
+	binPath       string
+	forcePull     bool
+	componentSpec string
+	componentArgs []string
+}
+
+func parseRootComponentArgs(args []string, binPath string, forcePull bool) rootComponentArgs {
+	if len(args) < 1 {
+		return rootComponentArgs{}
+	}
+
+	componentSpec := args[0]
+	componentArgs := args[1:]
+	if len(componentArgs) > 0 && componentArgs[0] == "--" {
+		componentArgs = componentArgs[1:]
+	}
+
+	return rootComponentArgs{
+		binPath:       binPath,
+		forcePull:     forcePull,
+		componentSpec: componentSpec,
+		componentArgs: componentArgs,
+	}
 }
 
 // Execute parses the command line arguments and calls proper functions

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRootComponentArgs_ForwardsComponentShortT(t *testing.T) {
+	got := parseRootComponentArgs([]string{"dumpling", "--no-views=false", "-T", "test.t11"}, "", false)
+	require.Equal(t, rootComponentArgs{
+		componentSpec: "dumpling",
+		componentArgs: []string{"--no-views=false", "-T", "test.t11"},
+	}, got)
+}
+
+func TestParseRootComponentArgs_ForwardsComponentTagFlag(t *testing.T) {
+	got := parseRootComponentArgs([]string{"playground", "-T", "demo"}, "", false)
+	require.Equal(t, rootComponentArgs{
+		componentSpec: "playground",
+		componentArgs: []string{"-T", "demo"},
+	}, got)
+}
+
+func TestParseRootComponentArgs_StripsExplicitSeparator(t *testing.T) {
+	got := parseRootComponentArgs([]string{"playground", "--", "-T", "demo"}, "/tmp/tidb-server", true)
+	require.Equal(t, rootComponentArgs{
+		binPath:       "/tmp/tidb-server",
+		forcePull:     true,
+		componentSpec: "playground",
+		componentArgs: []string{"-T", "demo"},
+	}, got)
+}

--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -74,11 +74,10 @@ Flags:
       --binpath string                 Specify the binary path of component instance
       --help                           Help for this command
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
-  -T, --tag string                     Specify a tag for component instance
   -v, --version                        Print the version of tiup
 
-Component instances with the same "tag" will share a data directory ($TIUP_HOME/data/$tag):
-  $ tiup --tag mycluster playground
+Components that support "tag" share a data directory for the same tag ($TIUP_HOME/data/$tag):
+  $ tiup playground --tag mycluster
 
 Examples:
   $ tiup playground                    # Quick start

--- a/doc/user/overview.md
+++ b/doc/user/overview.md
@@ -60,11 +60,10 @@ Flags:
       --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
-  -T, --tag string                     Specify a tag for component instance
       --version                        version for tiup
 
-Component instances with the same "tag" will share a data directory ($TIUP_HOME/data/$tag):
-  $ tiup --tag mycluster playground
+Components that support "tag" share a data directory for the same tag ($TIUP_HOME/data/$tag):
+  $ tiup playground --tag mycluster
 
 Examples:
   $ tiup playground                    # Quick start

--- a/tests/expected/tiup/tiup-h.output
+++ b/tests/expected/tiup/tiup-h.output
@@ -30,11 +30,10 @@ Flags:
       --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
-  -T, --tag string                     Specify a tag for component instance
       --version                        version for tiup
 
-Component instances with the same "tag" will share a data directory ($TIUP_HOME/data/$tag):
-  $ tiup --tag mycluster playground
+Components that support "tag" share a data directory for the same tag ($TIUP_HOME/data/$tag):
+  $ tiup playground --tag mycluster
 
 Examples:
   $ tiup playground                    # Quick start

--- a/tests/expected/tiup/tiup-help.output
+++ b/tests/expected/tiup/tiup-help.output
@@ -30,10 +30,9 @@ Flags:
       --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
-  -T, --tag string                     Specify a tag for component instance
 
-Component instances with the same "tag" will share a data directory ($TIUP_HOME/data/$tag):
-  $ tiup --tag mycluster playground
+Components that support "tag" share a data directory for the same tag ($TIUP_HOME/data/$tag):
+  $ tiup playground --tag mycluster
 
 Examples:
   $ tiup playground                    # Quick start

--- a/tests/expected/tiup/tiup.output
+++ b/tests/expected/tiup/tiup.output
@@ -30,11 +30,10 @@ Flags:
       --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
-  -T, --tag string                     Specify a tag for component instance
       --version                        version for tiup
 
-Component instances with the same "tag" will share a data directory ($TIUP_HOME/data/$tag):
-  $ tiup --tag mycluster playground
+Components that support "tag" share a data directory for the same tag ($TIUP_HOME/data/$tag):
+  $ tiup playground --tag mycluster
 
 Examples:
   $ tiup playground                    # Quick start


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Issue Number: N/A

TiUP root command currently owns the deprecated `--tag/-T` flag and also scans component arguments for `--tag/-T`. That causes TiUP to consume component-owned flags with the same short name, such as Dumpling's `-T/--tables-list`, and use the table list as the TiUP instance tag/data directory.

### What is changed and how it works?

- Remove TiUP root command handling for `--tag/-T`.
- Stop scanning component arguments for `--tag/-T`.
- Keep component arguments intact so components own their own flags, for example `tiup dumpling -T db.t` and `tiup playground -T mycluster`.
- Update root help docs and golden outputs to show component-level tag usage.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [x] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [x] Need to update the documentation

Release notes:

```release-note
Remove the deprecated TiUP root `--tag/-T` flag. Use component-level tag flags instead, such as `tiup playground --tag <name>`.
```