### PR TITLE
cluster: honor ignore_exporter when destroying a cluster

### DIFF
--- a/pkg/cluster/operation/destroy.go
+++ b/pkg/cluster/operation/destroy.go
@@ -58,7 +58,7 @@ func Destroy(
 		for _, inst := range insts {
 			instCount[inst.GetManageHost()]--
 			if instCount[inst.GetManageHost()] == 0 {
-				if cluster.GetMonitoredOptions() != nil {
+				if cluster.GetMonitoredOptions() != nil && !inst.IgnoreMonitorAgent() {
 					if err := DestroyMonitored(ctx, inst, cluster.GetMonitoredOptions(), options.OptTimeout, cluster.BaseTopo().GlobalOptions.SystemdMode); err != nil && !options.Force {
 						return err
 					}

--- a/pkg/cluster/operation/destroy_test.go
+++ b/pkg/cluster/operation/destroy_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiup/pkg/cluster/ctxt"
+	"github.com/pingcap/tiup/pkg/cluster/spec"
+	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type destroyExecutor struct {
+	commands []string
+}
+
+func (e *destroyExecutor) Execute(_ context.Context, cmd string, _ bool, _ ...time.Duration) ([]byte, []byte, error) {
+	e.commands = append(e.commands, cmd)
+	// Empty ss output models stopped ports, so an unexpected exporter cleanup
+	// is caught by the assertions without waiting for a timeout.
+	return nil, nil, nil
+}
+
+func (*destroyExecutor) Transfer(_ context.Context, _, _ string, _ bool, _ int, _ bool) error {
+	return nil
+}
+
+func TestDestroyIgnoreExporter(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		ignoreExporter    bool
+		multipleInstances bool
+		force             bool
+	}{
+		{name: "shared", ignoreExporter: true},
+		{name: "shared_multiple_instances", ignoreExporter: true, multipleInstances: true},
+		{name: "shared_force", ignoreExporter: true, force: true},
+		{name: "managed"},
+		{name: "managed_multiple_instances", multipleInstances: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			topology := fmt.Sprintf(`
+global:
+  user: tidb
+  deploy_dir: /tidb-deploy
+  data_dir: /tidb-data
+monitored:
+  deploy_dir: /tidb-deploy/monitor-9100
+  data_dir: /tidb-data/monitor-9100
+  log_dir: /tidb-log/monitor-9100
+pd_servers:
+  - host: 192.0.2.1
+    ignore_exporter: %t
+`, tc.ignoreExporter)
+			if tc.multipleInstances {
+				topology += fmt.Sprintf(`
+tidb_servers:
+  - host: 192.0.2.1
+    ignore_exporter: %t
+`, tc.ignoreExporter)
+			}
+			var topo spec.Specification
+			require.NoError(t, yaml.Unmarshal([]byte(topology), &topo))
+
+			exec := &destroyExecutor{}
+			ctx := ctxt.New(context.Background(), 1, logprinter.NewLogger(""))
+			inner := ctxt.GetInner(ctx)
+			inner.SetExecutor("192.0.2.1", exec)
+			inner.PublicKeyPath = filepath.Join(t.TempDir(), "id_rsa.pub")
+			require.NoError(t, os.WriteFile(inner.PublicKeyPath, []byte("ssh-ed25519 test-key"), 0600))
+
+			require.NoError(t, Destroy(ctx, &topo, Options{Force: tc.force}))
+
+			// Destroy must still remove the cluster's own components.
+			require.Contains(t, exec.commands, "rm -rf /etc/systemd/system/pd-2379.service;")
+			if tc.multipleInstances {
+				require.Contains(t, exec.commands, "rm -rf /etc/systemd/system/tidb-4000.service;")
+			}
+
+			wantDeletes := 1
+			if tc.ignoreExporter {
+				wantDeletes = 0
+			}
+			for _, path := range []string{
+				"/tidb-deploy/monitor-9100",
+				"/tidb-data/monitor-9100",
+				"/tidb-log/monitor-9100",
+				"/etc/systemd/system/node_exporter-9100.service",
+				"/etc/systemd/system/blackbox_exporter-9115.service",
+			} {
+				deletes := 0
+				for _, cmd := range exec.commands {
+					if strings.HasPrefix(cmd, "rm -rf ") && strings.Contains(cmd, path) {
+						deletes++
+					}
+				}
+				require.Equal(t, wantDeletes, deletes, "deletions of %s: %v", path, exec.commands)
+			}
+
+			portChecks := 0
+			for _, cmd := range exec.commands {
+				if cmd == "ss -ltn" {
+					portChecks++
+				}
+			}
+			require.Equal(t, 2*wantDeletes, portChecks, "each managed exporter port is checked once")
+		})
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #2733. Supersedes #2197, based on the fix originally proposed by @Smityz.

When clusters share a host, a cluster configured with `ignore_exporter: true` must leave the existing exporters untouched. `destroy` skips stopping those exporters but still deletes their directories and systemd units before waiting for their ports to close. The command can therefore damage another cluster's monitoring even when it fails with a timeout; `--force` does not prevent the deletion.

### What is changed and how it works?

Check `IgnoreMonitorAgent()` before calling `DestroyMonitored()`. Ignored exporters are left untouched, while cleanup of managed exporters and the cluster's own components remains unchanged.

Add command-recording unit tests around `Destroy()` covering ignored and managed exporters, multiple instances on one host, and `--force`. The tests verify exporter directory/unit deletion and port checks, while confirming the cluster's own components are still removed. The three ignored-exporter cases fail without the fix and pass with it.

### Check List

Tests:

- [x] Unit test: `go test ./pkg/cluster/operation ./pkg/cluster/spec -count=1`
- [x] Manual E2E on a native Linux host using real SSH/systemd and two TiDB v8.5.0 clusters, each with one PD, one TiKV, and one TiDB

Manual E2E results:

- Reproduced the issue without the fix: destroying the sharing cluster deletes exporter directories and unit files, then times out while the exporter processes remain alive
- With the fix, normal and `--force` destroy preserve the shared exporters' files, binary hashes, PIDs, and metrics; SQL reads and writes on the owner cluster continue to succeed
- Both exporters restart successfully after `systemctl daemon-reload`; destroying the owner cluster still removes their files and stops their ports

Additional validation: `make cluster` and `make lint` passed. Full static checking timed out loading packages; scoped checking found only the existing QF1003 in `operation/check.go:617`, and diff-filtered checking reported no new issues. The full multi-component build was stopped during the unrelated client build.

Related changes:

- [x] Need to cherry-pick to the release branch; target version to be agreed

Release notes:

```release-note
Fix the issue that `tiup cluster destroy` deletes shared exporter files when `ignore_exporter` is enabled
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster destruction now preserves monitored services for instances configured to ignore the monitor agent.
  * Exporter-related files and services are skipped when the corresponding ignore setting is enabled.
* **Tests**
  * Added coverage for destruction behavior with ignored monitor and exporter components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->