### PR TITLE
release: bump version to v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 TiUP Changelog
 
+## [1.17.1] 2026-09-08
+
+### Fixes
+
+- `tiup-cluster` fix Grafana dashboard datasource replacement when using VictoriaMetrics (#2732, @Defined2014)
+- `tiup-cluster` collect node_exporter metrics on dedicated TiDB Dashboard hosts (#2734, @mayjiang0203)
+- `tiup-cluster` preserve shared exporter directories and systemd units when destroying a cluster with `ignore_exporter: true` (#2737, @Smityz, @ekexium)
+- `tiup-cluster` prevent concurrent TLS certificate distribution from copying an empty CA certificate and blocking component startup (#2738, @ekexium)
+
 ## [1.17.0] 2026-07-27
 
 ### New Features

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,7 +23,7 @@ var (
 	// TiUPVerMinor is the minor version of TiUP
 	TiUPVerMinor = 17
 	// TiUPVerPatch is the patch version of TiUP
-	TiUPVerPatch = 0
+	TiUPVerPatch = 1
 	// TiUPVerName is an alternative name of the version
 	TiUPVerName = "tiup"
 	// GitHash is the current git commit hash


### PR DESCRIPTION
### What problem does this PR solve?

Prepare TiUP v1.17.1 with all four changes merged since v1.17.0: #2732, #2734, #2737, and #2738.

### What is changed and how it works?

- Bump the built-in version from 1.17.0 to 1.17.1.
- Add changelog entries for Grafana VictoriaMetrics datasource replacement, monitoring on dedicated TiDB Dashboard hosts, shared exporter preservation during destroy, and concurrent TLS CA distribution.

The release-1.17 branch needs the four fixes and this version/changelog commit before publication. The Bookworm CI updates in #2738 are included in the release scope.

### Check List

Tests:

- [x] `make tiup cluster lint`
- [x] `go test ./pkg/version ./pkg/cluster/operation ./pkg/cluster/task ./pkg/cluster/spec`
- [x] Built TiUP and cluster binaries report 1.17.1.

Related changes:

- [x] Need to cherry-pick to the release branch.

Release notes:
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Grafana dashboard data source replacement when using VictoriaMetrics.
  - Restored node_exporter metrics collection on dedicated TiDB Dashboard hosts.
  - Preserved shared exporter directories and systemd units when destroying clusters with exporter retention enabled.
  - Prevented concurrent TLS certificate distribution from deploying empty CA certificates and blocking component startup.

- **Release**
  - Updated the release version to 1.17.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->