### PR TITLE
cluster: scrape node_exporter on dedicated tidb-dashboard hosts

### DIFF
--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -439,7 +439,6 @@ func (i *MonitorInstance) InitConfig(
 			cfig.AddTiKVCDC(tikvCdc.Host, uint64(tikvCdc.Port))
 		}
 	}
-	addDashboardScrapeHosts(uniqueHosts, topoHasField)
 	if servers, found := topoHasField("Monitors"); found {
 		for idx := 0; idx < servers.Len(); idx++ {
 			monitoring := servers.Index(idx).Interface().(*PrometheusSpec)
@@ -477,6 +476,9 @@ func (i *MonitorInstance) InitConfig(
 			cfig.AddDMWorker(host, uint64(port))
 		}
 	}
+	// Keep this out of the uniqueHosts loops above: another if+for would
+	// push InitConfig over revive's cognitive-complexity limit of 110.
+	addDashboardScrapeHosts(uniqueHosts, topoHasField)
 
 	if monitoredOptions != nil {
 		for host := range uniqueHosts {

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -255,6 +255,17 @@ func (i *MonitorInstance) handleRemoteWrite(spec *PrometheusSpec, monitoring *Pr
 	}
 }
 
+func addDashboardScrapeHosts(uniqueHosts set.StringSet, topoHasField func(string) (reflect.Value, bool)) {
+	servers, found := topoHasField("DashboardServers")
+	if !found {
+		return
+	}
+	for idx := 0; idx < servers.Len(); idx++ {
+		dashboard := servers.Index(idx).Interface().(*DashboardSpec)
+		uniqueHosts.Insert(dashboard.Host)
+	}
+}
+
 // InitConfig implement Instance interface
 func (i *MonitorInstance) InitConfig(
 	ctx context.Context,
@@ -428,12 +439,7 @@ func (i *MonitorInstance) InitConfig(
 			cfig.AddTiKVCDC(tikvCdc.Host, uint64(tikvCdc.Port))
 		}
 	}
-	if servers, found := topoHasField("DashboardServers"); found {
-		for idx := 0; idx < servers.Len(); idx++ {
-			dashboard := servers.Index(idx).Interface().(*DashboardSpec)
-			uniqueHosts.Insert(dashboard.Host)
-		}
-	}
+	addDashboardScrapeHosts(uniqueHosts, topoHasField)
 	if servers, found := topoHasField("Monitors"); found {
 		for idx := 0; idx < servers.Len(); idx++ {
 			monitoring := servers.Index(idx).Interface().(*PrometheusSpec)

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -255,45 +255,6 @@ func (i *MonitorInstance) handleRemoteWrite(spec *PrometheusSpec, monitoring *Pr
 	}
 }
 
-// uniqueHostsFromTopo returns hosts scraped by node_exporter and blackbox_exporter.
-func uniqueHostsFromTopo(topo Topology) set.StringSet {
-	uniqueHosts := set.NewStringSet()
-	for _, field := range []string{
-		"PDServers",
-		"TSOServers",
-		"SchedulingServers",
-		"RouterServers",
-		"ResourceManagerServers",
-		"DashboardServers",
-		"TiKVServers",
-		"TiKVWorkerServers",
-		"TiDBServers",
-		"TiProxyServers",
-		"TiFlashServers",
-		"PumpServers",
-		"Drainers",
-		"CDCServers",
-		"TiKVCDCServers",
-		"Monitors",
-		"Grafanas",
-		"Alertmanagers",
-		"Masters",
-		"Workers",
-	} {
-		servers, found := findSliceField(topo, field)
-		if !found {
-			continue
-		}
-		for i := 0; i < servers.Len(); i++ {
-			hostField := reflect.Indirect(servers.Index(i)).FieldByName("Host")
-			if hostField.IsValid() && hostField.Kind() == reflect.String && hostField.String() != "" {
-				uniqueHosts.Insert(hostField.String())
-			}
-		}
-	}
-	return uniqueHosts
-}
-
 // InitConfig implement Instance interface
 func (i *MonitorInstance) InitConfig(
 	ctx context.Context,
@@ -366,65 +327,75 @@ func (i *MonitorInstance) InitConfig(
 	}
 	cfig.ScrapeInterval = spec.ScrapeInterval
 	cfig.ScrapeTimeout = spec.ScrapeTimeout
-	uniqueHosts := uniqueHostsFromTopo(i.topo)
+	uniqueHosts := set.NewStringSet()
 
 	if servers, found := topoHasField("PDServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			pd := servers.Index(i).Interface().(*PDSpec)
+			uniqueHosts.Insert(pd.Host)
 			cfig.AddPD(pd.Host, uint64(pd.ClientPort))
 		}
 	}
 	if servers, found := topoHasField("TSOServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			tso := servers.Index(i).Interface().(*TSOSpec)
+			uniqueHosts.Insert(tso.Host)
 			cfig.AddTSO(tso.Host, uint64(tso.Port))
 		}
 	}
 	if servers, found := topoHasField("SchedulingServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			scheduling := servers.Index(i).Interface().(*SchedulingSpec)
+			uniqueHosts.Insert(scheduling.Host)
 			cfig.AddScheduling(scheduling.Host, uint64(scheduling.Port))
 		}
 	}
 	if servers, found := topoHasField("RouterServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			router := servers.Index(i).Interface().(*RouterSpec)
+			uniqueHosts.Insert(router.Host)
 			cfig.AddRouter(router.Host, uint64(router.Port))
 		}
 	}
 	if servers, found := topoHasField("ResourceManagerServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			rm := servers.Index(i).Interface().(*ResourceManagerSpec)
+			uniqueHosts.Insert(rm.Host)
 			cfig.AddResourceManager(rm.Host, uint64(rm.Port))
 		}
 	}
 	if servers, found := topoHasField("TiKVServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			kv := servers.Index(i).Interface().(*TiKVSpec)
+			uniqueHosts.Insert(kv.Host)
 			cfig.AddTiKV(kv.Host, uint64(kv.StatusPort))
 		}
 	}
 	if servers, found := topoHasField("TiKVWorkerServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			worker := servers.Index(i).Interface().(*TiKVWorkerSpec)
+			uniqueHosts.Insert(worker.Host)
 			cfig.AddTiKVWorker(worker.Host, uint64(worker.Port))
 		}
 	}
 	if servers, found := topoHasField("TiDBServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			db := servers.Index(i).Interface().(*TiDBSpec)
+			uniqueHosts.Insert(db.Host)
 			cfig.AddTiDB(db.Host, uint64(db.StatusPort))
 		}
 	}
 	if servers, found := topoHasField("TiProxyServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			db := servers.Index(i).Interface().(*TiProxySpec)
+			uniqueHosts.Insert(db.Host)
 			cfig.AddTiProxy(db.Host, uint64(db.StatusPort))
 		}
 	}
 	if servers, found := topoHasField("TiFlashServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			flash := servers.Index(i).Interface().(*TiFlashSpec)
+			uniqueHosts.Insert(flash.Host)
 			cfig.AddTiFlashLearner(flash.Host, uint64(flash.FlashProxyStatusPort))
 			cfig.AddTiFlash(flash.Host, uint64(flash.StatusPort))
 		}
@@ -432,36 +403,54 @@ func (i *MonitorInstance) InitConfig(
 	if servers, found := topoHasField("PumpServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			pump := servers.Index(i).Interface().(*PumpSpec)
+			uniqueHosts.Insert(pump.Host)
 			cfig.AddPump(pump.Host, uint64(pump.Port))
 		}
 	}
 	if servers, found := topoHasField("Drainers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			drainer := servers.Index(i).Interface().(*DrainerSpec)
+			uniqueHosts.Insert(drainer.Host)
 			cfig.AddDrainer(drainer.Host, uint64(drainer.Port))
 		}
 	}
 	if servers, found := topoHasField("CDCServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			cdc := servers.Index(i).Interface().(*CDCSpec)
+			uniqueHosts.Insert(cdc.Host)
 			cfig.AddCDC(cdc.Host, uint64(cdc.Port))
 		}
 	}
 	if servers, found := topoHasField("TiKVCDCServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			tikvCdc := servers.Index(i).Interface().(*TiKVCDCSpec)
+			uniqueHosts.Insert(tikvCdc.Host)
 			cfig.AddTiKVCDC(tikvCdc.Host, uint64(tikvCdc.Port))
+		}
+	}
+	if servers, found := topoHasField("DashboardServers"); found {
+		for idx := 0; idx < servers.Len(); idx++ {
+			dashboard := servers.Index(idx).Interface().(*DashboardSpec)
+			uniqueHosts.Insert(dashboard.Host)
+		}
+	}
+	if servers, found := topoHasField("Monitors"); found {
+		for idx := 0; idx < servers.Len(); idx++ {
+			monitoring := servers.Index(idx).Interface().(*PrometheusSpec)
+			uniqueHosts.Insert(monitoring.Host)
 		}
 	}
 	if servers, found := topoHasField("Grafanas"); found {
 		for i := 0; i < servers.Len(); i++ {
 			grafana := servers.Index(i).Interface().(*GrafanaSpec)
+			uniqueHosts.Insert(grafana.Host)
 			cfig.AddGrafana(grafana.Host, uint64(grafana.Port))
 		}
 	}
 	if servers, found := topoHasField("Alertmanagers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			alertmanager := servers.Index(i).Interface().(*AlertmanagerSpec)
+			uniqueHosts.Insert(alertmanager.Host)
 			cfig.AddAlertmanager(alertmanager.Host, uint64(alertmanager.WebPort))
 		}
 	}
@@ -469,6 +458,7 @@ func (i *MonitorInstance) InitConfig(
 		for i := 0; i < servers.Len(); i++ {
 			master := reflect.Indirect(servers.Index(i))
 			host, port := master.FieldByName("Host").String(), master.FieldByName("Port").Int()
+			uniqueHosts.Insert(host)
 			cfig.AddDMMaster(host, uint64(port))
 		}
 	}
@@ -477,6 +467,7 @@ func (i *MonitorInstance) InitConfig(
 		for i := 0; i < servers.Len(); i++ {
 			worker := reflect.Indirect(servers.Index(i))
 			host, port := worker.FieldByName("Host").String(), worker.FieldByName("Port").Int()
+			uniqueHosts.Insert(host)
 			cfig.AddDMWorker(host, uint64(port))
 		}
 	}

--- a/pkg/cluster/spec/monitoring.go
+++ b/pkg/cluster/spec/monitoring.go
@@ -255,6 +255,45 @@ func (i *MonitorInstance) handleRemoteWrite(spec *PrometheusSpec, monitoring *Pr
 	}
 }
 
+// uniqueHostsFromTopo returns hosts scraped by node_exporter and blackbox_exporter.
+func uniqueHostsFromTopo(topo Topology) set.StringSet {
+	uniqueHosts := set.NewStringSet()
+	for _, field := range []string{
+		"PDServers",
+		"TSOServers",
+		"SchedulingServers",
+		"RouterServers",
+		"ResourceManagerServers",
+		"DashboardServers",
+		"TiKVServers",
+		"TiKVWorkerServers",
+		"TiDBServers",
+		"TiProxyServers",
+		"TiFlashServers",
+		"PumpServers",
+		"Drainers",
+		"CDCServers",
+		"TiKVCDCServers",
+		"Monitors",
+		"Grafanas",
+		"Alertmanagers",
+		"Masters",
+		"Workers",
+	} {
+		servers, found := findSliceField(topo, field)
+		if !found {
+			continue
+		}
+		for i := 0; i < servers.Len(); i++ {
+			hostField := reflect.Indirect(servers.Index(i)).FieldByName("Host")
+			if hostField.IsValid() && hostField.Kind() == reflect.String && hostField.String() != "" {
+				uniqueHosts.Insert(hostField.String())
+			}
+		}
+	}
+	return uniqueHosts
+}
+
 // InitConfig implement Instance interface
 func (i *MonitorInstance) InitConfig(
 	ctx context.Context,
@@ -327,75 +366,65 @@ func (i *MonitorInstance) InitConfig(
 	}
 	cfig.ScrapeInterval = spec.ScrapeInterval
 	cfig.ScrapeTimeout = spec.ScrapeTimeout
-	uniqueHosts := set.NewStringSet()
+	uniqueHosts := uniqueHostsFromTopo(i.topo)
 
 	if servers, found := topoHasField("PDServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			pd := servers.Index(i).Interface().(*PDSpec)
-			uniqueHosts.Insert(pd.Host)
 			cfig.AddPD(pd.Host, uint64(pd.ClientPort))
 		}
 	}
 	if servers, found := topoHasField("TSOServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			tso := servers.Index(i).Interface().(*TSOSpec)
-			uniqueHosts.Insert(tso.Host)
 			cfig.AddTSO(tso.Host, uint64(tso.Port))
 		}
 	}
 	if servers, found := topoHasField("SchedulingServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			scheduling := servers.Index(i).Interface().(*SchedulingSpec)
-			uniqueHosts.Insert(scheduling.Host)
 			cfig.AddScheduling(scheduling.Host, uint64(scheduling.Port))
 		}
 	}
 	if servers, found := topoHasField("RouterServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			router := servers.Index(i).Interface().(*RouterSpec)
-			uniqueHosts.Insert(router.Host)
 			cfig.AddRouter(router.Host, uint64(router.Port))
 		}
 	}
 	if servers, found := topoHasField("ResourceManagerServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			rm := servers.Index(i).Interface().(*ResourceManagerSpec)
-			uniqueHosts.Insert(rm.Host)
 			cfig.AddResourceManager(rm.Host, uint64(rm.Port))
 		}
 	}
 	if servers, found := topoHasField("TiKVServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			kv := servers.Index(i).Interface().(*TiKVSpec)
-			uniqueHosts.Insert(kv.Host)
 			cfig.AddTiKV(kv.Host, uint64(kv.StatusPort))
 		}
 	}
 	if servers, found := topoHasField("TiKVWorkerServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			worker := servers.Index(i).Interface().(*TiKVWorkerSpec)
-			uniqueHosts.Insert(worker.Host)
 			cfig.AddTiKVWorker(worker.Host, uint64(worker.Port))
 		}
 	}
 	if servers, found := topoHasField("TiDBServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			db := servers.Index(i).Interface().(*TiDBSpec)
-			uniqueHosts.Insert(db.Host)
 			cfig.AddTiDB(db.Host, uint64(db.StatusPort))
 		}
 	}
 	if servers, found := topoHasField("TiProxyServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			db := servers.Index(i).Interface().(*TiProxySpec)
-			uniqueHosts.Insert(db.Host)
 			cfig.AddTiProxy(db.Host, uint64(db.StatusPort))
 		}
 	}
 	if servers, found := topoHasField("TiFlashServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			flash := servers.Index(i).Interface().(*TiFlashSpec)
-			uniqueHosts.Insert(flash.Host)
 			cfig.AddTiFlashLearner(flash.Host, uint64(flash.FlashProxyStatusPort))
 			cfig.AddTiFlash(flash.Host, uint64(flash.StatusPort))
 		}
@@ -403,48 +432,36 @@ func (i *MonitorInstance) InitConfig(
 	if servers, found := topoHasField("PumpServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			pump := servers.Index(i).Interface().(*PumpSpec)
-			uniqueHosts.Insert(pump.Host)
 			cfig.AddPump(pump.Host, uint64(pump.Port))
 		}
 	}
 	if servers, found := topoHasField("Drainers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			drainer := servers.Index(i).Interface().(*DrainerSpec)
-			uniqueHosts.Insert(drainer.Host)
 			cfig.AddDrainer(drainer.Host, uint64(drainer.Port))
 		}
 	}
 	if servers, found := topoHasField("CDCServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			cdc := servers.Index(i).Interface().(*CDCSpec)
-			uniqueHosts.Insert(cdc.Host)
 			cfig.AddCDC(cdc.Host, uint64(cdc.Port))
 		}
 	}
 	if servers, found := topoHasField("TiKVCDCServers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			tikvCdc := servers.Index(i).Interface().(*TiKVCDCSpec)
-			uniqueHosts.Insert(tikvCdc.Host)
 			cfig.AddTiKVCDC(tikvCdc.Host, uint64(tikvCdc.Port))
-		}
-	}
-	if servers, found := topoHasField("Monitors"); found {
-		for idx := 0; idx < servers.Len(); idx++ {
-			monitoring := servers.Index(idx).Interface().(*PrometheusSpec)
-			uniqueHosts.Insert(monitoring.Host)
 		}
 	}
 	if servers, found := topoHasField("Grafanas"); found {
 		for i := 0; i < servers.Len(); i++ {
 			grafana := servers.Index(i).Interface().(*GrafanaSpec)
-			uniqueHosts.Insert(grafana.Host)
 			cfig.AddGrafana(grafana.Host, uint64(grafana.Port))
 		}
 	}
 	if servers, found := topoHasField("Alertmanagers"); found {
 		for i := 0; i < servers.Len(); i++ {
 			alertmanager := servers.Index(i).Interface().(*AlertmanagerSpec)
-			uniqueHosts.Insert(alertmanager.Host)
 			cfig.AddAlertmanager(alertmanager.Host, uint64(alertmanager.WebPort))
 		}
 	}
@@ -452,7 +469,6 @@ func (i *MonitorInstance) InitConfig(
 		for i := 0; i < servers.Len(); i++ {
 			master := reflect.Indirect(servers.Index(i))
 			host, port := master.FieldByName("Host").String(), master.FieldByName("Port").Int()
-			uniqueHosts.Insert(host)
 			cfig.AddDMMaster(host, uint64(port))
 		}
 	}
@@ -461,7 +477,6 @@ func (i *MonitorInstance) InitConfig(
 		for i := 0; i < servers.Len(); i++ {
 			worker := reflect.Indirect(servers.Index(i))
 			host, port := worker.FieldByName("Host").String(), worker.FieldByName("Port").Int()
-			uniqueHosts.Insert(host)
 			cfig.AddDMWorker(host, uint64(port))
 		}
 	}

--- a/pkg/cluster/spec/monitoring_test.go
+++ b/pkg/cluster/spec/monitoring_test.go
@@ -441,22 +441,17 @@ func TestHandleRemoteWriteDisabled(t *testing.T) {
 	assert.Equal(t, vmURL, spec.RemoteConfig.RemoteWrite[0]["url"])
 }
 
-func TestUniqueHostsFromTopoIncludesStandaloneDashboard(t *testing.T) {
+func TestDashboardServersDiscoveredForNodeExporter(t *testing.T) {
 	topo := &Specification{
-		PDServers: []*PDSpec{
-			{Host: "10.0.1.11", ClientPort: 2379},
-		},
-		Monitors: []*PrometheusSpec{
-			{Host: "10.0.1.21", Port: 9090},
-		},
 		DashboardServers: []*DashboardSpec{
 			{Host: "10.0.1.50", Port: 12333},
 		},
 	}
 
-	hosts := uniqueHostsFromTopo(topo)
-	assert.True(t, hosts.Exist("10.0.1.11"))
-	assert.True(t, hosts.Exist("10.0.1.21"))
-	assert.True(t, hosts.Exist("10.0.1.50"), "standalone tidb-dashboard host should be scraped by node_exporter")
-	assert.Equal(t, 3, len(hosts))
+	servers, found := findSliceField(topo, "DashboardServers")
+	assert.True(t, found)
+	assert.Equal(t, 1, servers.Len())
+
+	dashboard := servers.Index(0).Interface().(*DashboardSpec)
+	assert.Equal(t, "10.0.1.50", dashboard.Host)
 }

--- a/pkg/cluster/spec/monitoring_test.go
+++ b/pkg/cluster/spec/monitoring_test.go
@@ -23,10 +23,13 @@ import (
 	"testing"
 
 	"github.com/pingcap/tiup/pkg/checkpoint"
+	"github.com/pingcap/tiup/pkg/cluster/ctxt"
 	"github.com/pingcap/tiup/pkg/cluster/executor"
+	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
 	"github.com/pingcap/tiup/pkg/meta"
 	"github.com/pingcap/tiup/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
@@ -441,17 +444,77 @@ func TestHandleRemoteWriteDisabled(t *testing.T) {
 	assert.Equal(t, vmURL, spec.RemoteConfig.RemoteWrite[0]["url"])
 }
 
-func TestDashboardServersDiscoveredForNodeExporter(t *testing.T) {
+func TestStandaloneDashboardHostInNodeExporterTargets(t *testing.T) {
 	topo := &Specification{
+		GlobalOptions: GlobalOptions{
+			User:        "tidb",
+			SystemdMode: UserMode,
+		},
+		MonitoredOptions: MonitoredOptions{
+			NodeExporterPort:     9100,
+			BlackboxExporterPort: 9115,
+		},
+		PDServers: []*PDSpec{
+			{Host: "10.0.1.11", ClientPort: 2379},
+		},
+		Monitors: []*PrometheusSpec{
+			{Host: "10.0.1.21", Port: 9090},
+		},
 		DashboardServers: []*DashboardSpec{
 			{Host: "10.0.1.50", Port: 12333},
 		},
 	}
 
-	servers, found := findSliceField(topo, "DashboardServers")
-	assert.True(t, found)
-	assert.Equal(t, 1, servers.Len())
+	deployDir := t.TempDir()
+	cacheDir := t.TempDir()
+	paths := meta.DirPaths{
+		Deploy: deployDir,
+		Cache:  cacheDir,
+		Data:   []string{filepath.Join(deployDir, "data")},
+		Log:    filepath.Join(deployDir, "log"),
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(deployDir, "bin", "prometheus"), 0755))
 
-	dashboard := servers.Index(0).Interface().(*DashboardSpec)
-	assert.Equal(t, "10.0.1.50", dashboard.Host)
+	comp := MonitorComponent{Topology: topo}
+	prom := comp.Instances()[0].(*MonitorInstance)
+	err := prom.InitConfig(
+		ctxt.New(context.Background(), 0, logprinter.NewLogger("")),
+		&mockExecutor{},
+		"verify-dashboard",
+		"v8.5.0",
+		"tidb",
+		paths,
+	)
+	require.NoError(t, err)
+
+	body, err := os.ReadFile(filepath.Join(deployDir, "conf", "prometheus.yml"))
+	require.NoError(t, err)
+
+	var parsed struct {
+		ScrapeConfigs []struct {
+			JobName       string `yaml:"job_name"`
+			StaticConfigs []struct {
+				Targets []string `yaml:"targets"`
+			} `yaml:"static_configs"`
+		} `yaml:"scrape_configs"`
+	}
+	require.NoError(t, yaml.Unmarshal(body, &parsed))
+
+	targetsOf := func(job string) []string {
+		var out []string
+		for _, sc := range parsed.ScrapeConfigs {
+			if sc.JobName != job {
+				continue
+			}
+			for _, cfg := range sc.StaticConfigs {
+				out = append(out, cfg.Targets...)
+			}
+		}
+		return out
+	}
+
+	assert.Contains(t, targetsOf("overwritten-nodes"), "10.0.1.50:9100")
+	assert.Contains(t, targetsOf("overwritten-nodes"), "10.0.1.11:9100")
+	assert.Contains(t, targetsOf("overwritten-nodes"), "10.0.1.21:9100")
+	assert.Contains(t, targetsOf("monitor_port_probe"), "10.0.1.50:9115")
 }

--- a/pkg/cluster/spec/monitoring_test.go
+++ b/pkg/cluster/spec/monitoring_test.go
@@ -440,3 +440,23 @@ func TestHandleRemoteWriteDisabled(t *testing.T) {
 	assert.Len(t, spec.RemoteConfig.RemoteWrite, 1)
 	assert.Equal(t, vmURL, spec.RemoteConfig.RemoteWrite[0]["url"])
 }
+
+func TestUniqueHostsFromTopoIncludesStandaloneDashboard(t *testing.T) {
+	topo := &Specification{
+		PDServers: []*PDSpec{
+			{Host: "10.0.1.11", ClientPort: 2379},
+		},
+		Monitors: []*PrometheusSpec{
+			{Host: "10.0.1.21", Port: 9090},
+		},
+		DashboardServers: []*DashboardSpec{
+			{Host: "10.0.1.50", Port: 12333},
+		},
+	}
+
+	hosts := uniqueHostsFromTopo(topo)
+	assert.True(t, hosts.Exist("10.0.1.11"))
+	assert.True(t, hosts.Exist("10.0.1.21"))
+	assert.True(t, hosts.Exist("10.0.1.50"), "standalone tidb-dashboard host should be scraped by node_exporter")
+	assert.Equal(t, 3, len(hosts))
+}


### PR DESCRIPTION
### What problem does this PR solve?

close #2735

When `tidb-dashboard` is deployed on a dedicated host (`tidb_dashboard_servers`), TiUP already installs `node_exporter` / `blackbox_exporter` on that machine. Prometheus config generation did not include `DashboardServers` in the scrape host list, so CPU, memory, and other machine metrics from a standalone Dashboard node were never collected.

This is the same class of issue as Prometheus-only hosts not being scraped (https://github.com/pingcap/tiup/pull/1806).

### What is changed and how it works?

Add `DashboardServers` to the existing Prometheus scrape-host loop, the same way `Monitors` / Grafana hosts are added. There is no `AddDashboard` job because Prometheus does not scrape tidb-dashboard process metrics; only the node_exporter / blackbox_exporter targets are needed.

### Check List

Tests

 - Unit test

Code changes

Release notes:
```release-note
Fix the issue that node_exporter metrics are not collected when tidb-dashboard is deployed on a dedicated host
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring target generation for standalone dashboard hosts, ensuring they are included in node-exporter and port-probe monitoring targets.

* **Tests**
  * Added coverage to verify monitoring configuration includes dashboard, PD, and monitor hosts across the relevant exporter targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->