### PR TITLE
ci: migrate to Bookworm and fix concurrent TLS CA copying

### DIFF
--- a/.github/workflows/integrate-cluster-cmd.yaml
+++ b/.github/workflows/integrate-cluster-cmd.yaml
@@ -90,6 +90,8 @@ jobs:
         # if: always()
         run: |
           docker exec tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/script/pull_log.sh /tiup-cluster/logs
+          mkdir -p ./logs
+          docker cp tiup-cluster-control:/tiup-cluster/logs/. ./logs/
 
       - name: Detect error log
         if: ${{ failure() }}
@@ -103,7 +105,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           overwrite: true
-          name: component_logs
+          name: component_logs-${{ matrix.cases }}
           path: ./logs
 
       - name: Output cluster debug log

--- a/.github/workflows/integrate-cluster-scale.yaml
+++ b/.github/workflows/integrate-cluster-scale.yaml
@@ -91,6 +91,8 @@ jobs:
         # if: always()
         run: |
           docker exec tiup-cluster-control bash /tiup-cluster/tests/tiup-cluster/script/pull_log.sh /tiup-cluster/logs
+          mkdir -p ./logs
+          docker cp tiup-cluster-control:/tiup-cluster/logs/. ./logs/
 
       - name: Detect error log
         if: ${{ failure() }}
@@ -103,7 +105,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           overwrite: true
-          name: cluster_logs
+          name: cluster_logs-${{ matrix.cases }}
           path: ./logs
 
       - name: Output cluster debug log

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,19 +1,17 @@
 # Based on the deprecated `https://github.com/tutumcloud/tutum-debian`
-FROM golang:1.24-bullseye
+FROM golang:1.24-bookworm
 
 # Use mirrors for poor network...
 #RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list && \
 #    sed -i 's/security.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 
 # Install packages
-# JRE 11 is installed for tispark testing, a tispark node could be started
-# with Java 11, but is not going to work properly. However, we don't test
-# for SQL in CI, so it's ok to use Java 11 instead of Java 8.
 RUN apt-get update && \
     apt-get -y install \
         dos2unix \
         openssh-server \
-        openjdk-11-jre-headless \
+        systemd systemd-sysv \
+        psmisc \
         sudo vim \
         iproute2 \
         && \

--- a/pkg/cluster/task/tls.go
+++ b/pkg/cluster/task/tls.go
@@ -71,6 +71,9 @@ func (c *TLSCert) Execute(ctx context.Context) error {
 	// save cert to cache dir
 	keyFileName := fmt.Sprintf("%s-%s-%d.pem", c.role, c.host, c.port)
 	certFileName := fmt.Sprintf("%s-%s-%d.crt", c.role, c.host, c.port)
+	// Per-instance CA cache path. Parallel TLSCert tasks used to share
+	// cache/ca.crt and SCP a truncated file (#2727).
+	caFileName := fmt.Sprintf("%s-%s-%d-ca.crt", c.role, c.host, c.port)
 	keyFile := filepath.Join(
 		c.paths.Cache,
 		keyFileName,
@@ -79,7 +82,7 @@ func (c *TLSCert) Execute(ctx context.Context) error {
 		c.paths.Cache,
 		certFileName,
 	)
-	caFile := filepath.Join(c.paths.Cache, spec.TLSCACert)
+	caFile := filepath.Join(c.paths.Cache, caFileName)
 	if err := utils.SaveFileWithBackup(keyFile, privKey.Pem(), ""); err != nil {
 		return err
 	}

--- a/pkg/cluster/task/tls_test.go
+++ b/pkg/cluster/task/tls_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"context"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiup/pkg/cluster/ctxt"
+	"github.com/pingcap/tiup/pkg/cluster/spec"
+	"github.com/pingcap/tiup/pkg/crypto"
+	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
+	"github.com/pingcap/tiup/pkg/meta"
+	"github.com/stretchr/testify/require"
+)
+
+type overlappingCATransfer struct {
+	firstCA     string
+	firstReady  chan struct{}
+	readFirst   chan struct{}
+	firstRead   chan struct{}
+	mu          sync.Mutex
+	transferred map[string][]byte
+}
+
+func (*overlappingCATransfer) Execute(context.Context, string, bool, ...time.Duration) ([]byte, []byte, error) {
+	return nil, nil, nil
+}
+
+func (e *overlappingCATransfer) Transfer(ctx context.Context, src, dst string, _ bool, _ int, _ bool) error {
+	if filepath.Base(dst) != spec.TLSCACert {
+		return nil
+	}
+	if dst == e.firstCA {
+		close(e.firstReady)
+		select {
+		case <-e.readFirst:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		data, err := os.ReadFile(src)
+		e.mu.Lock()
+		e.transferred[dst] = data
+		e.mu.Unlock()
+		close(e.firstRead)
+		return err
+	}
+
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	// Reproduce a competing writer's truncation window without relying on
+	// scheduler timing. It must not corrupt the first task's in-flight source.
+	if err := os.Truncate(src, 0); err != nil {
+		return err
+	}
+	close(e.readFirst)
+	select {
+	case <-e.firstRead:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if err := os.WriteFile(src, data, 0600); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	e.transferred[dst] = data
+	e.mu.Unlock()
+	return nil
+}
+
+func TestTLSCertPreservesInFlightCA(t *testing.T) {
+	ca, err := crypto.NewCA("test")
+	require.NoError(t, err)
+	expected := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.Cert.Raw})
+	for _, tc := range []struct {
+		name string
+		host string
+		port int
+	}{
+		{name: "different_hosts", host: "n2", port: 20160},
+		{name: "same_host_different_ports", host: "n1", port: 20161},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			first := &TLSCert{comp: "tikv", role: "tikv", host: "n1", port: 20160, ca: ca,
+				paths: meta.DirPaths{Deploy: filepath.Join(root, "first"), Cache: filepath.Join(root, "cache")}}
+			second := &TLSCert{comp: "tikv", role: "tikv", host: tc.host, port: tc.port, ca: ca,
+				paths: meta.DirPaths{Deploy: filepath.Join(root, "second"), Cache: first.paths.Cache}}
+			firstCA := filepath.Join(first.paths.Deploy, spec.TLSCertKeyDir, spec.TLSCACert)
+			secondCA := filepath.Join(second.paths.Deploy, spec.TLSCertKeyDir, spec.TLSCACert)
+			e := &overlappingCATransfer{firstCA: firstCA, firstReady: make(chan struct{}),
+				readFirst: make(chan struct{}), firstRead: make(chan struct{}), transferred: make(map[string][]byte)}
+			base, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			ctx := ctxt.New(base, 2, logprinter.NewLogger(""))
+			ctxt.GetInner(ctx).SetExecutor(first.host, e)
+			ctxt.GetInner(ctx).SetExecutor(second.host, e)
+			done := make(chan error, 1)
+			go func() { done <- first.Execute(ctx) }()
+			select {
+			case <-e.firstReady:
+			case err := <-done:
+				require.NoError(t, err)
+				t.Fatal("first task did not reach CA transfer")
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			require.NoError(t, second.Execute(ctx))
+			require.NoError(t, <-done)
+			e.mu.Lock()
+			defer e.mu.Unlock()
+			require.Equal(t, expected, e.transferred[firstCA])
+			require.Equal(t, expected, e.transferred[secondCA])
+		})
+	}
+}

--- a/tests/tiup-cluster/script/scale_core.sh
+++ b/tests/tiup-cluster/script/scale_core.sh
@@ -61,7 +61,7 @@ function scale_core() {
     topo=./topo/full_scale_in_tidb.yaml
     tiup-cluster $client --yes scale-out $name $topo
     # after scale-out, ensure the service is enabled
-    tiup-cluster $client exec $name -N n1 --command "systemctl status tidb-4000 | grep Loaded |grep 'enabled; vendor'"
+    tiup-cluster $client exec $name -N n1 --command "systemctl is-enabled --quiet tidb-4000"
     tiup-cluster $client exec $name -N n1 --command "grep -q n1:10080 /home/tidb/deploy/prometheus-9090/conf/prometheus.yml"
     assert_prometheus_external_labels $name n1 production us-east-1
 

--- a/tests/tiup-cluster/test_scale_core_tls.sh
+++ b/tests/tiup-cluster/test_scale_core_tls.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/scale_core.sh
 
-echo "test scaling of core components in cluster for version v5.3.0 w/ TLS, via easy ssh"
-scale_core v4.0.12 true false
+echo "test scaling of core components in cluster for version v6.0.0 w/ TLS, via easy ssh"
+scale_core v6.0.0 true false

--- a/tests/tiup-cluster/test_scale_tools.sh
+++ b/tests/tiup-cluster/test_scale_tools.sh
@@ -4,5 +4,5 @@ set -eu
 
 source script/scale_tools.sh
 
-echo "test scaling of tools components in cluster for version v4.0.12, via easy ssh"
-scale_tools v4.0.12 false false
+echo "test scaling of tools components in cluster for version v6.2.0, via easy ssh"
+scale_tools v6.2.0 false false


### PR DESCRIPTION
### What problem does this PR solve?

Restore cluster/DM integration tests on a maintained Debian base and fix concurrent TLS CA distribution.

The Bullseye node image fails to build because security package downloads return HTTP 404. On Bookworm, the old TiFlash v4.0.12 test binary also cannot load against glibc 2.36 (`GLIBC_PRIVATE` in `libpthread`).

Separately, parallel `TLSCert` tasks overwrite the same temporary `ca.crt`. Another task can truncate that file while SCP reads it, successfully transferring an empty CA and preventing components from starting.

Fixes #2727. Unblocks the integration checks needed for #2737.

### What is changed and how it works?

- Move node images to `golang:1.24-bookworm`, remove the unused JRE 11 dependency, and explicitly install `systemd`, `systemd-sysv`, and `psmisc`.
- Move the non-TLS tools scale test from v4.0.12 to v6.2.0 and the core TLS scale test from v4.0.12 to v6.0.0; align their printed version descriptions.
- Use `systemctl is-enabled --quiet` instead of parsing version-dependent status text.
- Copy collected logs from the control container to the runner and retain separate artifacts for each matrix case.
- Give each TLS certificate task a CA source file identified by role, host, and port, matching the existing key/certificate namespace. Remote paths and certificate contents remain unchanged.

### Check List

- [x] All 21 GitHub Actions checks pass on `dc1d2929`, including cluster/DM integration matrices, unit tests, Lint, and reproducible-build checks
- [x] Local Bookworm node image build and real systemd/RSA SSH/TLS PD lifecycle smoke
- [x] Positive/negative checks for service enablement on Bookworm
- [x] `go test ./pkg/cluster/task ./pkg/crypto ./pkg/utils -count=1`
- [x] `go test -race ./pkg/cluster/task -run '^TestTLSCertPreservesInFlightCA$' -count=1`
- [x] The same deterministic regression tests fail with the previous TLS implementation and pass with this fix; cases cover different hosts and different ports on one host

Release notes:

```release-note
Fix an issue where concurrent TLS certificate distribution could copy an empty CA certificate and prevent cluster components from starting
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TLS certificate handling during concurrent operations to prevent certificate transfer conflicts.

- **Chores**
  - Updated the container environment to Debian Bookworm.
  - Added system service management utilities.
  - Removed the Java 11 runtime package from the container image.

- **Tests**
  - Improved scale-out validation to reliably verify that the relevant system service is enabled.
  - Updated scaling tests for newer cluster versions.
  - Improved integration workflows by preserving container logs and organizing uploaded artifacts by test case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
