### PR TITLE
bump version to v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,6 @@ TiUP Changelog
 
 - Fix the issue that `tiup mirror clone -h` and `tiup mirror clone --help` may panic (#2717, @xhebox)
 
-### Miscellaneous
-
-- Add lifecycle test and documentation coverage for Prometheus `external_labels` support (#2721, @zanmato1984)
-- Update test `root.json` fixtures to v7 (#2724, @bb7133)
-- Fix cluster scale CI by removing stale TiSpark from non-TLS test topologies (#2713, @app/copilot-swe-agent)
-
 ## [1.16.5] 2026-04-10
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 TiUP Changelog
 
+## [1.17.0] 2026-07-27
+
+### New Features
+
+- `tiup-cluster` support `monitoring_servers[].external_labels` to configure Prometheus external labels (#2719, @zanmato1984)
+- `tiup-cluster` support TiKV worker deployment and management (#2677, @Lloyd-Pottiger)
+
+### Improvements
+
+- `tiup-cluster` refresh TLS certificates after renaming a TLS-enabled cluster to avoid certificate mismatch (#2715, @xhebox)
+- Remove the deprecated TiUP root `--tag/-T` flag. Use component-level tag flags instead, such as `tiup playground --tag <name>` (#2716, @xhebox)
+
+### Fixes
+
+- Fix the issue that `tiup mirror clone -h` and `tiup mirror clone --help` may panic (#2717, @xhebox)
+
+### Miscellaneous
+
+- Add lifecycle test and documentation coverage for Prometheus `external_labels` support (#2721, @zanmato1984)
+- Update test `root.json` fixtures to v7 (#2724, @bb7133)
+- Fix cluster scale CI by removing stale TiSpark from non-TLS test topologies (#2713, @app/copilot-swe-agent)
+
 ## [1.16.5] 2026-04-10
 
 ### New Features

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -21,9 +21,9 @@ var (
 	// TiUPVerMajor is the major version of TiUP
 	TiUPVerMajor = 1
 	// TiUPVerMinor is the minor version of TiUP
-	TiUPVerMinor = 16
+	TiUPVerMinor = 17
 	// TiUPVerPatch is the patch version of TiUP
-	TiUPVerPatch = 5
+	TiUPVerPatch = 0
 	// TiUPVerName is an alternative name of the version
 	TiUPVerName = "tiup"
 	// GitHash is the current git commit hash


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Prepare the `v1.17.0` release on top of `release-1.17`.

### What is changed and how it works?

- bump the built-in TiUP version from `1.16.5` to `1.17.0`
- add the `v1.17.0` changelog entry based on merged changes since `v1.16.5`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] No code

Code changes

- [ ] Has exported function/method change
- [ ] Has exported variable/fields change
- [ ] Has interface methods change
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation

Release notes:
```release-note
NONE
```
