### PR TITLE
cluster: support Prometheus external labels in topology

### DIFF
--- a/.github/workflows/integrate-cluster-cmd.yaml
+++ b/.github/workflows/integrate-cluster-cmd.yaml
@@ -37,6 +37,7 @@ jobs:
         cases:
           - 'test_cmd'
           - 'test_cmd_tls_native_ssh'
+          - 'test_external_labels'
           - 'test_upgrade'
           - 'test_upgrade_tls'
           - 'test_tikv_cdc'
@@ -127,4 +128,3 @@ jobs:
 #        if: ${{ failure() }}
 #        with:
 #          limit-access-to-actor: true
-

--- a/embed/examples/cluster/minimal.yaml
+++ b/embed/examples/cluster/minimal.yaml
@@ -239,7 +239,9 @@ monitoring_servers:
     # data_dir: "/tidb-data/prometheus-8249"
     # # Prometheus log file storage directory.
     # log_dir: "/tidb-deploy/prometheus-8249/log"
+    # Show how to attach static cluster metadata through Prometheus global external_labels.
     # external_labels:
+    #   User-defined keys and values are rendered as-is instead of being derived by TiUP.
     #   environment: production
     #   region: us-east-1
 

--- a/embed/examples/cluster/minimal.yaml
+++ b/embed/examples/cluster/minimal.yaml
@@ -239,6 +239,9 @@ monitoring_servers:
     # data_dir: "/tidb-data/prometheus-8249"
     # # Prometheus log file storage directory.
     # log_dir: "/tidb-deploy/prometheus-8249/log"
+    # external_labels:
+    #   environment: production
+    #   region: us-east-1
 
 # # Server configs are used to specify the configuration of Grafana Servers.  
 grafana_servers:

--- a/embed/examples/cluster/minimal.yaml
+++ b/embed/examples/cluster/minimal.yaml
@@ -239,7 +239,9 @@ monitoring_servers:
     # data_dir: "/tidb-data/prometheus-8249"
     # # Prometheus log file storage directory.
     # log_dir: "/tidb-deploy/prometheus-8249/log"
+    # 这里展示最小化 topology 里 external_labels 的写法，表示把静态集群元数据直接写进 Prometheus 全局标签。
     # external_labels:
+    #   这里的 key/value 都是用户自己声明的静态字符串，不是 TiUP 自动推导出来的。
     #   environment: production
     #   region: us-east-1
 

--- a/embed/examples/cluster/minimal.yaml
+++ b/embed/examples/cluster/minimal.yaml
@@ -239,9 +239,7 @@ monitoring_servers:
     # data_dir: "/tidb-data/prometheus-8249"
     # # Prometheus log file storage directory.
     # log_dir: "/tidb-deploy/prometheus-8249/log"
-    # 这里展示最小化 topology 里 external_labels 的写法，表示把静态集群元数据直接写进 Prometheus 全局标签。
     # external_labels:
-    #   这里的 key/value 都是用户自己声明的静态字符串，不是 TiUP 自动推导出来的。
     #   environment: production
     #   region: us-east-1
 

--- a/embed/examples/cluster/topology.example.yaml
+++ b/embed/examples/cluster/topology.example.yaml
@@ -368,7 +368,9 @@ monitoring_servers:
     # rule_dir: /home/tidb/prometheus_rule
     # scrape_interval: 15s
     # scrape_timeout: 10s
+    # Use external_labels to attach stable metadata that is propagated to remote_write, federation, and alerts.
     # external_labels:
+    #   Typical keys describe user-defined dimensions such as environment or region.
     #   environment: production
     #   region: us-east-1
     # # The following configs are used to overwrite the `server_configs.ng_monitoring` values.

--- a/embed/examples/cluster/topology.example.yaml
+++ b/embed/examples/cluster/topology.example.yaml
@@ -368,6 +368,11 @@ monitoring_servers:
     # rule_dir: /home/tidb/prometheus_rule
     # scrape_interval: 15s
     # scrape_timeout: 10s
+    # 这里可以给当前 Prometheus 补充集群自定义的 external_labels，后续 remote_write/federation/alerts 都会带上这些标签。
+    # external_labels:
+    #   这里的 key 由用户自己定义，常见会写环境、地域、机房等稳定元数据。
+    #   environment: production
+    #   region: us-east-1
     # # The following configs are used to overwrite the `server_configs.ng_monitoring` values.
     # ng_monitoring_config:
     #   storage.path: "/tidb-data/prometheus-8249/docdb"

--- a/embed/examples/cluster/topology.example.yaml
+++ b/embed/examples/cluster/topology.example.yaml
@@ -368,9 +368,7 @@ monitoring_servers:
     # rule_dir: /home/tidb/prometheus_rule
     # scrape_interval: 15s
     # scrape_timeout: 10s
-    # 这里可以给当前 Prometheus 补充集群自定义的 external_labels，后续 remote_write/federation/alerts 都会带上这些标签。
     # external_labels:
-    #   这里的 key 由用户自己定义，常见会写环境、地域、机房等稳定元数据。
     #   environment: production
     #   region: us-east-1
     # # The following configs are used to overwrite the `server_configs.ng_monitoring` values.

--- a/embed/templates/config/prometheus.yml.tpl
+++ b/embed/templates/config/prometheus.yml.tpl
@@ -12,7 +12,7 @@ global:
   external_labels:
     cluster: '{{.ClusterName}}'
     monitor: "prometheus"
-{{- /* 这里继续把用户在 topology 里声明的自定义 external_labels 渲染到 Prometheus 全局标签中。 */}}
+{{- /* Render user-defined external_labels from the topology into Prometheus global labels. */}}
 {{- range $key, $value := .ExternalLabels}}
     {{$key}}: {{yamlQuote $value}}
 {{- end}}

--- a/embed/templates/config/prometheus.yml.tpl
+++ b/embed/templates/config/prometheus.yml.tpl
@@ -12,6 +12,7 @@ global:
   external_labels:
     cluster: '{{.ClusterName}}'
     monitor: "prometheus"
+{{- /* 这里继续把用户在 topology 里声明的自定义 external_labels 渲染到 Prometheus 全局标签中。 */}}
 {{- range $key, $value := .ExternalLabels}}
     {{$key}}: {{yamlQuote $value}}
 {{- end}}

--- a/embed/templates/config/prometheus.yml.tpl
+++ b/embed/templates/config/prometheus.yml.tpl
@@ -13,7 +13,7 @@ global:
     cluster: '{{.ClusterName}}'
     monitor: "prometheus"
 {{- range $key, $value := .ExternalLabels}}
-    {{$key}}: '{{$value}}'
+    {{$key}}: {{yamlQuote $value}}
 {{- end}}
 
 # Load and evaluate rules in this file every 'evaluation_interval' seconds.

--- a/embed/templates/config/prometheus.yml.tpl
+++ b/embed/templates/config/prometheus.yml.tpl
@@ -12,6 +12,9 @@ global:
   external_labels:
     cluster: '{{.ClusterName}}'
     monitor: "prometheus"
+{{- range $key, $value := .ExternalLabels}}
+    {{$key}}: '{{$value}}'
+{{- end}}
 
 # Load and evaluate rules in this file every 'evaluation_interval' seconds.
 rule_files:

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -320,6 +320,7 @@ func (i *MonitorInstance) InitConfig(
 
 	// transfer config
 	cfig := config.NewPrometheusConfig(clusterName, clusterVersion, enableTLS)
+	// 这里把 topology 中解析出的 external_labels 交给 Prometheus 配置对象，后面模板渲染时会落到 global.external_labels。
 	cfig.SetExternalLabels(spec.ExternalLabels)
 	if monitoredOptions != nil {
 		cfig.AddBlackbox(i.GetHost(), uint64(monitoredOptions.BlackboxExporterPort))

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -320,7 +320,7 @@ func (i *MonitorInstance) InitConfig(
 
 	// transfer config
 	cfig := config.NewPrometheusConfig(clusterName, clusterVersion, enableTLS)
-	// 这里把 topology 中解析出的 external_labels 交给 Prometheus 配置对象，后面模板渲染时会落到 global.external_labels。
+	// Pass topology external_labels through to the Prometheus config object.
 	cfig.SetExternalLabels(spec.ExternalLabels)
 	if monitoredOptions != nil {
 		cfig.AddBlackbox(i.GetHost(), uint64(monitoredOptions.BlackboxExporterPort))

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -54,6 +54,7 @@ type PrometheusSpec struct {
 	PromRemoteWriteToVM   bool                   `yaml:"prom_remote_write_to_vm,omitempty" validate:"prom_remote_write_to_vm:editable"` // Enable remote write to ng-monitoring
 	EnablePromAgentMode   bool                   `yaml:"enable_prom_agent_mode,omitempty" validate:"enable_prom_agent_mode:editable"`   // Enable Prometheus agent mode
 	RemoteConfig          Remote                 `yaml:"remote_config,omitempty" validate:"remote_config:ignore"`
+	ExternalLabels        map[string]string      `yaml:"external_labels,omitempty" validate:"external_labels:ignore"`
 	ExternalAlertmanagers []ExternalAlertmanager `yaml:"external_alertmanagers" validate:"external_alertmanagers:ignore"`
 	PushgatewayAddrs      []string               `yaml:"pushgateway_addrs,omitempty" validate:"pushgateway_addrs:ignore"`
 	Retention             string                 `yaml:"storage_retention,omitempty" validate:"storage_retention:editable"` // deprecated
@@ -319,6 +320,7 @@ func (i *MonitorInstance) InitConfig(
 
 	// transfer config
 	cfig := config.NewPrometheusConfig(clusterName, clusterVersion, enableTLS)
+	cfig.SetExternalLabels(spec.ExternalLabels)
 	if monitoredOptions != nil {
 		cfig.AddBlackbox(i.GetHost(), uint64(monitoredOptions.BlackboxExporterPort))
 	}

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -52,8 +52,9 @@ var (
 // ref https://man7.org/linux/man-pages/man8/useradd.8.html
 // ref https://man7.org/linux/man-pages/man8/groupadd.8.html
 var (
-	reUser                = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$`)
-	reGroup               = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,15})$`)
+	reUser  = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$`)
+	reGroup = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,15})$`)
+	// Prometheus label name 必须以字母或下划线开头，后面只能跟字母、数字或下划线。
 	rePrometheusLabelName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 )
 
@@ -1039,6 +1040,7 @@ func (s *Specification) validateTiFlashConfigs() error {
 }
 
 func (s *Specification) validatePrometheusExternalLabels() error {
+	// cluster 和 monitor 是 TiUP 已经内置写入的 external_labels，用户不能覆盖它们。
 	reservedLabels := set.NewStringSet("cluster", "monitor")
 	for _, monitor := range s.Monitors {
 		for label := range monitor.ExternalLabels {
@@ -1049,6 +1051,7 @@ func (s *Specification) validatePrometheusExternalLabels() error {
 					label,
 				)
 			}
+			// 以 __ 开头的标签名通常保留给 Prometheus 内部语义，这里直接拒绝，避免把内部保留风格暴露给用户配置。
 			if strings.HasPrefix(label, "__") {
 				return errors.Errorf(
 					"monitoring_servers:%s.external_labels contains invalid label name '%s': labels starting with '__' are reserved",
@@ -1056,6 +1059,7 @@ func (s *Specification) validatePrometheusExternalLabels() error {
 					label,
 				)
 			}
+			// 除了显式保留名之外，这里再按 Prometheus label name 规则校验，避免把非法键名写进最终配置。
 			if !rePrometheusLabelName.MatchString(label) {
 				return errors.Errorf(
 					"monitoring_servers:%s.external_labels contains invalid label name '%s'",

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -52,8 +52,9 @@ var (
 // ref https://man7.org/linux/man-pages/man8/useradd.8.html
 // ref https://man7.org/linux/man-pages/man8/groupadd.8.html
 var (
-	reUser  = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$`)
-	reGroup = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,15})$`)
+	reUser                = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$`)
+	reGroup               = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,15})$`)
+	rePrometheusLabelName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 )
 
 func fixDir(topo Topology) func(string) string {
@@ -1044,6 +1045,20 @@ func (s *Specification) validatePrometheusExternalLabels() error {
 			if reservedLabels.Exist(label) {
 				return errors.Errorf(
 					"monitoring_servers:%s.external_labels contains reserved label '%s'",
+					monitor.Host,
+					label,
+				)
+			}
+			if strings.HasPrefix(label, "__") {
+				return errors.Errorf(
+					"monitoring_servers:%s.external_labels contains invalid label name '%s': labels starting with '__' are reserved",
+					monitor.Host,
+					label,
+				)
+			}
+			if !rePrometheusLabelName.MatchString(label) {
+				return errors.Errorf(
+					"monitoring_servers:%s.external_labels contains invalid label name '%s'",
 					monitor.Host,
 					label,
 				)

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -1037,6 +1037,22 @@ func (s *Specification) validateTiFlashConfigs() error {
 	return nil
 }
 
+func (s *Specification) validatePrometheusExternalLabels() error {
+	reservedLabels := set.NewStringSet("cluster", "monitor")
+	for _, monitor := range s.Monitors {
+		for label := range monitor.ExternalLabels {
+			if reservedLabels.Exist(label) {
+				return errors.Errorf(
+					"monitoring_servers:%s.external_labels contains reserved label '%s'",
+					monitor.Host,
+					label,
+				)
+			}
+		}
+	}
+	return nil
+}
+
 // validateMonitorAgent checks for conflicts in topology for different ignore_exporter
 // settings for multiple instances on the same host / IP
 func (s *Specification) validateMonitorAgent() error {
@@ -1108,6 +1124,7 @@ func (s *Specification) Validate() error {
 		s.validateResourceManagerNames,
 		s.validateTiSparkSpec,
 		s.validateTiFlashConfigs,
+		s.validatePrometheusExternalLabels,
 		s.validateMonitorAgent,
 	}
 

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -54,7 +54,7 @@ var (
 var (
 	reUser  = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$`)
 	reGroup = regexp.MustCompile(`^[a-z_]([a-z0-9_-]{0,15})$`)
-	// Prometheus label name 必须以字母或下划线开头，后面只能跟字母、数字或下划线。
+	// Prometheus label names must start with a letter or underscore and then use letters, digits, or underscores.
 	rePrometheusLabelName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 )
 
@@ -1040,7 +1040,7 @@ func (s *Specification) validateTiFlashConfigs() error {
 }
 
 func (s *Specification) validatePrometheusExternalLabels() error {
-	// cluster 和 monitor 是 TiUP 已经内置写入的 external_labels，用户不能覆盖它们。
+	// cluster and monitor are injected by TiUP and cannot be overridden by user input.
 	reservedLabels := set.NewStringSet("cluster", "monitor")
 	for _, monitor := range s.Monitors {
 		for label := range monitor.ExternalLabels {
@@ -1051,7 +1051,7 @@ func (s *Specification) validatePrometheusExternalLabels() error {
 					label,
 				)
 			}
-			// 以 __ 开头的标签名通常保留给 Prometheus 内部语义，这里直接拒绝，避免把内部保留风格暴露给用户配置。
+			// Labels starting with __ are reserved by Prometheus internals and are rejected here.
 			if strings.HasPrefix(label, "__") {
 				return errors.Errorf(
 					"monitoring_servers:%s.external_labels contains invalid label name '%s': labels starting with '__' are reserved",
@@ -1059,7 +1059,7 @@ func (s *Specification) validatePrometheusExternalLabels() error {
 					label,
 				)
 			}
-			// 除了显式保留名之外，这里再按 Prometheus label name 规则校验，避免把非法键名写进最终配置。
+			// Apply the Prometheus label name rules after the explicit reserved-name checks.
 			if !rePrometheusLabelName.MatchString(label) {
 				return errors.Errorf(
 					"monitoring_servers:%s.external_labels contains invalid label name '%s'",

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -649,6 +649,7 @@ func TestRelativePathDetect(t *testing.T) {
 
 func TestPrometheusExternalLabels(t *testing.T) {
 	topo := Specification{}
+	// Allow user-defined external labels to round-trip into the monitor spec.
 	err := yaml.Unmarshal([]byte(`
 monitoring_servers:
   - host: 172.16.5.138
@@ -661,6 +662,7 @@ monitoring_servers:
 	require.Equal(t, "us-east-1", topo.Monitors[0].ExternalLabels["region"])
 
 	topo = Specification{}
+	// Reject labels reserved for the built-in TiUP metadata.
 	err = yaml.Unmarshal([]byte(`
 monitoring_servers:
   - host: 172.16.5.138
@@ -681,6 +683,7 @@ monitoring_servers:
 	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains reserved label 'monitor'", err.Error())
 
 	topo = Specification{}
+	// Reject names that violate the Prometheus label naming rules.
 	err = yaml.Unmarshal([]byte(`
 monitoring_servers:
   - host: 172.16.5.138
@@ -691,6 +694,7 @@ monitoring_servers:
 	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains invalid label name '1region'", err.Error())
 
 	topo = Specification{}
+	// Reject the Prometheus-reserved __* label namespace.
 	err = yaml.Unmarshal([]byte(`
 monitoring_servers:
   - host: 172.16.5.138

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -649,7 +649,6 @@ func TestRelativePathDetect(t *testing.T) {
 
 func TestPrometheusExternalLabels(t *testing.T) {
 	topo := Specification{}
-	// 先验证正常场景：合法 external_labels 可以被 topology 正常解析进监控节点配置。
 	err := yaml.Unmarshal([]byte(`
 monitoring_servers:
   - host: 172.16.5.138
@@ -658,13 +657,10 @@ monitoring_servers:
       region: us-east-1
 `), &topo)
 	require.NoError(t, err)
-	// 这里确认 environment 这个用户自定义标签会完整保存在 PrometheusSpec 里。
 	require.Equal(t, "production", topo.Monitors[0].ExternalLabels["environment"])
-	// 这里确认 region 这个用户自定义标签也会完整保存在 PrometheusSpec 里。
 	require.Equal(t, "us-east-1", topo.Monitors[0].ExternalLabels["region"])
 
 	topo = Specification{}
-	// 这里验证保留标签 cluster：它是 TiUP 固定写入的，不应该允许用户重定义。
 	err = yaml.Unmarshal([]byte(`
 monitoring_servers:
   - host: 172.16.5.138
@@ -672,11 +668,9 @@ monitoring_servers:
       cluster: production
 `), &topo)
 	require.Error(t, err)
-	// 这里把报错内容精确锁住，确保后续不会悄悄变成“允许覆盖”或者“报一个模糊错误”。
 	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains reserved label 'cluster'", err.Error())
 
 	topo = Specification{}
-	// 再验证保留标签 monitor：它和 cluster 一样是 TiUP 固定写入的，不应该允许用户重定义。
 	err = yaml.Unmarshal([]byte(`
 monitoring_servers:
   - host: 172.16.5.138
@@ -684,11 +678,9 @@ monitoring_servers:
       monitor: production
 `), &topo)
 	require.Error(t, err)
-	// 这里同样把 monitor 的报错信息锁住，避免未来回归。
 	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains reserved label 'monitor'", err.Error())
 
 	topo = Specification{}
-	// 这里验证不合法的标签名：以数字开头不符合 Prometheus label name 规则，应该在校验阶段失败。
 	err = yaml.Unmarshal([]byte(`
 monitoring_servers:
   - host: 172.16.5.138
@@ -696,11 +688,9 @@ monitoring_servers:
       1region: us-east-1
 `), &topo)
 	require.Error(t, err)
-	// 这里把非法标签名的错误内容锁住，确保是“标签名非法”而不是其他副作用报错。
 	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains invalid label name '1region'", err.Error())
 
 	topo = Specification{}
-	// 这里验证 __ 前缀：这种前缀通常保留给 Prometheus 内部标签语义，不应该暴露给用户 external_labels。
 	err = yaml.Unmarshal([]byte(`
 monitoring_servers:
   - host: 172.16.5.138
@@ -708,7 +698,6 @@ monitoring_servers:
       __replica__: tiflash
 `), &topo)
 	require.Error(t, err)
-	// 这里精确锁住 __ 前缀的报错文案，确保后续实现继续明确拒绝这类保留风格标签。
 	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains invalid label name '__replica__': labels starting with '__' are reserved", err.Error())
 }
 

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -658,7 +658,9 @@ monitoring_servers:
       region: us-east-1
 `), &topo)
 	require.NoError(t, err)
+	// 这里确认 environment 这个用户自定义标签会完整保存在 PrometheusSpec 里。
 	require.Equal(t, "production", topo.Monitors[0].ExternalLabels["environment"])
+	// 这里确认 region 这个用户自定义标签也会完整保存在 PrometheusSpec 里。
 	require.Equal(t, "us-east-1", topo.Monitors[0].ExternalLabels["region"])
 
 	topo = Specification{}

--- a/pkg/cluster/spec/validate_test.go
+++ b/pkg/cluster/spec/validate_test.go
@@ -647,6 +647,69 @@ func TestRelativePathDetect(t *testing.T) {
 	}
 }
 
+func TestPrometheusExternalLabels(t *testing.T) {
+	topo := Specification{}
+	// 先验证正常场景：合法 external_labels 可以被 topology 正常解析进监控节点配置。
+	err := yaml.Unmarshal([]byte(`
+monitoring_servers:
+  - host: 172.16.5.138
+    external_labels:
+      environment: production
+      region: us-east-1
+`), &topo)
+	require.NoError(t, err)
+	require.Equal(t, "production", topo.Monitors[0].ExternalLabels["environment"])
+	require.Equal(t, "us-east-1", topo.Monitors[0].ExternalLabels["region"])
+
+	topo = Specification{}
+	// 这里验证保留标签 cluster：它是 TiUP 固定写入的，不应该允许用户重定义。
+	err = yaml.Unmarshal([]byte(`
+monitoring_servers:
+  - host: 172.16.5.138
+    external_labels:
+      cluster: production
+`), &topo)
+	require.Error(t, err)
+	// 这里把报错内容精确锁住，确保后续不会悄悄变成“允许覆盖”或者“报一个模糊错误”。
+	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains reserved label 'cluster'", err.Error())
+
+	topo = Specification{}
+	// 再验证保留标签 monitor：它和 cluster 一样是 TiUP 固定写入的，不应该允许用户重定义。
+	err = yaml.Unmarshal([]byte(`
+monitoring_servers:
+  - host: 172.16.5.138
+    external_labels:
+      monitor: production
+`), &topo)
+	require.Error(t, err)
+	// 这里同样把 monitor 的报错信息锁住，避免未来回归。
+	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains reserved label 'monitor'", err.Error())
+
+	topo = Specification{}
+	// 这里验证不合法的标签名：以数字开头不符合 Prometheus label name 规则，应该在校验阶段失败。
+	err = yaml.Unmarshal([]byte(`
+monitoring_servers:
+  - host: 172.16.5.138
+    external_labels:
+      1region: us-east-1
+`), &topo)
+	require.Error(t, err)
+	// 这里把非法标签名的错误内容锁住，确保是“标签名非法”而不是其他副作用报错。
+	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains invalid label name '1region'", err.Error())
+
+	topo = Specification{}
+	// 这里验证 __ 前缀：这种前缀通常保留给 Prometheus 内部标签语义，不应该暴露给用户 external_labels。
+	err = yaml.Unmarshal([]byte(`
+monitoring_servers:
+  - host: 172.16.5.138
+    external_labels:
+      __replica__: tiflash
+`), &topo)
+	require.Error(t, err)
+	// 这里精确锁住 __ 前缀的报错文案，确保后续实现继续明确拒绝这类保留风格标签。
+	require.Equal(t, "monitoring_servers:172.16.5.138.external_labels contains invalid label name '__replica__': labels starting with '__' are reserved", err.Error())
+}
+
 func TestTiKVLocationLabelsCheck(t *testing.T) {
 	// 2 tikv on different host
 	topo := Specification{}

--- a/pkg/cluster/template/config/prometheus.go
+++ b/pkg/cluster/template/config/prometheus.go
@@ -16,6 +16,7 @@ package config
 import (
 	"bytes"
 	"path"
+	// 这里复用标准库的字符串转义逻辑，避免手写 YAML 引号时漏掉单引号、双引号等特殊字符。
 	"strconv"
 	"strings"
 	"text/template"
@@ -27,10 +28,11 @@ import (
 
 // PrometheusConfig represent the data to generate Prometheus config
 type PrometheusConfig struct {
-	ClusterName               string
-	ScrapeInterval            string
-	ScrapeTimeout             string
-	TLSEnabled                bool
+	ClusterName    string
+	ScrapeInterval string
+	ScrapeTimeout  string
+	TLSEnabled     bool
+	// ExternalLabels 表示用户希望额外注入到 Prometheus global.external_labels 的自定义标签集合。
 	ExternalLabels            map[string]string
 	NodeExporterAddrs         []string
 	TiDBStatusAddrs           []string
@@ -250,8 +252,10 @@ func (c *PrometheusConfig) SetExternalLabels(labels map[string]string) *Promethe
 		return c
 	}
 
+	// 这里复制一份 map，而不是直接持有外部引用，避免调用方后续修改原 map 影响配置对象内部状态。
 	c.ExternalLabels = make(map[string]string, len(labels))
 	for key, value := range labels {
+		// 这里逐项复制用户配置的 label，后续模板渲染会原样输出这些 key/value。
 		c.ExternalLabels[key] = value
 	}
 	return c
@@ -303,6 +307,7 @@ func (c *PrometheusConfig) ConfigWithAgentMode(enableAgent bool) ([]byte, error)
 
 // ConfigWithTemplate generate the Prometheus config content by tpl
 func (c *PrometheusConfig) ConfigWithTemplate(tpl string) ([]byte, error) {
+	// 这里向模板注册 yamlQuote，专门负责把 external_labels 的 value 安全地转成带转义的 YAML 字符串。
 	tmpl, err := template.New("Prometheus").Funcs(template.FuncMap{
 		"yamlQuote": strconv.Quote,
 	}).Parse(tpl)

--- a/pkg/cluster/template/config/prometheus.go
+++ b/pkg/cluster/template/config/prometheus.go
@@ -30,6 +30,7 @@ type PrometheusConfig struct {
 	ScrapeInterval            string
 	ScrapeTimeout             string
 	TLSEnabled                bool
+	ExternalLabels            map[string]string
 	NodeExporterAddrs         []string
 	TiDBStatusAddrs           []string
 	TiProxyStatusAddrs        []string
@@ -239,6 +240,19 @@ func (c *PrometheusConfig) AddLocalRule(rule string) *PrometheusConfig {
 // SetRemoteConfig set remote read/write config
 func (c *PrometheusConfig) SetRemoteConfig(cfg string) *PrometheusConfig {
 	c.RemoteConfig = cfg
+	return c
+}
+
+// SetExternalLabels sets custom Prometheus external labels.
+func (c *PrometheusConfig) SetExternalLabels(labels map[string]string) *PrometheusConfig {
+	if len(labels) == 0 {
+		return c
+	}
+
+	c.ExternalLabels = make(map[string]string, len(labels))
+	for key, value := range labels {
+		c.ExternalLabels[key] = value
+	}
 	return c
 }
 

--- a/pkg/cluster/template/config/prometheus.go
+++ b/pkg/cluster/template/config/prometheus.go
@@ -16,7 +16,6 @@ package config
 import (
 	"bytes"
 	"path"
-	// 这里复用标准库的字符串转义逻辑，避免手写 YAML 引号时漏掉单引号、双引号等特殊字符。
 	"strconv"
 	"strings"
 	"text/template"
@@ -32,7 +31,6 @@ type PrometheusConfig struct {
 	ScrapeInterval string
 	ScrapeTimeout  string
 	TLSEnabled     bool
-	// ExternalLabels 表示用户希望额外注入到 Prometheus global.external_labels 的自定义标签集合。
 	ExternalLabels            map[string]string
 	NodeExporterAddrs         []string
 	TiDBStatusAddrs           []string
@@ -252,10 +250,8 @@ func (c *PrometheusConfig) SetExternalLabels(labels map[string]string) *Promethe
 		return c
 	}
 
-	// 这里复制一份 map，而不是直接持有外部引用，避免调用方后续修改原 map 影响配置对象内部状态。
 	c.ExternalLabels = make(map[string]string, len(labels))
 	for key, value := range labels {
-		// 这里逐项复制用户配置的 label，后续模板渲染会原样输出这些 key/value。
 		c.ExternalLabels[key] = value
 	}
 	return c
@@ -307,7 +303,6 @@ func (c *PrometheusConfig) ConfigWithAgentMode(enableAgent bool) ([]byte, error)
 
 // ConfigWithTemplate generate the Prometheus config content by tpl
 func (c *PrometheusConfig) ConfigWithTemplate(tpl string) ([]byte, error) {
-	// 这里向模板注册 yamlQuote，专门负责把 external_labels 的 value 安全地转成带转义的 YAML 字符串。
 	tmpl, err := template.New("Prometheus").Funcs(template.FuncMap{
 		"yamlQuote": strconv.Quote,
 	}).Parse(tpl)

--- a/pkg/cluster/template/config/prometheus.go
+++ b/pkg/cluster/template/config/prometheus.go
@@ -16,6 +16,7 @@ package config
 import (
 	"bytes"
 	"path"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -302,7 +303,9 @@ func (c *PrometheusConfig) ConfigWithAgentMode(enableAgent bool) ([]byte, error)
 
 // ConfigWithTemplate generate the Prometheus config content by tpl
 func (c *PrometheusConfig) ConfigWithTemplate(tpl string) ([]byte, error) {
-	tmpl, err := template.New("Prometheus").Parse(tpl)
+	tmpl, err := template.New("Prometheus").Funcs(template.FuncMap{
+		"yamlQuote": strconv.Quote,
+	}).Parse(tpl)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/template/config/prometheus.go
+++ b/pkg/cluster/template/config/prometheus.go
@@ -31,6 +31,7 @@ type PrometheusConfig struct {
 	ScrapeInterval string
 	ScrapeTimeout  string
 	TLSEnabled     bool
+	// ExternalLabels holds user-defined entries merged into global.external_labels.
 	ExternalLabels            map[string]string
 	NodeExporterAddrs         []string
 	TiDBStatusAddrs           []string
@@ -250,6 +251,7 @@ func (c *PrometheusConfig) SetExternalLabels(labels map[string]string) *Promethe
 		return c
 	}
 
+	// Copy the input map so later caller mutations do not change the config object.
 	c.ExternalLabels = make(map[string]string, len(labels))
 	for key, value := range labels {
 		c.ExternalLabels[key] = value
@@ -303,6 +305,7 @@ func (c *PrometheusConfig) ConfigWithAgentMode(enableAgent bool) ([]byte, error)
 
 // ConfigWithTemplate generate the Prometheus config content by tpl
 func (c *PrometheusConfig) ConfigWithTemplate(tpl string) ([]byte, error) {
+	// yamlQuote keeps label values valid even when they contain quotes or other special characters.
 	tmpl, err := template.New("Prometheus").Funcs(template.FuncMap{
 		"yamlQuote": strconv.Quote,
 	}).Parse(tpl)

--- a/pkg/cluster/template/config/prometheus_test.go
+++ b/pkg/cluster/template/config/prometheus_test.go
@@ -22,7 +22,6 @@ import (
 
 type renderedPrometheusConfig struct {
 	Global struct {
-		// 这里直接只解析 global.external_labels，测试只关心本次改动真正影响的输出片段。
 		ExternalLabels map[string]string `yaml:"external_labels"`
 	} `yaml:"global"`
 }
@@ -31,16 +30,13 @@ func decodeExternalLabels(t *testing.T, content []byte) map[string]string {
 	t.Helper()
 
 	var cfg renderedPrometheusConfig
-	// 这里把渲染结果重新反序列化成 YAML 结构，而不是只做字符串 contains，这样能真正验证结果是合法 YAML。
 	if err := yaml.Unmarshal(content, &cfg); err != nil {
 		t.Fatalf("failed to decode rendered prometheus config: %v\n%s", err, string(content))
 	}
-	// 这里只返回 external_labels，方便下面的测试直接对 map 做键值断言。
 	return cfg.Global.ExternalLabels
 }
 
 func TestPrometheusConfigExternalLabelsDefaults(t *testing.T) {
-	// 这里构造一个完全不带自定义标签的默认 Prometheus 配置，用来验证 backward compatibility。
 	cfg := NewPrometheusConfig("test-cluster", "v6.1.0", false)
 
 	content, err := cfg.Config()
@@ -48,18 +44,15 @@ func TestPrometheusConfigExternalLabelsDefaults(t *testing.T) {
 		t.Fatalf("failed to render prometheus config: %v", err)
 	}
 
-	// 这里解析渲染结果，确认在没有 external_labels 输入时仍然只保留 TiUP 默认的两个标签。
 	labels := decodeExternalLabels(t, content)
 	expected := map[string]string{
 		"cluster": "test-cluster",
 		"monitor": "prometheus",
 	}
-	// 这里先校验标签总数，确保默认情况下不会平白多渲染出其他标签。
 	if len(labels) != len(expected) {
 		t.Fatalf("expected %d labels, got %d: %#v", len(expected), len(labels), labels)
 	}
 	for key, value := range expected {
-		// 这里逐项校验 cluster/monitor 的默认值，确保这次改动没有破坏已有行为。
 		if labels[key] != value {
 			t.Fatalf("expected %s=%q, got %#v", key, value, labels)
 		}
@@ -67,7 +60,6 @@ func TestPrometheusConfigExternalLabelsDefaults(t *testing.T) {
 }
 
 func TestPrometheusConfigExternalLabels(t *testing.T) {
-	// 这里构造带自定义 external_labels 的配置，并故意放入单引号和双引号，验证 YAML 转义路径是否安全。
 	cfg := NewPrometheusConfig("test-cluster", "v6.1.0", false)
 	cfg.SetExternalLabels(map[string]string{
 		"environment": "prod'uction",
@@ -80,7 +72,6 @@ func TestPrometheusConfigExternalLabels(t *testing.T) {
 		t.Fatalf("failed to render prometheus config: %v", err)
 	}
 
-	// 这里再次把渲染后的 YAML 解回来，验证特殊字符值并不会破坏最终配置结构。
 	labels := decodeExternalLabels(t, content)
 	expected := map[string]string{
 		"cluster":     "test-cluster",
@@ -89,12 +80,10 @@ func TestPrometheusConfigExternalLabels(t *testing.T) {
 		"owner":       `sre:"primary"`,
 		"region":      "us-east-1",
 	}
-	// 这里先确认最终 external_labels 的数量符合预期，确保自定义标签和默认标签都在。
 	if len(labels) != len(expected) {
 		t.Fatalf("expected %d labels, got %d: %#v", len(expected), len(labels), labels)
 	}
 	for key, value := range expected {
-		// 这里逐项确认默认标签和自定义标签都被正确渲染并且值没有因为转义而发生变化。
 		if labels[key] != value {
 			t.Fatalf("expected %s=%q, got %#v", key, value, labels)
 		}

--- a/pkg/cluster/template/config/prometheus_test.go
+++ b/pkg/cluster/template/config/prometheus_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 PingCAP, Inc.
+// Copyright 2026 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,90 @@ package config
 import (
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
+
+type renderedPrometheusConfig struct {
+	Global struct {
+		// 这里直接只解析 global.external_labels，测试只关心本次改动真正影响的输出片段。
+		ExternalLabels map[string]string `yaml:"external_labels"`
+	} `yaml:"global"`
+}
+
+func decodeExternalLabels(t *testing.T, content []byte) map[string]string {
+	t.Helper()
+
+	var cfg renderedPrometheusConfig
+	// 这里把渲染结果重新反序列化成 YAML 结构，而不是只做字符串 contains，这样能真正验证结果是合法 YAML。
+	if err := yaml.Unmarshal(content, &cfg); err != nil {
+		t.Fatalf("failed to decode rendered prometheus config: %v\n%s", err, string(content))
+	}
+	// 这里只返回 external_labels，方便下面的测试直接对 map 做键值断言。
+	return cfg.Global.ExternalLabels
+}
+
+func TestPrometheusConfigExternalLabelsDefaults(t *testing.T) {
+	// 这里构造一个完全不带自定义标签的默认 Prometheus 配置，用来验证 backward compatibility。
+	cfg := NewPrometheusConfig("test-cluster", "v6.1.0", false)
+
+	content, err := cfg.Config()
+	if err != nil {
+		t.Fatalf("failed to render prometheus config: %v", err)
+	}
+
+	// 这里解析渲染结果，确认在没有 external_labels 输入时仍然只保留 TiUP 默认的两个标签。
+	labels := decodeExternalLabels(t, content)
+	expected := map[string]string{
+		"cluster": "test-cluster",
+		"monitor": "prometheus",
+	}
+	// 这里先校验标签总数，确保默认情况下不会平白多渲染出其他标签。
+	if len(labels) != len(expected) {
+		t.Fatalf("expected %d labels, got %d: %#v", len(expected), len(labels), labels)
+	}
+	for key, value := range expected {
+		// 这里逐项校验 cluster/monitor 的默认值，确保这次改动没有破坏已有行为。
+		if labels[key] != value {
+			t.Fatalf("expected %s=%q, got %#v", key, value, labels)
+		}
+	}
+}
+
+func TestPrometheusConfigExternalLabels(t *testing.T) {
+	// 这里构造带自定义 external_labels 的配置，并故意放入单引号和双引号，验证 YAML 转义路径是否安全。
+	cfg := NewPrometheusConfig("test-cluster", "v6.1.0", false)
+	cfg.SetExternalLabels(map[string]string{
+		"environment": "prod'uction",
+		"owner":       `sre:"primary"`,
+		"region":      "us-east-1",
+	})
+
+	content, err := cfg.Config()
+	if err != nil {
+		t.Fatalf("failed to render prometheus config: %v", err)
+	}
+
+	// 这里再次把渲染后的 YAML 解回来，验证特殊字符值并不会破坏最终配置结构。
+	labels := decodeExternalLabels(t, content)
+	expected := map[string]string{
+		"cluster":     "test-cluster",
+		"environment": "prod'uction",
+		"monitor":     "prometheus",
+		"owner":       `sre:"primary"`,
+		"region":      "us-east-1",
+	}
+	// 这里先确认最终 external_labels 的数量符合预期，确保自定义标签和默认标签都在。
+	if len(labels) != len(expected) {
+		t.Fatalf("expected %d labels, got %d: %#v", len(expected), len(labels), labels)
+	}
+	for key, value := range expected {
+		// 这里逐项确认默认标签和自定义标签都被正确渲染并且值没有因为转义而发生变化。
+		if labels[key] != value {
+			t.Fatalf("expected %s=%q, got %#v", key, value, labels)
+		}
+	}
+}
 
 func TestPrometheusConfigWithAgentMode(t *testing.T) {
 	cfg := NewPrometheusConfig("test-cluster", "v6.1.0", false)

--- a/pkg/cluster/template/config/prometheus_test.go
+++ b/pkg/cluster/template/config/prometheus_test.go
@@ -22,6 +22,7 @@ import (
 
 type renderedPrometheusConfig struct {
 	Global struct {
+		// Only decode global.external_labels because that is the output surface under test.
 		ExternalLabels map[string]string `yaml:"external_labels"`
 	} `yaml:"global"`
 }
@@ -30,6 +31,7 @@ func decodeExternalLabels(t *testing.T, content []byte) map[string]string {
 	t.Helper()
 
 	var cfg renderedPrometheusConfig
+	// Decode the rendered YAML instead of string matching so the test validates a real config.
 	if err := yaml.Unmarshal(content, &cfg); err != nil {
 		t.Fatalf("failed to decode rendered prometheus config: %v\n%s", err, string(content))
 	}
@@ -37,6 +39,7 @@ func decodeExternalLabels(t *testing.T, content []byte) map[string]string {
 }
 
 func TestPrometheusConfigExternalLabelsDefaults(t *testing.T) {
+	// Keep backward compatibility when no custom external_labels are provided.
 	cfg := NewPrometheusConfig("test-cluster", "v6.1.0", false)
 
 	content, err := cfg.Config()
@@ -60,6 +63,7 @@ func TestPrometheusConfigExternalLabelsDefaults(t *testing.T) {
 }
 
 func TestPrometheusConfigExternalLabels(t *testing.T) {
+	// Include both quote styles to cover YAML escaping in custom label values.
 	cfg := NewPrometheusConfig("test-cluster", "v6.1.0", false)
 	cfg.SetExternalLabels(map[string]string{
 		"environment": "prod'uction",

--- a/tests/tiup-cluster/script/external_labels.sh
+++ b/tests/tiup-cluster/script/external_labels.sh
@@ -11,6 +11,7 @@ function external_labels() {
     invalid_topo=./topo/external_labels_invalid.yaml
     prometheus_config=/home/tidb/deploy/prometheus-9090/conf/prometheus.yml
 
+    echo "check invalid external_labels topology"
     set +e
     invalid_output=$(tiup-cluster check $invalid_topo -i ~/.ssh/id_rsa 2>&1)
     invalid_status=$?
@@ -21,16 +22,23 @@ function external_labels() {
     fi
     echo "$invalid_output" | grep "contains reserved label 'cluster'"
 
+    echo "deploy cluster with external_labels"
     tiup-cluster --yes deploy $name $version $topo -i ~/.ssh/id_rsa
+    tiup-cluster list | grep "$name"
+
+    echo "start cluster"
     tiup-cluster --yes start $name
 
     tiup-cluster _test $name writable
+    tiup-cluster display $name
 
+    # check the generated Prometheus config after the initial deploy
     tiup-cluster exec $name -N n1 --command "grep -q \"cluster: '$name'\" $prometheus_config"
     tiup-cluster exec $name -N n1 --command "grep -q 'monitor: \"prometheus\"' $prometheus_config"
     tiup-cluster exec $name -N n1 --command "grep -q 'environment: \"production\"' $prometheus_config"
     tiup-cluster exec $name -N n1 --command "grep -q 'region: \"us-east-1\"' $prometheus_config"
 
+    echo "edit config and reload cluster"
     EDITOR=ex tiup-cluster edit-config -y $name <<EOEX
 :%s/production/staging/g
 :%s/us-east-1/eu-central-1/g
@@ -40,6 +48,7 @@ EOEX
 
     tiup-cluster _test $name writable
 
+    # verify reload updates the rendered external_labels instead of keeping the old values
     tiup-cluster exec $name -N n1 --command "grep -q \"cluster: '$name'\" $prometheus_config"
     tiup-cluster exec $name -N n1 --command "grep -q 'monitor: \"prometheus\"' $prometheus_config"
     ! tiup-cluster exec $name -N n1 --command "grep -q 'environment: \"production\"' $prometheus_config"
@@ -47,5 +56,6 @@ EOEX
     ! tiup-cluster exec $name -N n1 --command "grep -q 'region: \"us-east-1\"' $prometheus_config"
     tiup-cluster exec $name -N n1 --command "grep -q 'region: \"eu-central-1\"' $prometheus_config"
 
+    echo "destroy cluster"
     tiup-cluster --yes destroy $name
 }

--- a/tests/tiup-cluster/script/external_labels.sh
+++ b/tests/tiup-cluster/script/external_labels.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -eu
+
+function external_labels() {
+    mkdir -p ~/.tiup/bin/
+
+    version=$1
+    name="test_external_labels_$RANDOM"
+    topo=./topo/external_labels.yaml
+    invalid_topo=./topo/external_labels_invalid.yaml
+    prometheus_config=/home/tidb/deploy/prometheus-9090/conf/prometheus.yml
+
+    set +e
+    invalid_output=$(tiup-cluster check $invalid_topo -i ~/.ssh/id_rsa 2>&1)
+    invalid_status=$?
+    set -e
+    if [ $invalid_status -eq 0 ]; then
+        echo "expected invalid external_labels topology check to fail"
+        exit 1
+    fi
+    echo "$invalid_output" | grep "contains reserved label 'cluster'"
+
+    tiup-cluster --yes deploy $name $version $topo -i ~/.ssh/id_rsa
+    tiup-cluster --yes start $name
+
+    tiup-cluster _test $name writable
+
+    tiup-cluster exec $name -N n1 --command "grep -q \"cluster: '$name'\" $prometheus_config"
+    tiup-cluster exec $name -N n1 --command "grep -q 'monitor: \"prometheus\"' $prometheus_config"
+    tiup-cluster exec $name -N n1 --command "grep -q 'environment: \"production\"' $prometheus_config"
+    tiup-cluster exec $name -N n1 --command "grep -q 'region: \"us-east-1\"' $prometheus_config"
+
+    EDITOR=ex tiup-cluster edit-config -y $name <<EOEX
+:%s/production/staging/g
+:%s/us-east-1/eu-central-1/g
+:x
+EOEX
+    yes | tiup-cluster reload $name --transfer-timeout 60
+
+    tiup-cluster _test $name writable
+
+    tiup-cluster exec $name -N n1 --command "grep -q \"cluster: '$name'\" $prometheus_config"
+    tiup-cluster exec $name -N n1 --command "grep -q 'monitor: \"prometheus\"' $prometheus_config"
+    ! tiup-cluster exec $name -N n1 --command "grep -q 'environment: \"production\"' $prometheus_config"
+    tiup-cluster exec $name -N n1 --command "grep -q 'environment: \"staging\"' $prometheus_config"
+    ! tiup-cluster exec $name -N n1 --command "grep -q 'region: \"us-east-1\"' $prometheus_config"
+    tiup-cluster exec $name -N n1 --command "grep -q 'region: \"eu-central-1\"' $prometheus_config"
+
+    tiup-cluster --yes destroy $name
+}

--- a/tests/tiup-cluster/test_external_labels.sh
+++ b/tests/tiup-cluster/test_external_labels.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+version=${version-v6.2.0}
+
+source script/external_labels.sh
+
+echo "test prometheus external_labels for version $version"
+external_labels "$version"

--- a/tests/tiup-cluster/topo/external_labels.yaml
+++ b/tests/tiup-cluster/topo/external_labels.yaml
@@ -1,38 +1,15 @@
 server_configs:
-  tidb:
-    binlog.enable: true
-    binlog.ignore-error: false
   tikv:
     storage.reserve-space: 1K
-  pump:
-    storage.stop-write-at-available-space: 1 mib
 
 tidb_servers:
   - host: n1
-  - host: n2
 
 pd_servers:
-  - host: n3
-  - host: n4
-  - host: n5
+  - host: n1
 
 tikv_servers:
-  - host: n2
-  - host: n3
-  - host: n4
-  - host: n5
-
-pump_servers:
-  - host: n3
-  - host: n4
-  - host: n5
-
-drainer_servers:
   - host: n1
-    data_dir: /home/tidb/data/drainer-8249/data
-    commit_ts: -1
-    config:
-      syncer.db-type: "file"
 
 monitoring_servers:
   - host: n1

--- a/tests/tiup-cluster/topo/external_labels.yaml
+++ b/tests/tiup-cluster/topo/external_labels.yaml
@@ -1,0 +1,48 @@
+server_configs:
+  tidb:
+    binlog.enable: true
+    binlog.ignore-error: false
+  tikv:
+    storage.reserve-space: 1K
+  pump:
+    storage.stop-write-at-available-space: 1 mib
+
+tidb_servers:
+  - host: n1
+  - host: n2
+
+pd_servers:
+  - host: n3
+  - host: n4
+  - host: n5
+
+tikv_servers:
+  - host: n2
+  - host: n3
+  - host: n4
+  - host: n5
+
+pump_servers:
+  - host: n3
+  - host: n4
+  - host: n5
+
+drainer_servers:
+  - host: n1
+    data_dir: /home/tidb/data/drainer-8249/data
+    commit_ts: -1
+    config:
+      syncer.db-type: "file"
+
+monitoring_servers:
+  - host: n1
+    rule_dir: /tmp/local/prometheus
+    external_labels:
+      environment: production
+      region: us-east-1
+grafana_servers:
+  - host: n1
+    dashboard_dir: /tmp/local/grafana
+alertmanager_servers:
+  - host: n1
+    config_file: /tmp/local/alertmanager/alertmanager.yml

--- a/tests/tiup-cluster/topo/external_labels_invalid.yaml
+++ b/tests/tiup-cluster/topo/external_labels_invalid.yaml
@@ -1,38 +1,15 @@
 server_configs:
-  tidb:
-    binlog.enable: true
-    binlog.ignore-error: false
   tikv:
     storage.reserve-space: 1K
-  pump:
-    storage.stop-write-at-available-space: 1 mib
 
 tidb_servers:
   - host: n1
-  - host: n2
 
 pd_servers:
-  - host: n3
-  - host: n4
-  - host: n5
+  - host: n1
 
 tikv_servers:
-  - host: n2
-  - host: n3
-  - host: n4
-  - host: n5
-
-pump_servers:
-  - host: n3
-  - host: n4
-  - host: n5
-
-drainer_servers:
   - host: n1
-    data_dir: /home/tidb/data/drainer-8249/data
-    commit_ts: -1
-    config:
-      syncer.db-type: "file"
 
 monitoring_servers:
   - host: n1

--- a/tests/tiup-cluster/topo/external_labels_invalid.yaml
+++ b/tests/tiup-cluster/topo/external_labels_invalid.yaml
@@ -1,0 +1,47 @@
+server_configs:
+  tidb:
+    binlog.enable: true
+    binlog.ignore-error: false
+  tikv:
+    storage.reserve-space: 1K
+  pump:
+    storage.stop-write-at-available-space: 1 mib
+
+tidb_servers:
+  - host: n1
+  - host: n2
+
+pd_servers:
+  - host: n3
+  - host: n4
+  - host: n5
+
+tikv_servers:
+  - host: n2
+  - host: n3
+  - host: n4
+  - host: n5
+
+pump_servers:
+  - host: n3
+  - host: n4
+  - host: n5
+
+drainer_servers:
+  - host: n1
+    data_dir: /home/tidb/data/drainer-8249/data
+    commit_ts: -1
+    config:
+      syncer.db-type: "file"
+
+monitoring_servers:
+  - host: n1
+    rule_dir: /tmp/local/prometheus
+    external_labels:
+      cluster: overwritten
+grafana_servers:
+  - host: n1
+    dashboard_dir: /tmp/local/grafana
+alertmanager_servers:
+  - host: n1
+    config_file: /tmp/local/alertmanager/alertmanager.yml


### PR DESCRIPTION
## What changed

This PR adds a topology-level `external_labels` field for `monitoring_servers` and renders the configured labels into Prometheus `global.external_labels`.

It keeps TiUP-managed `cluster` and `monitor` labels as reserved keys and rejects user configurations that try to override them.

## Why it changed

Today TiUP hardcodes only `cluster` and `monitor` in the generated `prometheus.yml` and does not provide a supported way to declare extra Prometheus external labels in topology.

Users can edit the generated config manually, but those changes are not preserved across TiUP lifecycle operations such as reload, scale, or upgrade.

## User impact

Users can now declare static Prometheus external labels in topology, for example:

```yaml
monitoring_servers:
  - host: 10.0.1.21
    external_labels:
      environment: production
      region: us-east-1
```

TiUP will render them into `global.external_labels` together with the built-in `cluster` and `monitor` labels.

## Validation

- `go test ./pkg/cluster/template/config ./pkg/cluster/spec`
- `bash -n tests/tiup-cluster/test_external_labels.sh tests/tiup-cluster/script/external_labels.sh`
- `version=v4.0.12 ./run.sh test_external_labels`

The integration coverage verifies:

- invalid topology is rejected when reserved labels are overridden
- deploy/start renders the expected `external_labels` into `prometheus.yml`
- `edit-config + reload` updates the rendered labels on a running cluster


## Issue

close #1795
