### PR TITLE
cmd: fix mirror clone help panic

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -922,7 +922,6 @@ func newMirrorCloneCmd() *cobra.Command {
 	)
 
 	initMirrorCloneExtraArgs := func(cmd *cobra.Command) error {
-		initialized = true
 		env := environment.GlobalEnv()
 		repo = env.V1Repository()
 		index, err := repo.FetchIndexManifest()
@@ -943,6 +942,7 @@ func newMirrorCloneCmd() *cobra.Command {
 			options.Components[name] = new([]string)
 			cmd.Flags().StringSliceVar(options.Components[name], name, nil, "Specify the versions for component "+name)
 		}
+		initialized = true
 		return nil
 	}
 	cmd := &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,11 +75,8 @@ the latest stable version will be downloaded from the repository.`,
 			return nil
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 0 {
-				switch args[0] {
-				case "--help", "-h", "--version", "-v":
-					return nil
-				}
+			if shouldSkipEnvInit(cmd, args) {
+				return nil
 			}
 			switch cmd.Name() {
 			case "init", "rotate", "set":
@@ -206,6 +203,25 @@ the latest stable version will be downloaded from the repository.`,
 		newLinkCmd(),
 		newUnlinkCmd(),
 	)
+}
+
+func shouldSkipEnvInit(cmd *cobra.Command, args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+
+	switch args[0] {
+	case "--help", "-h":
+		return !isMirrorCloneCommand(cmd)
+	case "--version", "-v":
+		return true
+	default:
+		return false
+	}
+}
+
+func isMirrorCloneCommand(cmd *cobra.Command) bool {
+	return cmd != nil && cmd.Name() == "clone" && cmd.HasParent() && cmd.Parent().Name() == "mirror"
 }
 
 type rootComponentArgs struct {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,6 +16,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,4 +44,17 @@ func TestParseRootComponentArgs_StripsExplicitSeparator(t *testing.T) {
 		componentSpec: "playground",
 		componentArgs: []string{"-T", "demo"},
 	}, got)
+}
+
+func TestShouldSkipEnvInit(t *testing.T) {
+	mirrorCmd := &cobra.Command{Use: "mirror"}
+	cloneCmd := &cobra.Command{Use: "clone"}
+	mirrorCmd.AddCommand(cloneCmd)
+
+	require.True(t, shouldSkipEnvInit(rootCmd, []string{"-h"}))
+	require.True(t, shouldSkipEnvInit(rootCmd, []string{"--help"}))
+	require.True(t, shouldSkipEnvInit(rootCmd, []string{"-v"}))
+	require.False(t, shouldSkipEnvInit(rootCmd, []string{"playground"}))
+	require.False(t, shouldSkipEnvInit(cloneCmd, []string{"-h"}))
+	require.False(t, shouldSkipEnvInit(cloneCmd, []string{"--help"}))
 }

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -296,11 +296,7 @@ func (i *MonitorInstance) InitConfig(
 	cfg.RetentionSize = getRetentionSize(logPtr, spec.RetentionSize)
 
 	// Check if agent mode is enabled in additional arguments
-	if !cfg.EnablePromAgentMode {
-		if slices.Contains(spec.AdditionalArgs, "--enable-feature=agent") {
-			cfg.EnablePromAgentMode = true
-		}
-	}
+	cfg.EnablePromAgentMode = cfg.EnablePromAgentMode || slices.Contains(spec.AdditionalArgs, "--enable-feature=agent")
 
 	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_prometheus_%s_%d.sh", i.GetHost(), i.GetPort()))
 	if err := cfg.ConfigToFile(fp); err != nil {

--- a/pkg/cluster/spec/tikv_worker.go
+++ b/pkg/cluster/spec/tikv_worker.go
@@ -140,7 +140,7 @@ func (c *TiKVWorkerComponent) Instances() []Instance {
 			},
 			StatusFn: s.Status,
 			UptimeFn: func(_ context.Context, timeout time.Duration, tlsCfg *tls.Config) time.Duration {
-				return UptimeByHost(s.GetManageHost(), s.Port, timeout, tlsCfg)
+				return UptimeByHost(s.GetManageHost(), s.Port, timeout, tlsCfg, "")
 			},
 			Component: c,
 		}, c.Topology})


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Issue Number: N/A

`tiup mirror clone -h` panics because the root command skips environment initialization for help requests. Unlike most commands, `mirror clone` builds part of its help output from the remote mirror index so it needs the TiUP environment even on the help path.

### What is changed and how it works?

- Special-case `mirror clone -h/--help` in the root command so it does not skip environment initialization.
- Keep the existing `mirror clone` dynamic component flag initialization path intact, so help still includes component flags such as `--tidb` and `--tikv`.
- Move the `mirror clone` `initialized` marker to after component flags are successfully loaded, so a failed index fetch does not prevent later retries.
- Add a regression test for the root environment-initialization decision.
- Fix branch-wide CI blockers exposed by this PR run:
  - update TiKV worker's `UptimeByHost` call for the current signature;
  - simplify the Prometheus agent-mode boolean assignment to satisfy the existing cognitive complexity threshold.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)

Manual test:

```bash
go run . mirror clone -h
go run . mirror clone --help
```

Local validation:

```bash
go test ./cmd ./pkg/cluster/spec ./components/playground
make lint
git diff --check
```

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

Release notes:

```release-note
NONE
```
